### PR TITLE
Add structured prompt form extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Use it to define main agents, delegate work to allowed subagents, and ask an adv
 | `system-prompt` | Yes | Replaces pi's base system prompt from a Markdown template with explicit runtime variables. |
 | `main-agent-selection` | Yes | Lets you switch between predefined working modes instead of repeating instructions manually. |
 | `run-subagent` | Yes | Lets the main agent delegate focused tasks to subagents. |
+| `structured-prompt` | Yes | Opens a structured form for building one user request from named sections. |
 | `ask-llm` | Yes | Lets you ask a one-off model question without writing it to the current session. |
 | `consult-advisor` | Yes | Lets the main agent ask another model for an independent opinion before deciding. |
 | `convene-council` | No | Lets two model participants discuss one question and return one bounded answer. |
@@ -547,6 +548,35 @@ How it works:
 - Reads oversized child RPC progress.
 - Wraps long `prompt` text in the `Task` field and limits collapsed task previews.
 - Shows live progress and returns the subagent's final answer.
+
+### `structured-prompt`
+
+Why you need it:
+
+- Helps build complex user requests without rewriting the same prompt structure.
+- Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
+- Shows a review screen before the request is sent.
+
+Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
+
+Options:
+
+- `enabled`: default `true`. Enables or disables `/prompt` and `ctrl+alt+p`.
+
+Command and shortcut:
+
+- `/prompt` opens the structured prompt form.
+- `ctrl+alt+p` opens the same form when the terminal and operating system pass that key sequence to Pi.
+
+How it works:
+
+- Opens a centered overlay with one active multi-line section editor.
+- Builds one Markdown prompt from non-empty sections.
+- Omits empty sections from the generated prompt.
+- Sends the generated prompt as a user message when the agent is idle.
+- Asks before queuing the generated prompt as a follow-up when the agent is busy.
+- Sends nothing when the form is cancelled or every section is empty.
+- Treats `/prompt` as the reliable entry point because `ctrl+alt+p` can be intercepted outside Pi.
 
 ### `ask-llm`
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Why you need it:
 - Helps build complex user requests without rewriting the same prompt structure.
 - Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
 - Shows a review screen before the request is sent.
+- Can copy the generated prompt or place it in the main input before sending.
 
 Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
 
@@ -573,6 +574,8 @@ How it works:
 - Opens a centered overlay with one active multi-line section editor.
 - Builds one Markdown prompt from non-empty sections.
 - Omits empty sections from the generated prompt.
+- Copies the generated prompt from the review screen with `Ctrl+Y`.
+- Places the generated prompt in the main input field from the review screen with `Ctrl+T`.
 - Sends the generated prompt as a user message when the agent is idle.
 - Asks before queuing the generated prompt as a follow-up when the agent is busy.
 - Sends nothing when the form is cancelled or every section is empty.

--- a/docs/extensions/structured-prompt.md
+++ b/docs/extensions/structured-prompt.md
@@ -1,0 +1,85 @@
+# structured-prompt
+
+## Purpose
+
+`structured-prompt` owns the `/prompt` command and the `ctrl+alt+p` shortcut for creating structured user requests from a focused form.
+
+## Behavior
+
+- Registers command `/prompt`.
+- Registers shortcut `ctrl+alt+p` as a best-effort default.
+- Reads configuration from `~/.pi/agent/agent-suite/structured-prompt/config.json`.
+- Is enabled by default when `config.json` is missing.
+- Does not register the command or shortcut when `enabled` is `false`.
+- Does not register the command or shortcut when config is invalid.
+- Requires interactive UI.
+- Opens a centered custom UI overlay.
+- Captures these sections in order:
+  - Goal
+  - Task
+  - Context
+  - Criteria
+  - Constraints
+  - Work order
+- Supports multi-line section text.
+- Shows a review screen before sending.
+- Omits empty sections from the generated prompt.
+- Sends the generated prompt as one user message when the agent is idle.
+- When the agent is busy, asks whether to queue the generated prompt as a follow-up.
+- Sends no message when the form is cancelled.
+- Sends no message when every section is empty.
+
+`/prompt` is the reliable entry point. `ctrl+alt+p` can be intercepted by a terminal, operating system, or user keybinding before Pi receives it.
+
+## Configuration
+
+File: `~/.pi/agent/agent-suite/structured-prompt/config.json`.
+
+```json
+{
+  "enabled": true
+}
+```
+
+Options:
+
+- `enabled`: default `true`. Enables or disables `/prompt` and `ctrl+alt+p`.
+
+Unsupported keys make the config invalid. The first version does not support custom sections or shortcut configuration.
+
+## Generated prompt format
+
+Only non-empty sections are included. Section order is fixed.
+
+Example:
+
+```md
+## Goal
+Create structured requests.
+
+## Task
+Implement the structured-prompt extension.
+
+## Constraints
+Keep tests isolated.
+```
+
+## Verification
+
+Tests must verify:
+
+- default command and shortcut registration when the config file is missing;
+- command and shortcut omission when `enabled` is `false`;
+- command and shortcut omission when config is invalid;
+- command and shortcut use the same submit flow;
+- UI-unavailable mode sends no message;
+- cancel sends no message;
+- empty submit sends no message;
+- idle submit sends one generated user message;
+- busy submit asks before follow-up delivery;
+- rejecting follow-up sends no message;
+- accepting follow-up queues the generated prompt as `followUp`;
+- empty sections are omitted from the generated prompt;
+- multi-line section text is preserved;
+- terminal navigation escape sequences are not inserted into section text;
+- rendered form rows stay within the requested width.

--- a/docs/extensions/structured-prompt.md
+++ b/docs/extensions/structured-prompt.md
@@ -23,6 +23,8 @@
   - Work order
 - Supports multi-line section text.
 - Shows a review screen before sending.
+- On the review screen, `Ctrl+Y` copies the generated prompt to the clipboard without closing the form.
+- On the review screen, `Ctrl+T` places the generated prompt in the main input field and sends no message.
 - Omits empty sections from the generated prompt.
 - Sends the generated prompt as one user message when the agent is idle.
 - When the agent is busy, asks whether to queue the generated prompt as a follow-up.
@@ -79,6 +81,9 @@ Tests must verify:
 - busy submit asks before follow-up delivery;
 - rejecting follow-up sends no message;
 - accepting follow-up queues the generated prompt as `followUp`;
+- review copy copies the full generated prompt without closing the form;
+- review input placement writes the full generated prompt to the main input and sends no message;
+- clipboard copy failure reports a warning and sends no message;
 - empty sections are omitted from the generated prompt;
 - multi-line section text is preserved;
 - terminal navigation escape sequences are not inserted into section text;

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -23,6 +23,7 @@ Use it to define main agents, delegate work to allowed subagents, and ask an adv
 | `system-prompt` | Yes | Replaces pi's base system prompt from a Markdown template with explicit runtime variables. |
 | `main-agent-selection` | Yes | Lets you switch between predefined working modes instead of repeating instructions manually. |
 | `run-subagent` | Yes | Lets the main agent delegate focused tasks to subagents. |
+| `structured-prompt` | Yes | Opens a structured form for building one user request from named sections. |
 | `ask-llm` | Yes | Lets you ask a one-off model question without writing it to the current session. |
 | `consult-advisor` | Yes | Lets the main agent ask another model for an independent opinion before deciding. |
 | `convene-council` | No | Lets two model participants discuss one question and return one bounded answer. |
@@ -547,6 +548,35 @@ How it works:
 - Reads oversized child RPC progress.
 - Wraps long `prompt` text in the `Task` field and limits collapsed task previews.
 - Shows live progress and returns the subagent's final answer.
+
+### `structured-prompt`
+
+Why you need it:
+
+- Helps build complex user requests without rewriting the same prompt structure.
+- Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
+- Shows a review screen before the request is sent.
+
+Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
+
+Options:
+
+- `enabled`: default `true`. Enables or disables `/prompt` and `ctrl+alt+p`.
+
+Command and shortcut:
+
+- `/prompt` opens the structured prompt form.
+- `ctrl+alt+p` opens the same form when the terminal and operating system pass that key sequence to Pi.
+
+How it works:
+
+- Opens a centered overlay with one active multi-line section editor.
+- Builds one Markdown prompt from non-empty sections.
+- Omits empty sections from the generated prompt.
+- Sends the generated prompt as a user message when the agent is idle.
+- Asks before queuing the generated prompt as a follow-up when the agent is busy.
+- Sends nothing when the form is cancelled or every section is empty.
+- Treats `/prompt` as the reliable entry point because `ctrl+alt+p` can be intercepted outside Pi.
 
 ### `ask-llm`
 

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -556,6 +556,7 @@ Why you need it:
 - Helps build complex user requests without rewriting the same prompt structure.
 - Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
 - Shows a review screen before the request is sent.
+- Can copy the generated prompt or place it in the main input before sending.
 
 Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
 
@@ -573,6 +574,8 @@ How it works:
 - Opens a centered overlay with one active multi-line section editor.
 - Builds one Markdown prompt from non-empty sections.
 - Omits empty sections from the generated prompt.
+- Copies the generated prompt from the review screen with `Ctrl+Y`.
+- Places the generated prompt in the main input field from the review screen with `Ctrl+T`.
 - Sends the generated prompt as a user message when the agent is idle.
 - Asks before queuing the generated prompt as a follow-up when the agent is busy.
 - Sends nothing when the form is cancelled or every section is empty.

--- a/pi-package/extensions/structured-prompt/config.test.ts
+++ b/pi-package/extensions/structured-prompt/config.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage.ts";
+import { parsePromptConfig, readPromptConfig } from "./config.ts";
+
+const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	if (previousAgentSuiteDir === undefined) {
+		delete process.env[AGENT_SUITE_DIR_ENV];
+	} else {
+		process.env[AGENT_SUITE_DIR_ENV] = previousAgentSuiteDir;
+	}
+
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("structured-prompt config", () => {
+	test("uses enabled true when config is missing", async () => {
+		// Purpose: prompt must be usable without setup because missing config enables the extension.
+		// Input and expected output: no config file returns enabled true.
+		// Edge case: the suite config directory is absent.
+		// Dependencies: this test uses only temporary suite storage.
+		await withIsolatedSuiteDir(async () => {
+			const result = readPromptConfig();
+
+			expect(result.kind).toBe("valid");
+			if (result.kind !== "valid") {
+				throw new Error(result.issue);
+			}
+			expect(result.config).toEqual({ enabled: true });
+		});
+	});
+
+	test("accepts explicit enabled values", () => {
+		// Purpose: users need one supported config key that can enable or disable the extension.
+		// Input and expected output: enabled true and false are accepted as booleans.
+		// Edge case: false is preserved and does not default back to true.
+		// Dependencies: this test exercises the pure parser only.
+		expect(parsePromptConfig({ enabled: true })).toEqual({
+			kind: "valid",
+			config: { enabled: true },
+		});
+		expect(parsePromptConfig({ enabled: false })).toEqual({
+			kind: "valid",
+			config: { enabled: false },
+		});
+	});
+
+	test("rejects unsupported keys and invalid enabled values", () => {
+		// Purpose: config validation must fail closed for unsupported public contract changes.
+		// Input and expected output: unsupported keys and non-boolean enabled values are invalid.
+		// Edge case: an empty object is valid and uses defaults.
+		// Dependencies: this test exercises the pure parser only.
+		expect(parsePromptConfig({}).kind).toBe("valid");
+		expect(parsePromptConfig({ shortcut: "ctrl+alt+p" }).kind).toBe("invalid");
+		expect(parsePromptConfig({ enabled: "true" }).kind).toBe("invalid");
+		expect(parsePromptConfig(null).kind).toBe("invalid");
+	});
+
+	test("reports malformed JSON as invalid", async () => {
+		// Purpose: a broken config file must not register a partially configured extension.
+		// Input and expected output: malformed JSON returns an invalid result.
+		// Edge case: the file exists but cannot be parsed.
+		// Dependencies: this test uses only temporary suite storage.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			await writePromptConfigText(suiteDir, "{");
+
+			const result = readPromptConfig();
+
+			expect(result.kind).toBe("invalid");
+		});
+	});
+});
+
+async function withIsolatedSuiteDir(
+	testBody: (suiteDir: string) => Promise<void>,
+): Promise<void> {
+	const suiteDir = await mkdtemp(join(tmpdir(), "structured-prompt-config-"));
+	tempDirs.push(suiteDir);
+	process.env[AGENT_SUITE_DIR_ENV] = suiteDir;
+	await testBody(suiteDir);
+}
+
+async function writePromptConfigText(
+	suiteDir: string,
+	content: string,
+): Promise<void> {
+	const configDir = join(suiteDir, "structured-prompt");
+	await mkdir(configDir, { recursive: true });
+	await writeFile(join(configDir, "config.json"), content);
+}

--- a/pi-package/extensions/structured-prompt/config.ts
+++ b/pi-package/extensions/structured-prompt/config.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import {
+	getSuiteConfigLocation,
+	isFileNotFoundError,
+} from "../../shared/agent-suite-storage.ts";
+
+const STRUCTURED_PROMPT_EXTENSION_DIR = "structured-prompt";
+const ENABLED_CONFIG_KEY = "enabled";
+const PROMPT_CONFIG_KEYS = [ENABLED_CONFIG_KEY] as const;
+
+export interface PromptConfig {
+	readonly enabled: boolean;
+}
+
+export type PromptConfigResult =
+	| { readonly kind: "valid"; readonly config: PromptConfig }
+	| { readonly kind: "invalid"; readonly issue: string };
+
+/** Parses the structured-prompt config and rejects every unsupported public key. */
+export function parsePromptConfig(config: unknown): PromptConfigResult {
+	if (!isRecord(config)) {
+		return invalidConfig("config must be an object");
+	}
+
+	const unsupportedKey = Object.keys(config).find(
+		(key) =>
+			!PROMPT_CONFIG_KEYS.includes(key as (typeof PROMPT_CONFIG_KEYS)[number]),
+	);
+	if (unsupportedKey !== undefined) {
+		return invalidConfig("config contains unsupported keys");
+	}
+
+	const enabled = config[ENABLED_CONFIG_KEY];
+	if (enabled !== undefined && typeof enabled !== "boolean") {
+		return invalidConfig("enabled must be a boolean");
+	}
+
+	return {
+		kind: "valid",
+		config: { enabled: enabled ?? true },
+	};
+}
+
+/** Reads the suite-owned prompt config once during extension load. */
+export function readPromptConfig(): PromptConfigResult {
+	const configLocation = getSuiteConfigLocation(
+		STRUCTURED_PROMPT_EXTENSION_DIR,
+	);
+
+	let content: string;
+	try {
+		content = readFileSync(configLocation.path, "utf8");
+	} catch (error) {
+		if (isFileNotFoundError(error)) {
+			return { kind: "valid", config: { enabled: true } };
+		}
+
+		return invalidConfig(`failed to read config: ${formatError(error)}`);
+	}
+
+	try {
+		return parsePromptConfig(JSON.parse(content) as unknown);
+	} catch (error) {
+		return invalidConfig(`failed to parse config: ${formatError(error)}`);
+	}
+}
+
+function invalidConfig(issue: string): PromptConfigResult {
+	return { kind: "invalid", issue };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/pi-package/extensions/structured-prompt/form.test.ts
+++ b/pi-package/extensions/structured-prompt/form.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+	StructuredPromptForm,
+	type StructuredPromptFormResult,
+} from "./form.ts";
+import { PROMPT_SECTIONS } from "./formatter.ts";
+
+const ENTER = "\r";
+const ESCAPE = "\x1b";
+const ARROW_DOWN = "\x1b[B";
+const PAGE_DOWN = "\x1b[6~";
+const HOME = "\x1b[H";
+
+describe("structured-prompt form", () => {
+	test("submits entered section values from the review screen", () => {
+		// Purpose: users must review the generated prompt before it can be submitted.
+		// Input and expected output: text entered in Goal is submitted only after the review confirmation.
+		// Edge case: empty later sections are allowed and are returned for formatter filtering.
+		// Dependencies: this test uses the form component with fake TUI and theme dependencies.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+
+		typeText(form, "Create structured requests");
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		expect(observedResults).toEqual([]);
+
+		form.handleInput(ENTER);
+
+		expect(observedResults).toEqual([
+			{
+				kind: "submitted",
+				values: [
+					{ sectionId: "goal", value: "Create structured requests" },
+					{ sectionId: "task", value: "" },
+					{ sectionId: "context", value: "" },
+					{ sectionId: "criteria", value: "" },
+					{ sectionId: "constraints", value: "" },
+					{ sectionId: "work-order", value: "" },
+				],
+			},
+		]);
+	});
+
+	test("preserves pasted multi-line text in a section", () => {
+		// Purpose: request sections must support multi-line content.
+		// Input and expected output: one pasted chunk with a newline is submitted unchanged for the active section.
+		// Edge case: the newline is part of section content and does not advance the wizard.
+		// Dependencies: this test uses the form component with fake TUI and theme dependencies.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+
+		typeText(form, "Line one\nLine two");
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		form.handleInput(ENTER);
+
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: "Line one\nLine two" },
+			]),
+		});
+	});
+
+	test("does not insert navigation escape sequences into section text", () => {
+		// Purpose: terminal navigation keys must remain editor controls, not prompt content.
+		// Input and expected output: arrow-up after typed text is not submitted as section text.
+		// Edge case: the arrow key is a multi-byte terminal sequence.
+		// Dependencies: this test uses the form component with fake TUI and theme dependencies.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+
+		typeText(form, "Goal text");
+		form.handleInput("\x1b[A");
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		form.handleInput(ENTER);
+
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: "Goal text" },
+			]),
+		});
+	});
+
+	test("cancels without submitting values", () => {
+		// Purpose: users need an explicit no-send exit path.
+		// Input and expected output: Escape reports cancellation and no submitted values.
+		// Edge case: cancellation works after editing has started.
+		// Dependencies: this test uses the form component with fake TUI and theme dependencies.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+
+		typeText(form, "Draft text");
+		form.handleInput(ESCAPE);
+
+		expect(observedResults).toEqual([{ kind: "cancelled" }]);
+	});
+
+	test("renders the form inside a bright outer border", () => {
+		// Purpose: the prompt dialog must be visually separated from the chat background.
+		// Input and expected output: rendered rows include a full outer border.
+		// Edge case: the frame is present before any section text is entered.
+		// Dependencies: this test uses structural border checks and visible width measurement.
+		const form = createForm(() => {});
+		const rows = form.render(48);
+
+		expect(rows.length).toBeGreaterThan(2);
+		expect(rows[0]).toContain("┏");
+		expect(rows[0]).toContain("┓");
+		expect(rows.at(-1)).toContain("┗");
+		expect(rows.at(-1)).toContain("┛");
+		expect(rows.every((row) => visibleWidth(row) <= 48)).toBe(true);
+	});
+
+	test("keeps bordered rows within width when the theme emits ANSI colors", () => {
+		// Purpose: real Pi themes add ANSI color sequences that must not break layout width.
+		// Input and expected output: styled border and styled labels still fit within the requested width.
+		// Edge case: border and content styling are both present.
+		// Dependencies: this test uses public visible width measurement.
+		const form = new StructuredPromptForm({
+			tui: {
+				terminal: { rows: 40 },
+				requestRender(): void {},
+			} as never,
+			theme: {
+				fg: (_color, value) => `\u001b[96m${value}\u001b[39m`,
+				bold: (value) => `\u001b[1m${value}\u001b[22m`,
+			},
+			sections: PROMPT_SECTIONS,
+			onDone: () => {},
+		});
+
+		const rows = form.render(48);
+
+		expect(rows.every((row) => visibleWidth(row) <= 48)).toBe(true);
+	});
+
+	test("bounds long review output to the terminal height", () => {
+		// Purpose: long generated prompts must not overflow the terminal during review.
+		// Input and expected output: a long review renders no more rows than the terminal height.
+		// Edge case: wrapped frame, header, help, and preview rows all count against the limit.
+		// Dependencies: this test uses the form component with a small fake terminal height.
+		const form = createForm(() => {}, { rows: 12 });
+		openReviewWithGoal(form, numberedLines(80));
+
+		const rows = form.render(64);
+
+		expect(rows.length).toBeLessThanOrEqual(12);
+		expect(rows.join("\n")).toContain("line-001");
+		expect(rows.join("\n")).not.toContain("line-080");
+	});
+
+	test("scrolls the long review preview without moving the frame", () => {
+		// Purpose: users must be able to inspect long generated prompts before sending.
+		// Input and expected output: Down and PageDown change visible preview lines, Home returns to the start.
+		// Edge case: scrolling affects only the review preview area.
+		// Dependencies: this test uses terminal escape sequences for navigation keys.
+		const form = createForm(() => {}, { rows: 12 });
+		openReviewWithGoal(form, numberedLines(80));
+
+		const initialRows = form.render(64).join("\n");
+		form.handleInput(ARROW_DOWN);
+		const downRows = form.render(64).join("\n");
+		form.handleInput(PAGE_DOWN);
+		const pageRows = form.render(64).join("\n");
+		form.handleInput(HOME);
+		const homeRows = form.render(64).join("\n");
+
+		expect(initialRows).toContain("line-001");
+		expect(downRows).not.toBe(initialRows);
+		expect(pageRows).not.toBe(downRows);
+		expect(homeRows).toBe(initialRows);
+	});
+
+	test("can scroll to the bottom of a wrapped narrow review", () => {
+		// Purpose: narrow terminals wrap preview lines and must still allow reaching the end.
+		// Input and expected output: repeated PageDown reaches the final visual content.
+		// Edge case: scroll limits use the current rendered width, not a fixed width.
+		// Dependencies: this test renders before scrolling so the component can measure the viewport.
+		const form = createForm(() => {}, { rows: 12 });
+		const longGoal = Array.from(
+			{ length: 30 },
+			(_value, index) =>
+				`line-${String(index + 1).padStart(3, "0")} has a long wrapped suffix`,
+		).join("\n");
+		openReviewWithGoal(form, longGoal);
+		form.render(32);
+
+		for (let index = 0; index < 20; index += 1) {
+			form.handleInput(PAGE_DOWN);
+		}
+
+		const rows = form.render(32).join("\n");
+
+		expect(rows).toContain("line-030");
+	});
+
+	test("submits the full generated prompt after review scrolling", () => {
+		// Purpose: review scrolling must not truncate the message sent to the agent.
+		// Input and expected output: after scrolling, submit returns the complete section value.
+		// Edge case: the submitted value contains lines that were not visible in the review viewport.
+		// Dependencies: this test uses the form component result instead of Pi delivery.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result), {
+			rows: 12,
+		});
+		const longGoal = numberedLines(80);
+		openReviewWithGoal(form, longGoal);
+
+		form.handleInput(PAGE_DOWN);
+		form.handleInput(ENTER);
+
+		expect(observedResults).toEqual([
+			{
+				kind: "submitted",
+				values: expect.arrayContaining([
+					{ sectionId: "goal", value: longGoal },
+				]),
+			},
+		]);
+	});
+
+	test("keeps rendered rows within the requested width", () => {
+		// Purpose: the custom overlay must honor the TUI render width contract.
+		// Input and expected output: narrow and normal widths produce rows within those widths.
+		// Edge case: long entered text is present before rendering.
+		// Dependencies: this test uses public visible width measurement.
+		const form = createForm(() => {});
+		typeText(
+			form,
+			"A very long goal that must be wrapped or clipped inside the structured prompt form overlay",
+		);
+
+		for (const width of [32, 80]) {
+			const rows = form.render(width);
+			expect(rows.length).toBeGreaterThan(0);
+			expect(rows.every((row) => visibleWidth(row) <= width)).toBe(true);
+		}
+	});
+});
+
+function createForm(
+	onDone: (result: StructuredPromptFormResult) => void,
+	options: { readonly rows?: number } = {},
+): StructuredPromptForm {
+	return new StructuredPromptForm({
+		tui: {
+			terminal: { rows: options.rows ?? 40 },
+			requestRender(): void {},
+		} as never,
+		theme: {
+			fg: (_color, value) => value,
+			bold: (value) => value,
+		},
+		sections: PROMPT_SECTIONS,
+		onDone,
+	});
+}
+
+function openReviewWithGoal(form: StructuredPromptForm, goal: string): void {
+	typeText(form, goal);
+	for (const _section of PROMPT_SECTIONS) {
+		form.handleInput(ENTER);
+	}
+}
+
+function numberedLines(count: number): string {
+	return Array.from(
+		{ length: count },
+		(_value, index) => `line-${String(index + 1).padStart(3, "0")}`,
+	).join("\n");
+}
+
+function typeText(form: StructuredPromptForm, value: string): void {
+	form.handleInput(value);
+}

--- a/pi-package/extensions/structured-prompt/form.test.ts
+++ b/pi-package/extensions/structured-prompt/form.test.ts
@@ -11,6 +11,8 @@ const ESCAPE = "\x1b";
 const ARROW_DOWN = "\x1b[B";
 const PAGE_DOWN = "\x1b[6~";
 const HOME = "\x1b[H";
+const CTRL_T = "\x14";
+const CTRL_Y = "\x19";
 
 describe("structured-prompt form", () => {
 	test("submits entered section values from the review screen", () => {
@@ -227,6 +229,124 @@ describe("structured-prompt form", () => {
 		]);
 	});
 
+	test("copies the full generated prompt from review without closing it", async () => {
+		// Purpose: users must be able to copy the generated prompt before deciding whether to send.
+		// Input and expected output: Ctrl+Y reports the full formatted prompt and Enter can still submit.
+		// Edge case: the copied text contains rows that are outside the current review viewport.
+		// Dependencies: this test uses a callback fake for the clipboard action.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const copiedPrompts: string[] = [];
+		const form = createForm((result) => observedResults.push(result), {
+			onCopyPrompt: (promptText) => copiedPrompts.push(promptText),
+			rows: 12,
+		});
+		const longGoal = numberedLines(80);
+		openReviewWithGoal(form, longGoal);
+
+		form.handleInput(PAGE_DOWN);
+		form.handleInput(CTRL_Y);
+		await waitForCopySettlement();
+		form.handleInput(ENTER);
+
+		expect(copiedPrompts).toEqual([["## Goal", longGoal].join("\n")]);
+		expect(observedResults).toEqual([
+			{
+				kind: "submitted",
+				values: expect.arrayContaining([
+					{ sectionId: "goal", value: longGoal },
+				]),
+			},
+		]);
+	});
+
+	test("waits for review copy before allowing submit", async () => {
+		// Purpose: copying before sending must not race with an immediate Enter press.
+		// Input and expected output: Enter is ignored while Ctrl+Y copy is still pending, then works after copy finishes.
+		// Edge case: the clipboard callback is asynchronous.
+		// Dependencies: this test uses a deferred callback fake for the clipboard action.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const copy = createDeferred();
+		const form = createForm((result) => observedResults.push(result), {
+			onCopyPrompt: () => copy.promise,
+			rows: 12,
+		});
+		const longGoal = numberedLines(80);
+		openReviewWithGoal(form, longGoal);
+
+		form.handleInput(CTRL_Y);
+		form.handleInput(ENTER);
+		expect(observedResults).toEqual([]);
+
+		copy.resolve();
+		await copy.promise;
+		await waitForCopySettlement();
+		form.handleInput(ENTER);
+
+		expect(observedResults).toEqual([
+			{
+				kind: "submitted",
+				values: expect.arrayContaining([
+					{ sectionId: "goal", value: longGoal },
+				]),
+			},
+		]);
+	});
+
+	test("unblocks submit after a synchronous review copy failure", async () => {
+		// Purpose: a clipboard callback defect must not leave review actions blocked.
+		// Input and expected output: a synchronous copy failure is swallowed and a later Enter submits.
+		// Edge case: the callback throws before returning a Promise.
+		// Dependencies: this test uses a throwing callback fake for the clipboard action.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result), {
+			onCopyPrompt: () => {
+				throw new Error("copy callback failed");
+			},
+			rows: 12,
+		});
+		const longGoal = numberedLines(80);
+		openReviewWithGoal(form, longGoal);
+
+		form.handleInput(CTRL_Y);
+		await waitForCopySettlement();
+		form.handleInput(ENTER);
+
+		expect(observedResults).toEqual([
+			{
+				kind: "submitted",
+				values: expect.arrayContaining([
+					{ sectionId: "goal", value: longGoal },
+				]),
+			},
+		]);
+	});
+
+	test("returns the full generated prompt for input placement without submitting", () => {
+		// Purpose: users must be able to place the generated prompt in the main input instead of sending it.
+		// Input and expected output: Ctrl+T returns an inserted result with all section values.
+		// Edge case: Enter after Ctrl+T does not create a later submit result because the form is closed.
+		// Dependencies: this test uses the form component result instead of Pi editor integration.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result), {
+			rows: 12,
+		});
+		const longGoal = numberedLines(80);
+		openReviewWithGoal(form, longGoal);
+
+		form.handleInput(PAGE_DOWN);
+		form.handleInput(CTRL_T);
+		form.handleInput(ENTER);
+
+		expect(observedResults).toEqual([
+			{
+				kind: "inserted",
+				values: expect.arrayContaining([
+					{ sectionId: "goal", value: longGoal },
+				]),
+			},
+		]);
+	});
+
 	test("keeps rendered rows within the requested width", () => {
 		// Purpose: the custom overlay must honor the TUI render width contract.
 		// Input and expected output: narrow and normal widths produce rows within those widths.
@@ -248,7 +368,10 @@ describe("structured-prompt form", () => {
 
 function createForm(
 	onDone: (result: StructuredPromptFormResult) => void,
-	options: { readonly rows?: number } = {},
+	options: {
+		readonly onCopyPrompt?: (promptText: string) => void;
+		readonly rows?: number;
+	} = {},
 ): StructuredPromptForm {
 	return new StructuredPromptForm({
 		tui: {
@@ -260,6 +383,7 @@ function createForm(
 			bold: (value) => value,
 		},
 		sections: PROMPT_SECTIONS,
+		onCopyPrompt: options.onCopyPrompt,
 		onDone,
 	});
 }
@@ -280,4 +404,24 @@ function numberedLines(count: number): string {
 
 function typeText(form: StructuredPromptForm, value: string): void {
 	form.handleInput(value);
+}
+
+async function waitForCopySettlement(): Promise<void> {
+	for (let index = 0; index < 5; index += 1) {
+		await Promise.resolve();
+	}
+}
+
+function createDeferred(): {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+} {
+	let resolvePromise: (() => void) | undefined;
+	const promise = new Promise<void>((resolve) => {
+		resolvePromise = resolve;
+	});
+	if (resolvePromise === undefined) {
+		throw new Error("deferred promise resolver was not initialized");
+	}
+	return { promise, resolve: resolvePromise };
 }

--- a/pi-package/extensions/structured-prompt/form.ts
+++ b/pi-package/extensions/structured-prompt/form.ts
@@ -22,6 +22,10 @@ export type StructuredPromptFormResult =
 			readonly kind: "submitted";
 			readonly values: readonly PromptSectionValue[];
 	  }
+	| {
+			readonly kind: "inserted";
+			readonly values: readonly PromptSectionValue[];
+	  }
 	| { readonly kind: "cancelled" };
 
 export interface PromptFormTheme {
@@ -33,6 +37,9 @@ export interface StructuredPromptFormOptions {
 	readonly tui: TUI;
 	readonly theme: PromptFormTheme;
 	readonly sections: readonly PromptSection[];
+	readonly onCopyPrompt?:
+		| ((promptText: string) => Promise<void> | void)
+		| undefined;
 	readonly onDone: (result: StructuredPromptFormResult) => void;
 }
 
@@ -41,13 +48,16 @@ type PromptFormMode = "edit" | "review" | "closed";
 const FRAME_SIDE_WIDTH = 2;
 const FRAME_HORIZONTAL_PADDING = 2;
 const FRAME_DECORATION_WIDTH = FRAME_SIDE_WIDTH + FRAME_HORIZONTAL_PADDING;
-const REVIEW_NON_PREVIEW_ROWS = 5;
+const REVIEW_NON_PREVIEW_ROWS = 6;
 
 /** Captures section text first, then requires a review confirmation before submit. */
 export class StructuredPromptForm implements Component {
 	private readonly tui: TUI;
 	private readonly theme: PromptFormTheme;
 	private readonly sections: readonly PromptSection[];
+	private readonly onCopyPrompt:
+		| ((promptText: string) => Promise<void> | void)
+		| undefined;
 	private readonly onDone: (result: StructuredPromptFormResult) => void;
 	private readonly values = new Map<string, string>();
 	private readonly editor: Editor;
@@ -56,12 +66,14 @@ export class StructuredPromptForm implements Component {
 	private reviewScrollOffset = 0;
 	private reviewMaxScrollOffset = 0;
 	private reviewPageRows = 1;
+	private copyInProgress = false;
 
 	/** Creates the form with a Pi editor for multi-line section input. */
 	public constructor(options: StructuredPromptFormOptions) {
 		this.tui = options.tui;
 		this.theme = options.theme;
 		this.sections = options.sections;
+		this.onCopyPrompt = options.onCopyPrompt;
 		this.onDone = options.onDone;
 		this.editor = new Editor(this.tui, this.createEditorTheme());
 	}
@@ -87,6 +99,13 @@ export class StructuredPromptForm implements Component {
 		}
 		if (matchesKey(data, Key.escape)) {
 			this.finish({ kind: "cancelled" });
+			return;
+		}
+		if (
+			this.mode === "review" &&
+			this.copyInProgress &&
+			matchesKey(data, Key.enter)
+		) {
 			return;
 		}
 		if (matchesKey(data, Key.enter)) {
@@ -192,7 +211,14 @@ export class StructuredPromptForm implements Component {
 			truncateToWidth(
 				this.theme.fg(
 					"dim",
-					"Enter: send • Esc: cancel • Up/Down: scroll • PageUp/PageDown: page",
+					"Enter: send • Ctrl+Y: copy • Ctrl+T: place in input • Esc: cancel",
+				),
+				width,
+			),
+			truncateToWidth(
+				this.theme.fg(
+					"dim",
+					"Up/Down: scroll • PageUp/PageDown: page • Home/End: jump",
 				),
 				width,
 			),
@@ -203,8 +229,19 @@ export class StructuredPromptForm implements Component {
 		];
 	}
 
-	/** Handles review-only navigation keys without changing the generated prompt. */
+	/** Handles review-only actions without changing the generated prompt. */
 	private handleReviewInput(data: string): void {
+		if (matchesKey(data, "ctrl+y")) {
+			this.copyCurrentPrompt();
+			return;
+		}
+		if (matchesKey(data, "ctrl+t")) {
+			if (this.copyInProgress) {
+				return;
+			}
+			this.finish({ kind: "inserted", values: this.collectValues() });
+			return;
+		}
 		if (matchesKey(data, Key.down)) {
 			this.reviewScrollOffset = Math.min(
 				this.reviewMaxScrollOffset,
@@ -243,6 +280,26 @@ export class StructuredPromptForm implements Component {
 			this.reviewScrollOffset = this.reviewMaxScrollOffset;
 			this.tui.requestRender();
 		}
+	}
+
+	/** Starts clipboard copy and blocks send actions until the copy attempt finishes. */
+	private copyCurrentPrompt(): void {
+		if (this.copyInProgress) {
+			return;
+		}
+
+		const promptText = formatStructuredPrompt(
+			this.sections,
+			this.collectValues(),
+		);
+		this.copyInProgress = true;
+		Promise.resolve()
+			.then(() => this.onCopyPrompt?.(promptText))
+			.catch(() => undefined)
+			.finally(() => {
+				this.copyInProgress = false;
+				this.tui.requestRender();
+			});
 	}
 
 	/** Advances from editing to review, or submits when the review screen is active. */

--- a/pi-package/extensions/structured-prompt/form.ts
+++ b/pi-package/extensions/structured-prompt/form.ts
@@ -1,0 +1,322 @@
+import type { ThemeColor } from "@earendil-works/pi-coding-agent";
+import {
+	type Component,
+	Editor,
+	type EditorTheme,
+	Key,
+	matchesKey,
+	parseKey,
+	Text,
+	type TUI,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import {
+	formatStructuredPrompt,
+	type PromptSection,
+	type PromptSectionValue,
+} from "./formatter.ts";
+
+export type StructuredPromptFormResult =
+	| {
+			readonly kind: "submitted";
+			readonly values: readonly PromptSectionValue[];
+	  }
+	| { readonly kind: "cancelled" };
+
+export interface PromptFormTheme {
+	readonly fg: (color: ThemeColor, value: string) => string;
+	readonly bold: (value: string) => string;
+}
+
+export interface StructuredPromptFormOptions {
+	readonly tui: TUI;
+	readonly theme: PromptFormTheme;
+	readonly sections: readonly PromptSection[];
+	readonly onDone: (result: StructuredPromptFormResult) => void;
+}
+
+type PromptFormMode = "edit" | "review" | "closed";
+
+const FRAME_SIDE_WIDTH = 2;
+const FRAME_HORIZONTAL_PADDING = 2;
+const FRAME_DECORATION_WIDTH = FRAME_SIDE_WIDTH + FRAME_HORIZONTAL_PADDING;
+const REVIEW_NON_PREVIEW_ROWS = 5;
+
+/** Captures section text first, then requires a review confirmation before submit. */
+export class StructuredPromptForm implements Component {
+	private readonly tui: TUI;
+	private readonly theme: PromptFormTheme;
+	private readonly sections: readonly PromptSection[];
+	private readonly onDone: (result: StructuredPromptFormResult) => void;
+	private readonly values = new Map<string, string>();
+	private readonly editor: Editor;
+	private mode: PromptFormMode = "edit";
+	private sectionIndex = 0;
+	private reviewScrollOffset = 0;
+	private reviewMaxScrollOffset = 0;
+	private reviewPageRows = 1;
+
+	/** Creates the form with a Pi editor for multi-line section input. */
+	public constructor(options: StructuredPromptFormOptions) {
+		this.tui = options.tui;
+		this.theme = options.theme;
+		this.sections = options.sections;
+		this.onDone = options.onDone;
+		this.editor = new Editor(this.tui, this.createEditorTheme());
+	}
+
+	/** Renders either the active section editor or the final prompt preview. */
+	public render(width: number): string[] {
+		const safeWidth = Math.max(1, width);
+		const contentWidth =
+			safeWidth >= FRAME_DECORATION_WIDTH
+				? safeWidth - FRAME_DECORATION_WIDTH
+				: safeWidth;
+		const content =
+			this.mode === "review"
+				? this.renderReview(contentWidth)
+				: this.renderEditor(contentWidth);
+		return this.renderBorderedPanel(content, safeWidth);
+	}
+
+	/** Routes cancel and step confirmation keys before passing text input to the editor. */
+	public handleInput(data: string): void {
+		if (this.mode === "closed") {
+			return;
+		}
+		if (matchesKey(data, Key.escape)) {
+			this.finish({ kind: "cancelled" });
+			return;
+		}
+		if (matchesKey(data, Key.enter)) {
+			this.confirmCurrentMode();
+			return;
+		}
+		if (this.mode === "review") {
+			this.handleReviewInput(data);
+			return;
+		}
+
+		if (data.length > 1 && parseKey(data) === undefined) {
+			this.editor.insertTextAtCursor(data);
+		} else {
+			this.editor.handleInput(data);
+		}
+		this.tui.requestRender();
+	}
+
+	/** Clears cached rendering in the embedded editor. */
+	public invalidate(): void {
+		this.editor.invalidate();
+	}
+
+	/** Draws a bright outer frame that separates the overlay from the chat background. */
+	private renderBorderedPanel(
+		lines: readonly string[],
+		width: number,
+	): string[] {
+		if (width < FRAME_DECORATION_WIDTH) {
+			return lines.map((line) => truncateToWidth(line, width));
+		}
+
+		const innerWidth = width - FRAME_DECORATION_WIDTH;
+		const horizontal = "━".repeat(innerWidth + FRAME_HORIZONTAL_PADDING);
+		return [
+			this.theme.fg("borderAccent", `┏${horizontal}┓`),
+			...lines.map((line) => {
+				const clippedLine = truncateToWidth(line, innerWidth);
+				const padding = " ".repeat(
+					Math.max(0, innerWidth - visibleWidth(clippedLine)),
+				);
+				return (
+					this.theme.fg("borderAccent", "┃") +
+					` ${clippedLine}${padding} ` +
+					this.theme.fg("borderAccent", "┃")
+				);
+			}),
+			this.theme.fg("borderAccent", `┗${horizontal}┛`),
+		];
+	}
+
+	/** Shows the active section, editing help, and the embedded multi-line editor. */
+	private renderEditor(width: number): string[] {
+		const section = this.currentSection();
+		if (section === undefined) {
+			return this.renderReview(width);
+		}
+
+		return [
+			truncateToWidth(this.theme.bold("Structured prompt"), width),
+			truncateToWidth(
+				`${this.sectionIndex + 1}/${this.sections.length}: ${section.title}`,
+				width,
+			),
+			truncateToWidth(
+				this.theme.fg(
+					"dim",
+					"Enter: next section • Shift+Enter: newline • Esc: cancel",
+				),
+				width,
+			),
+			...this.editor.render(width),
+		];
+	}
+
+	/** Shows the generated prompt preview and requires explicit confirmation to send. */
+	private renderReview(width: number): string[] {
+		const prompt = formatStructuredPrompt(this.sections, this.collectValues());
+		const previewText = prompt.length > 0 ? prompt : "No non-empty sections.";
+		const preview = new Text(previewText, 0, 0);
+		const previewLines = preview.render(width);
+		const maxPreviewRows = this.maxReviewPreviewRows();
+		this.reviewPageRows = maxPreviewRows;
+		this.reviewMaxScrollOffset = Math.max(
+			0,
+			previewLines.length - maxPreviewRows,
+		);
+		this.reviewScrollOffset = Math.min(
+			this.reviewScrollOffset,
+			this.reviewMaxScrollOffset,
+		);
+		const visiblePreview = previewLines.slice(
+			this.reviewScrollOffset,
+			this.reviewScrollOffset + maxPreviewRows,
+		);
+		const scrollInfo = this.formatReviewScrollInfo(
+			previewLines.length,
+			visiblePreview.length,
+		);
+		return [
+			truncateToWidth(this.theme.bold("Review prompt"), width),
+			truncateToWidth(
+				this.theme.fg(
+					"dim",
+					"Enter: send • Esc: cancel • Up/Down: scroll • PageUp/PageDown: page",
+				),
+				width,
+			),
+			...visiblePreview,
+			...(scrollInfo === undefined
+				? []
+				: [truncateToWidth(this.theme.fg("dim", scrollInfo), width)]),
+		];
+	}
+
+	/** Handles review-only navigation keys without changing the generated prompt. */
+	private handleReviewInput(data: string): void {
+		if (matchesKey(data, Key.down)) {
+			this.reviewScrollOffset = Math.min(
+				this.reviewMaxScrollOffset,
+				this.reviewScrollOffset + 1,
+			);
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.up)) {
+			this.reviewScrollOffset = Math.max(0, this.reviewScrollOffset - 1);
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.pageDown)) {
+			this.reviewScrollOffset = Math.min(
+				this.reviewMaxScrollOffset,
+				this.reviewScrollOffset + this.reviewPageRows,
+			);
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.pageUp)) {
+			this.reviewScrollOffset = Math.max(
+				0,
+				this.reviewScrollOffset - this.reviewPageRows,
+			);
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.home)) {
+			this.reviewScrollOffset = 0;
+			this.tui.requestRender();
+			return;
+		}
+		if (matchesKey(data, Key.end)) {
+			this.reviewScrollOffset = this.reviewMaxScrollOffset;
+			this.tui.requestRender();
+		}
+	}
+
+	/** Advances from editing to review, or submits when the review screen is active. */
+	private confirmCurrentMode(): void {
+		if (this.mode === "review") {
+			this.finish({ kind: "submitted", values: this.collectValues() });
+			return;
+		}
+
+		const section = this.currentSection();
+		if (section !== undefined) {
+			this.values.set(section.id, this.editor.getText());
+		}
+		this.sectionIndex += 1;
+		if (this.sectionIndex >= this.sections.length) {
+			this.mode = "review";
+			this.reviewScrollOffset = 0;
+		} else {
+			this.editor.setText(
+				this.values.get(this.sections[this.sectionIndex]?.id ?? "") ?? "",
+			);
+		}
+		this.tui.requestRender();
+	}
+
+	/** Reserves space for frame, title, help, and optional scroll indicator. */
+	private maxReviewPreviewRows(): number {
+		return Math.max(1, this.tui.terminal.rows - REVIEW_NON_PREVIEW_ROWS);
+	}
+
+	/** Reports which visual preview rows are visible when the prompt is scrollable. */
+	private formatReviewScrollInfo(
+		totalRows: number,
+		visibleRows: number,
+	): string | undefined {
+		if (totalRows <= visibleRows) {
+			return undefined;
+		}
+
+		const firstVisibleRow = this.reviewScrollOffset + 1;
+		const lastVisibleRow = this.reviewScrollOffset + visibleRows;
+		return `Lines ${firstVisibleRow}-${lastVisibleRow} of ${totalRows}`;
+	}
+
+	/** Returns values for every configured section so the formatter owns empty-section filtering. */
+	private collectValues(): readonly PromptSectionValue[] {
+		return this.sections.map((section) => ({
+			sectionId: section.id,
+			value: this.values.get(section.id) ?? "",
+		}));
+	}
+
+	/** Returns the section currently controlled by the embedded editor. */
+	private currentSection(): PromptSection | undefined {
+		return this.sections[this.sectionIndex];
+	}
+
+	/** Closes the component and reports the terminal form result once. */
+	private finish(result: StructuredPromptFormResult): void {
+		this.mode = "closed";
+		this.onDone(result);
+	}
+
+	/** Adapts the active Pi theme to the embedded editor contract. */
+	private createEditorTheme(): EditorTheme {
+		return {
+			borderColor: (value) => this.theme.fg("accent", value),
+			selectList: {
+				selectedPrefix: (value) => this.theme.fg("accent", value),
+				selectedText: (value) => this.theme.fg("accent", value),
+				description: (value) => this.theme.fg("muted", value),
+				scrollInfo: (value) => this.theme.fg("dim", value),
+				noMatch: (value) => this.theme.fg("warning", value),
+			},
+		};
+	}
+}

--- a/pi-package/extensions/structured-prompt/formatter.test.ts
+++ b/pi-package/extensions/structured-prompt/formatter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { formatStructuredPrompt, PROMPT_SECTIONS } from "./formatter.ts";
+
+describe("structured-prompt formatter", () => {
+	test("formats non-empty sections in the configured order", () => {
+		// Purpose: generated prompts must be deterministic and easy to scan.
+		// Input and expected output: unordered values are emitted by section order with Markdown headings.
+		// Edge case: a section value can contain multiple lines.
+		// Dependencies: this test exercises the pure formatter only.
+		const result = formatStructuredPrompt(PROMPT_SECTIONS, [
+			{ sectionId: "task", value: "Implement the extension" },
+			{ sectionId: "goal", value: "Create structured requests" },
+			{ sectionId: "context", value: "Line one\nLine two" },
+		]);
+
+		expect(result).toBe(
+			[
+				"## Goal",
+				"Create structured requests",
+				"",
+				"## Task",
+				"Implement the extension",
+				"",
+				"## Context",
+				"Line one\nLine two",
+			].join("\n"),
+		);
+	});
+
+	test("omits empty sections after trimming whitespace", () => {
+		// Purpose: generated prompts must not include unused form sections.
+		// Input and expected output: whitespace-only values are omitted, and kept values are trimmed at boundaries.
+		// Edge case: an omitted middle section does not leave duplicate blank separators.
+		// Dependencies: this test exercises the pure formatter only.
+		const result = formatStructuredPrompt(PROMPT_SECTIONS, [
+			{ sectionId: "goal", value: "  " },
+			{ sectionId: "criteria", value: "  Must pass tests  " },
+			{ sectionId: "constraints", value: "\n\t" },
+		]);
+
+		expect(result).toBe(["## Criteria", "Must pass tests"].join("\n"));
+	});
+
+	test("returns an empty string when all sections are empty", () => {
+		// Purpose: callers need an explicit empty result to cancel submission before sending.
+		// Input and expected output: no non-empty values returns an empty string.
+		// Edge case: unknown section ids do not create output.
+		// Dependencies: this test exercises the pure formatter only.
+		const result = formatStructuredPrompt(PROMPT_SECTIONS, [
+			{ sectionId: "goal", value: "" },
+			{ sectionId: "unknown", value: "Ignored" },
+		]);
+
+		expect(result).toBe("");
+	});
+});

--- a/pi-package/extensions/structured-prompt/formatter.ts
+++ b/pi-package/extensions/structured-prompt/formatter.ts
@@ -1,0 +1,38 @@
+export interface PromptSection {
+	readonly id: string;
+	readonly title: string;
+}
+
+export interface PromptSectionValue {
+	readonly sectionId: string;
+	readonly value: string;
+}
+
+export const PROMPT_SECTIONS: readonly PromptSection[] = [
+	{ id: "goal", title: "Goal" },
+	{ id: "task", title: "Task" },
+	{ id: "context", title: "Context" },
+	{ id: "criteria", title: "Criteria" },
+	{ id: "constraints", title: "Constraints" },
+	{ id: "work-order", title: "Work order" },
+];
+
+/** Builds the final user message from configured sections and non-empty user values. */
+export function formatStructuredPrompt(
+	sections: readonly PromptSection[],
+	values: readonly PromptSectionValue[],
+): string {
+	const valuesBySection = new Map(
+		values.map((value) => [value.sectionId, value.value.trim()]),
+	);
+	const blocks = sections.flatMap((section) => {
+		const value = valuesBySection.get(section.id);
+		if (value === undefined || value.length === 0) {
+			return [];
+		}
+
+		return [`## ${section.title}\n${value}`];
+	});
+
+	return blocks.join("\n\n");
+}

--- a/pi-package/extensions/structured-prompt/index.test.ts
+++ b/pi-package/extensions/structured-prompt/index.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage.ts";
+import type { StructuredPromptFormResult } from "./form.ts";
+import prompt from "./index.ts";
+
+interface RegisteredCommandFake {
+	readonly name: string;
+	readonly handler: (
+		args: string,
+		ctx: PromptCommandContextFake,
+	) => Promise<void> | void;
+}
+
+interface RegisteredShortcutFake {
+	readonly shortcut: string;
+	readonly handler: (ctx: PromptCommandContextFake) => Promise<void> | void;
+}
+
+interface CommandRegistrationOptionsFake {
+	readonly handler: (
+		args: string,
+		ctx: PromptCommandContextFake,
+	) => Promise<void> | void;
+}
+
+interface ShortcutRegistrationOptionsFake {
+	readonly handler: (ctx: PromptCommandContextFake) => Promise<void> | void;
+}
+
+interface SentUserMessageFake {
+	readonly content: string;
+	readonly options: { readonly deliverAs?: "followUp" } | undefined;
+}
+
+interface PromptExtensionApiFake {
+	readonly commands: RegisteredCommandFake[];
+	readonly shortcuts: RegisteredShortcutFake[];
+	readonly sentUserMessages: SentUserMessageFake[];
+}
+
+interface PromptCommandContextFake {
+	readonly hasUI: boolean;
+	readonly notifications: Array<{
+		readonly message: string;
+		readonly type: string | undefined;
+	}>;
+	readonly confirmations: Array<{
+		readonly title: string;
+		readonly message: string;
+	}>;
+	readonly customOptions: unknown[];
+	ui: {
+		notify(message: string, type?: string): void;
+		confirm(title: string, message: string): Promise<boolean>;
+		custom<T>(factory: unknown, options?: unknown): Promise<T>;
+	};
+	isIdle(): boolean;
+}
+
+const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	if (previousAgentSuiteDir === undefined) {
+		delete process.env[AGENT_SUITE_DIR_ENV];
+	} else {
+		process.env[AGENT_SUITE_DIR_ENV] = previousAgentSuiteDir;
+	}
+
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("structured-prompt extension", () => {
+	test("registers command and shortcut by default when config is missing", async () => {
+		// Purpose: the extension must be usable without setup.
+		// Input and expected output: missing config registers /prompt and the best-effort shortcut.
+		// Edge case: the suite config directory is absent.
+		// Dependencies: this test uses isolated temp storage and an in-memory ExtensionAPI fake.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+
+			prompt(pi as unknown as ExtensionAPI);
+
+			expect(pi.commands.map(({ name }) => name)).toEqual(["prompt"]);
+			expect(pi.shortcuts.map(({ shortcut }) => shortcut)).toEqual([
+				"ctrl+alt+p",
+			]);
+		});
+	});
+
+	test("does not register command or shortcut when disabled", async () => {
+		// Purpose: enabled false must remove both public invocation paths.
+		// Input and expected output: suite config with enabled false registers no command and no shortcut.
+		// Edge case: no other config fields are needed for disablement.
+		// Dependencies: this test uses isolated temp storage and an in-memory ExtensionAPI fake.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			await writePromptConfig(suiteDir, { enabled: false });
+			const pi = createExtensionApiFake();
+
+			prompt(pi as unknown as ExtensionAPI);
+
+			expect(pi.commands).toEqual([]);
+			expect(pi.shortcuts).toEqual([]);
+		});
+	});
+
+	test("does not register command or shortcut when config is invalid", async () => {
+		// Purpose: invalid config must fail closed instead of exposing partial behavior.
+		// Input and expected output: malformed config registers no command and no shortcut.
+		// Edge case: invalid config is detected during extension load.
+		// Dependencies: this test uses isolated temp storage and an in-memory ExtensionAPI fake.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			await writePromptConfigText(suiteDir, "{");
+			const pi = createExtensionApiFake();
+
+			prompt(pi as unknown as ExtensionAPI);
+
+			expect(pi.commands).toEqual([]);
+			expect(pi.shortcuts).toEqual([]);
+		});
+	});
+
+	test("command and shortcut use the same idle submit flow", async () => {
+		// Purpose: /prompt and ctrl+alt+p must not drift in behavior.
+		// Input and expected output: both handlers send the same generated prompt when idle.
+		// Edge case: empty sections are omitted before delivery.
+		// Dependencies: this test uses fake UI result and fake user-message delivery.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const ctx = createCommandContextFake({
+				formResult: submittedFormResult(),
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI);
+
+			await getPromptCommand(pi).handler("", ctx);
+			await getPromptShortcut(pi).handler(ctx);
+
+			expect(pi.sentUserMessages).toEqual([
+				{
+					content: ["## Goal", "Create structured requests"].join("\n"),
+					options: undefined,
+				},
+				{
+					content: ["## Goal", "Create structured requests"].join("\n"),
+					options: undefined,
+				},
+			]);
+			expect(ctx.customOptions).toHaveLength(2);
+			for (const options of ctx.customOptions) {
+				expect(options).toMatchObject({
+					overlay: true,
+					overlayOptions: { anchor: "center" },
+				});
+			}
+		});
+	});
+
+	test("does not send when UI is unavailable", async () => {
+		// Purpose: the form requires interactive UI and must fail closed outside it.
+		// Input and expected output: no UI reports a warning and sends no message.
+		// Edge case: the form is not opened.
+		// Dependencies: this test uses fake UI and fake user-message delivery.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const ctx = createCommandContextFake({
+				formResult: submittedFormResult(),
+				hasUI: false,
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI);
+
+			await getPromptCommand(pi).handler("", ctx);
+
+			expect(pi.sentUserMessages).toEqual([]);
+			expect(ctx.customOptions).toEqual([]);
+			expect(ctx.notifications).toEqual([
+				{ message: "Prompt form requires interactive mode.", type: "warning" },
+			]);
+		});
+	});
+
+	test("cancel and empty submit do not send messages", async () => {
+		// Purpose: closing the form or submitting only empty sections must not create an empty user message.
+		// Input and expected output: cancelled and empty submitted results send no messages.
+		// Edge case: all section values are whitespace.
+		// Dependencies: this test uses fake UI and fake user-message delivery.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const cancelCtx = createCommandContextFake({
+				formResult: { kind: "cancelled" },
+				idle: true,
+			});
+			const emptyCtx = createCommandContextFake({
+				formResult: {
+					kind: "submitted",
+					values: [{ sectionId: "goal", value: "  " }],
+				},
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI);
+
+			await getPromptCommand(pi).handler("", cancelCtx);
+			await getPromptCommand(pi).handler("", emptyCtx);
+
+			expect(pi.sentUserMessages).toEqual([]);
+			expect(emptyCtx.notifications).toEqual([
+				{ message: "Prompt form is empty.", type: "warning" },
+			]);
+		});
+	});
+
+	test("asks before queuing a follow-up while the agent is busy", async () => {
+		// Purpose: follow-up delivery changes timing and must be explicit.
+		// Input and expected output: rejecting confirmation sends nothing; accepting queues follow-up.
+		// Edge case: confirmation text states that the prompt will be queued.
+		// Dependencies: this test uses fake confirmation and fake user-message delivery.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const rejectCtx = createCommandContextFake({
+				formResult: submittedFormResult(),
+				idle: false,
+				confirmResult: false,
+			});
+			const acceptCtx = createCommandContextFake({
+				formResult: submittedFormResult(),
+				idle: false,
+				confirmResult: true,
+			});
+			prompt(pi as unknown as ExtensionAPI);
+
+			await getPromptCommand(pi).handler("", rejectCtx);
+			await getPromptCommand(pi).handler("", acceptCtx);
+
+			expect(rejectCtx.confirmations).toEqual([
+				{
+					title: "Queue prompt as follow-up?",
+					message:
+						"The agent is busy. Queue this prompt to run after the current response finishes?",
+				},
+			]);
+			expect(pi.sentUserMessages).toEqual([
+				{
+					content: ["## Goal", "Create structured requests"].join("\n"),
+					options: { deliverAs: "followUp" },
+				},
+			]);
+		});
+	});
+});
+
+function createExtensionApiFake(): PromptExtensionApiFake {
+	const commands: RegisteredCommandFake[] = [];
+	const shortcuts: RegisteredShortcutFake[] = [];
+	const sentUserMessages: SentUserMessageFake[] = [];
+
+	return {
+		commands,
+		shortcuts,
+		sentUserMessages,
+		registerCommand(
+			name: string,
+			options: CommandRegistrationOptionsFake,
+		): void {
+			commands.push({ name, handler: options.handler });
+		},
+		registerShortcut(
+			shortcut: string,
+			options: ShortcutRegistrationOptionsFake,
+		): void {
+			shortcuts.push({ shortcut, handler: options.handler });
+		},
+		sendUserMessage(
+			content: string,
+			options?: { deliverAs?: "followUp" },
+		): void {
+			sentUserMessages.push({ content, options });
+		},
+	} as unknown as PromptExtensionApiFake;
+}
+
+function createCommandContextFake(options: {
+	readonly formResult: StructuredPromptFormResult;
+	readonly hasUI?: boolean;
+	readonly idle: boolean;
+	readonly confirmResult?: boolean;
+}): PromptCommandContextFake {
+	const notifications: Array<{
+		readonly message: string;
+		readonly type: string | undefined;
+	}> = [];
+	const confirmations: Array<{
+		readonly title: string;
+		readonly message: string;
+	}> = [];
+	const customOptions: unknown[] = [];
+	return {
+		hasUI: options.hasUI ?? true,
+		notifications,
+		confirmations,
+		customOptions,
+		ui: {
+			notify(message: string, type?: string): void {
+				notifications.push({ message, type });
+			},
+			async confirm(title: string, message: string): Promise<boolean> {
+				confirmations.push({ title, message });
+				return options.confirmResult ?? false;
+			},
+			async custom<T>(
+				_factory: unknown,
+				customOptionsValue?: unknown,
+			): Promise<T> {
+				customOptions.push(customOptionsValue);
+				return options.formResult as T;
+			},
+		},
+		isIdle(): boolean {
+			return options.idle;
+		},
+	};
+}
+
+function submittedFormResult(): StructuredPromptFormResult {
+	return {
+		kind: "submitted",
+		values: [
+			{ sectionId: "goal", value: "Create structured requests" },
+			{ sectionId: "task", value: "" },
+		],
+	};
+}
+
+function getPromptCommand(pi: PromptExtensionApiFake): RegisteredCommandFake {
+	const command = pi.commands.find(({ name }) => name === "prompt");
+	if (command === undefined) {
+		throw new Error("prompt command was not registered");
+	}
+	return command;
+}
+
+function getPromptShortcut(pi: PromptExtensionApiFake): RegisteredShortcutFake {
+	const shortcut = pi.shortcuts.find(
+		({ shortcut }) => shortcut === "ctrl+alt+p",
+	);
+	if (shortcut === undefined) {
+		throw new Error("prompt shortcut was not registered");
+	}
+	return shortcut;
+}
+
+async function withIsolatedSuiteDir(
+	testBody: (suiteDir: string) => Promise<void>,
+): Promise<void> {
+	const suiteDir = await mkdtemp(
+		join(tmpdir(), "structured-prompt-extension-"),
+	);
+	tempDirs.push(suiteDir);
+	process.env[AGENT_SUITE_DIR_ENV] = suiteDir;
+	await testBody(suiteDir);
+}
+
+async function writePromptConfig(
+	suiteDir: string,
+	config: unknown,
+): Promise<void> {
+	await writePromptConfigText(suiteDir, JSON.stringify(config));
+}
+
+async function writePromptConfigText(
+	suiteDir: string,
+	content: string,
+): Promise<void> {
+	const configDir = join(suiteDir, "structured-prompt");
+	await mkdir(configDir, { recursive: true });
+	await writeFile(join(configDir, "config.json"), content);
+}

--- a/pi-package/extensions/structured-prompt/index.test.ts
+++ b/pi-package/extensions/structured-prompt/index.test.ts
@@ -42,6 +42,14 @@ interface PromptExtensionApiFake {
 	readonly sentUserMessages: SentUserMessageFake[];
 }
 
+interface StructuredPromptDependenciesFake {
+	readonly copyToClipboard?: (text: string) => Promise<void>;
+}
+
+interface CustomComponentFake {
+	handleInput(data: string): Promise<void> | void;
+}
+
 interface PromptCommandContextFake {
 	readonly hasUI: boolean;
 	readonly notifications: Array<{
@@ -53,14 +61,19 @@ interface PromptCommandContextFake {
 		readonly message: string;
 	}>;
 	readonly customOptions: unknown[];
+	readonly editorTexts: string[];
 	ui: {
 		notify(message: string, type?: string): void;
 		confirm(title: string, message: string): Promise<boolean>;
 		custom<T>(factory: unknown, options?: unknown): Promise<T>;
+		setEditorText(text: string): void;
 	};
 	isIdle(): boolean;
+	triggerLastReviewCopy(): Promise<void>;
 }
 
+const ENTER = "\r";
+const CTRL_Y = "\x19";
 const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
 const tempDirs: string[] = [];
 
@@ -253,6 +266,89 @@ describe("structured-prompt extension", () => {
 			]);
 		});
 	});
+
+	test("places the generated prompt in the input field without sending", async () => {
+		// Purpose: users must be able to review and then edit the generated prompt manually.
+		// Input and expected output: inserted form result sets the main editor text and sends no message.
+		// Edge case: the agent is busy, but no follow-up confirmation is requested because nothing is sent.
+		// Dependencies: this test uses fake UI editor integration.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const ctx = createCommandContextFake({
+				formResult: insertedFormResult(),
+				idle: false,
+			});
+			prompt(pi as unknown as ExtensionAPI);
+
+			await getPromptCommand(pi).handler("", ctx);
+
+			expect(ctx.editorTexts).toEqual([
+				["## Goal", "Create structured requests"].join("\n"),
+			]);
+			expect(pi.sentUserMessages).toEqual([]);
+			expect(ctx.confirmations).toEqual([]);
+		});
+	});
+
+	test("copies the generated prompt from review without sending", async () => {
+		// Purpose: users must be able to copy the generated prompt before deciding whether to send.
+		// Input and expected output: Ctrl+Y copy callback copies the formatted prompt and sends no message.
+		// Edge case: copy is a review action and does not finish the form by itself.
+		// Dependencies: this test executes the custom UI factory with fake TUI and theme objects.
+		await withIsolatedSuiteDir(async () => {
+			const copiedPrompts: string[] = [];
+			const pi = createExtensionApiFake();
+			const ctx = createCommandContextFake({
+				formResult: { kind: "cancelled" },
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI, {
+				copyToClipboard: async (text) => {
+					copiedPrompts.push(text);
+				},
+			} satisfies StructuredPromptDependenciesFake);
+
+			await getPromptCommand(pi).handler("", ctx);
+			await ctx.triggerLastReviewCopy();
+
+			expect(copiedPrompts).toEqual([
+				["## Goal", "Create structured requests"].join("\n"),
+			]);
+			expect(pi.sentUserMessages).toEqual([]);
+			expect(ctx.notifications).toContainEqual({
+				message: "Prompt copied to clipboard.",
+				type: "info",
+			});
+		});
+	});
+
+	test("reports clipboard copy failures without sending", async () => {
+		// Purpose: clipboard failures must be visible and must not submit a message.
+		// Input and expected output: failed Ctrl+Y reports a warning while the command result remains cancelled.
+		// Edge case: the copy dependency rejects while the review action is active.
+		// Dependencies: this test executes the custom UI factory with fake TUI and theme objects.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const ctx = createCommandContextFake({
+				formResult: { kind: "cancelled" },
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI, {
+				copyToClipboard: async () => {
+					throw new Error("clipboard unavailable");
+				},
+			} satisfies StructuredPromptDependenciesFake);
+
+			await getPromptCommand(pi).handler("", ctx);
+			await ctx.triggerLastReviewCopy();
+
+			expect(ctx.notifications).toContainEqual({
+				message: "Failed to copy prompt to clipboard: clipboard unavailable",
+				type: "warning",
+			});
+			expect(pi.sentUserMessages).toEqual([]);
+		});
+	});
 });
 
 function createExtensionApiFake(): PromptExtensionApiFake {
@@ -300,11 +396,14 @@ function createCommandContextFake(options: {
 		readonly message: string;
 	}> = [];
 	const customOptions: unknown[] = [];
+	const editorTexts: string[] = [];
+	let lastCustomComponent: CustomComponentFake | undefined;
 	return {
 		hasUI: options.hasUI ?? true,
 		notifications,
 		confirmations,
 		customOptions,
+		editorTexts,
 		ui: {
 			notify(message: string, type?: string): void {
 				notifications.push({ message, type });
@@ -314,15 +413,42 @@ function createCommandContextFake(options: {
 				return options.confirmResult ?? false;
 			},
 			async custom<T>(
-				_factory: unknown,
+				factory: unknown,
 				customOptionsValue?: unknown,
 			): Promise<T> {
 				customOptions.push(customOptionsValue);
+				if (typeof factory === "function") {
+					lastCustomComponent = factory(
+						{
+							terminal: { rows: 40 },
+							requestRender(): void {},
+						},
+						{
+							fg: (_color: string, value: string) => value,
+							bold: (value: string) => value,
+						},
+						undefined,
+						() => {},
+					) as CustomComponentFake;
+				}
 				return options.formResult as T;
+			},
+			setEditorText(text: string): void {
+				editorTexts.push(text);
 			},
 		},
 		isIdle(): boolean {
 			return options.idle;
+		},
+		async triggerLastReviewCopy(): Promise<void> {
+			if (lastCustomComponent === undefined) {
+				throw new Error("custom form was not opened");
+			}
+			await lastCustomComponent.handleInput("Create structured requests");
+			for (let index = 0; index < 6; index += 1) {
+				await lastCustomComponent.handleInput(ENTER);
+			}
+			await lastCustomComponent.handleInput(CTRL_Y);
 		},
 	};
 }
@@ -330,6 +456,16 @@ function createCommandContextFake(options: {
 function submittedFormResult(): StructuredPromptFormResult {
 	return {
 		kind: "submitted",
+		values: [
+			{ sectionId: "goal", value: "Create structured requests" },
+			{ sectionId: "task", value: "" },
+		],
+	};
+}
+
+function insertedFormResult(): StructuredPromptFormResult {
+	return {
+		kind: "inserted",
 		values: [
 			{ sectionId: "goal", value: "Create structured requests" },
 			{ sectionId: "task", value: "" },

--- a/pi-package/extensions/structured-prompt/index.ts
+++ b/pi-package/extensions/structured-prompt/index.ts
@@ -1,7 +1,8 @@
-import type {
-	ExtensionAPI,
-	ExtensionCommandContext,
-	ExtensionContext,
+import {
+	copyToClipboard as defaultCopyToClipboard,
+	type ExtensionAPI,
+	type ExtensionCommandContext,
+	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import { readPromptConfig } from "./config.ts";
@@ -18,24 +19,34 @@ const PROMPT_OVERLAY_OPTIONS = {
 	overlayOptions: { anchor: "center" as const },
 };
 
+interface StructuredPromptDependencies {
+	readonly copyToClipboard?: (text: string) => Promise<void>;
+}
+
 /** Registers the structured prompt form command and shortcut when the extension is enabled. */
-export default function prompt(pi: ExtensionAPI): void {
+export default function prompt(
+	pi: ExtensionAPI,
+	dependencies: StructuredPromptDependencies = {},
+): void {
 	const configResult = readPromptConfig();
 	if (configResult.kind === "invalid" || !configResult.config.enabled) {
 		return;
 	}
 
+	const copyToClipboard =
+		dependencies.copyToClipboard ?? defaultCopyToClipboard;
+
 	pi.registerCommand(PROMPT_COMMAND, {
 		description: "Open a structured prompt form",
 		handler: async (_args, ctx) => {
-			await openPromptForm(pi, ctx);
+			await openPromptForm(pi, ctx, copyToClipboard);
 		},
 	});
 
 	pi.registerShortcut(PROMPT_SHORTCUT, {
 		description: "Open a structured prompt form",
 		handler: async (ctx) => {
-			await openPromptForm(pi, ctx);
+			await openPromptForm(pi, ctx, copyToClipboard);
 		},
 	});
 }
@@ -43,6 +54,7 @@ export default function prompt(pi: ExtensionAPI): void {
 async function openPromptForm(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext | ExtensionContext,
+	copyToClipboard: (text: string) => Promise<void>,
 ): Promise<void> {
 	if (!ctx.hasUI) {
 		ctx.ui.notify("Prompt form requires interactive mode.", "warning");
@@ -55,6 +67,8 @@ async function openPromptForm(
 				tui,
 				theme,
 				sections: PROMPT_SECTIONS,
+				onCopyPrompt: (promptText) =>
+					copyPromptToClipboard(ctx, copyToClipboard, promptText),
 				onDone: done,
 			}),
 		PROMPT_OVERLAY_OPTIONS,
@@ -66,6 +80,11 @@ async function openPromptForm(
 	const promptText = formatStructuredPrompt(PROMPT_SECTIONS, result.values);
 	if (promptText.length === 0) {
 		ctx.ui.notify("Prompt form is empty.", "warning");
+		return;
+	}
+
+	if (result.kind === "inserted") {
+		ctx.ui.setEditorText(promptText);
 		return;
 	}
 
@@ -83,4 +102,27 @@ async function openPromptForm(
 	}
 
 	pi.sendUserMessage(promptText, { deliverAs: "followUp" });
+}
+
+async function copyPromptToClipboard(
+	ctx: ExtensionCommandContext | ExtensionContext,
+	copyToClipboard: (text: string) => Promise<void>,
+	promptText: string,
+): Promise<void> {
+	try {
+		await copyToClipboard(promptText);
+		ctx.ui.notify("Prompt copied to clipboard.", "info");
+	} catch (error) {
+		ctx.ui.notify(
+			`Failed to copy prompt to clipboard: ${formatError(error)}`,
+			"warning",
+		);
+	}
+}
+
+function formatError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
 }

--- a/pi-package/extensions/structured-prompt/index.ts
+++ b/pi-package/extensions/structured-prompt/index.ts
@@ -1,0 +1,86 @@
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Key } from "@earendil-works/pi-tui";
+import { readPromptConfig } from "./config.ts";
+import {
+	StructuredPromptForm,
+	type StructuredPromptFormResult,
+} from "./form.ts";
+import { formatStructuredPrompt, PROMPT_SECTIONS } from "./formatter.ts";
+
+const PROMPT_COMMAND = "prompt";
+const PROMPT_SHORTCUT = Key.ctrlAlt("p");
+const PROMPT_OVERLAY_OPTIONS = {
+	overlay: true,
+	overlayOptions: { anchor: "center" as const },
+};
+
+/** Registers the structured prompt form command and shortcut when the extension is enabled. */
+export default function prompt(pi: ExtensionAPI): void {
+	const configResult = readPromptConfig();
+	if (configResult.kind === "invalid" || !configResult.config.enabled) {
+		return;
+	}
+
+	pi.registerCommand(PROMPT_COMMAND, {
+		description: "Open a structured prompt form",
+		handler: async (_args, ctx) => {
+			await openPromptForm(pi, ctx);
+		},
+	});
+
+	pi.registerShortcut(PROMPT_SHORTCUT, {
+		description: "Open a structured prompt form",
+		handler: async (ctx) => {
+			await openPromptForm(pi, ctx);
+		},
+	});
+}
+
+async function openPromptForm(
+	pi: ExtensionAPI,
+	ctx: ExtensionCommandContext | ExtensionContext,
+): Promise<void> {
+	if (!ctx.hasUI) {
+		ctx.ui.notify("Prompt form requires interactive mode.", "warning");
+		return;
+	}
+
+	const result = await ctx.ui.custom<StructuredPromptFormResult>(
+		(tui, theme, _keybindings, done) =>
+			new StructuredPromptForm({
+				tui,
+				theme,
+				sections: PROMPT_SECTIONS,
+				onDone: done,
+			}),
+		PROMPT_OVERLAY_OPTIONS,
+	);
+	if (result.kind === "cancelled") {
+		return;
+	}
+
+	const promptText = formatStructuredPrompt(PROMPT_SECTIONS, result.values);
+	if (promptText.length === 0) {
+		ctx.ui.notify("Prompt form is empty.", "warning");
+		return;
+	}
+
+	if (ctx.isIdle()) {
+		pi.sendUserMessage(promptText);
+		return;
+	}
+
+	const queueFollowUp = await ctx.ui.confirm(
+		"Queue prompt as follow-up?",
+		"The agent is busy. Queue this prompt to run after the current response finishes?",
+	);
+	if (!queueFollowUp) {
+		return;
+	}
+
+	pi.sendUserMessage(promptText, { deliverAs: "followUp" });
+}

--- a/pi-package/package.json
+++ b/pi-package/package.json
@@ -39,6 +39,7 @@
 			"./extensions/url-scheme/index.ts",
 			"./extensions/main-agent-selection/index.ts",
 			"./extensions/run-subagent/index.ts",
+			"./extensions/structured-prompt/index.ts",
 			"./extensions/ask-llm/index.ts",
 			"./extensions/consult-advisor/index.ts",
 			"./extensions/convene-council/index.ts"


### PR DESCRIPTION
Introduce a new extension that provides a structured form for building user requests with defined sections. This extension includes configuration options, a review screen, and tests to ensure functionality.