### PR TITLE
Fix structured prompt to enhance form submissions and autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Why you need it:
 - Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
 - Shows a review screen before the request is sent.
 - Can copy the generated prompt or place it in the main input before sending.
+- Can insert `@...` file references from a section editor dropdown when `fd` is available.
 
 Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
 
@@ -572,6 +573,7 @@ Command and shortcut:
 How it works:
 
 - Opens a centered overlay with one active multi-line section editor.
+- Uses Pi TUI file autocomplete for `@...` references in section editors when `fd` is available in `PATH`.
 - Builds one Markdown prompt from non-empty sections.
 - Omits empty sections from the generated prompt.
 - Copies the generated prompt from the review screen with `Ctrl+Y`.

--- a/docs/extensions/structured-prompt.md
+++ b/docs/extensions/structured-prompt.md
@@ -22,6 +22,8 @@
   - Constraints
   - Work order
 - Supports multi-line section text.
+- Shows file suggestions for `@...` in section editors when `fd` is available in `PATH`.
+- Keeps slash-command completion disabled inside section editors.
 - Shows a review screen before sending.
 - On the review screen, `Ctrl+Y` copies the generated prompt to the clipboard without closing the form.
 - On the review screen, `Ctrl+T` places the generated prompt in the main input field and sends no message.
@@ -86,5 +88,9 @@ Tests must verify:
 - clipboard copy failure reports a warning and sends no message;
 - empty sections are omitted from the generated prompt;
 - multi-line section text is preserved;
+- `@...` file autocomplete suggestions render in section editors when `fd` is available;
+- selected `@...` file autocomplete is saved as section text;
+- slash commands stay disabled inside section editors;
+- missing `fd` does not block normal form submission;
 - terminal navigation escape sequences are not inserted into section text;
 - rendered form rows stay within the requested width.

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -557,6 +557,7 @@ Why you need it:
 - Separates Goal, Task, Context, Criteria, Constraints, and Work order before sending.
 - Shows a review screen before the request is sent.
 - Can copy the generated prompt or place it in the main input before sending.
+- Can insert `@...` file references from a section editor dropdown when `fd` is available.
 
 Config file: `~/.pi/agent/agent-suite/structured-prompt/config.json`
 
@@ -572,6 +573,7 @@ Command and shortcut:
 How it works:
 
 - Opens a centered overlay with one active multi-line section editor.
+- Uses Pi TUI file autocomplete for `@...` references in section editors when `fd` is available in `PATH`.
 - Builds one Markdown prompt from non-empty sections.
 - Omits empty sections from the generated prompt.
 - Copies the generated prompt from the review screen with `Ctrl+Y`.

--- a/pi-package/extensions/structured-prompt/environment.ts
+++ b/pi-package/extensions/structured-prompt/environment.ts
@@ -1,0 +1,6 @@
+const PATH_ENV = "PATH";
+
+/** Reads PATH from the current process environment for executable discovery. */
+export function readPathEnvironment(): string | undefined {
+	return process.env[PATH_ENV];
+}

--- a/pi-package/extensions/structured-prompt/form.test.ts
+++ b/pi-package/extensions/structured-prompt/form.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+	type AutocompleteProvider,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
 import {
 	StructuredPromptForm,
 	type StructuredPromptFormResult,
@@ -66,6 +70,37 @@ describe("structured-prompt form", () => {
 			kind: "submitted",
 			values: expect.arrayContaining([
 				{ sectionId: "goal", value: "Line one\nLine two" },
+			]),
+		});
+	});
+
+	test("selects @ file autocomplete before advancing to the next section", async () => {
+		// Purpose: file references selected from the section dropdown must become section text.
+		// Input and expected output: @READ opens a README.md suggestion, Enter selects it, and later Enter advances the form.
+		// Edge case: Enter must go to the editor while autocomplete is open instead of saving a partial prefix.
+		// Dependencies: this test uses the Pi Editor autocomplete contract with a fake provider.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const provider = createAutocompleteProviderFake();
+		const form = createForm((result) => observedResults.push(result), {
+			autocompleteProvider: provider,
+		});
+
+		typeCharacters(form, "@READ");
+		const suggestionRender = await waitForRenderedText(form, "README.md");
+		expect(suggestionRender.join("\n")).toContain("README.md");
+
+		form.handleInput(ENTER);
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		expect(observedResults).toEqual([]);
+
+		form.handleInput(ENTER);
+
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: "@README.md " },
 			]),
 		});
 	});
@@ -459,6 +494,7 @@ describe("structured-prompt form", () => {
 function createForm(
 	onDone: (result: StructuredPromptFormResult) => void,
 	options: {
+		readonly autocompleteProvider?: AutocompleteProvider;
 		readonly onCopyPrompt?: (promptText: string) => void;
 		readonly rows?: number;
 	} = {},
@@ -473,6 +509,9 @@ function createForm(
 			bold: (value) => value,
 		},
 		sections: PROMPT_SECTIONS,
+		...(options.autocompleteProvider === undefined
+			? {}
+			: { autocompleteProvider: options.autocompleteProvider }),
 		onCopyPrompt: options.onCopyPrompt,
 		onDone,
 	});
@@ -494,6 +533,55 @@ function numberedLines(count: number): string {
 
 function typeText(form: StructuredPromptForm, value: string): void {
 	form.handleInput(value);
+}
+
+function typeCharacters(form: StructuredPromptForm, value: string): void {
+	for (const char of value) {
+		form.handleInput(char);
+	}
+}
+
+async function waitForRenderedText(
+	form: StructuredPromptForm,
+	text: string,
+): Promise<string[]> {
+	let latestRows = form.render(80);
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (latestRows.join("\n").includes(text)) {
+			return latestRows;
+		}
+		await delay(10);
+		latestRows = form.render(80);
+	}
+	return latestRows;
+}
+
+function createAutocompleteProviderFake(): AutocompleteProvider {
+	return {
+		async getSuggestions(lines, cursorLine, cursorCol) {
+			const currentLine = lines[cursorLine] ?? "";
+			const prefix = currentLine.slice(0, cursorCol);
+			if (!prefix.startsWith("@")) {
+				return null;
+			}
+			return {
+				prefix,
+				items: [{ value: "@README.md", label: "README.md" }],
+			};
+		},
+		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+			const currentLine = lines[cursorLine] ?? "";
+			const beforePrefix = currentLine.slice(0, cursorCol - prefix.length);
+			const afterCursor = currentLine.slice(cursorCol);
+			const newLines = [...lines];
+			newLines[cursorLine] = `${beforePrefix}${item.value} ${afterCursor}`;
+			return {
+				lines: newLines,
+				cursorLine,
+				cursorCol: beforePrefix.length + item.value.length + 1,
+			};
+		},
+	};
 }
 
 async function waitForCopySettlement(): Promise<void> {

--- a/pi-package/extensions/structured-prompt/form.test.ts
+++ b/pi-package/extensions/structured-prompt/form.test.ts
@@ -13,6 +13,8 @@ const PAGE_DOWN = "\x1b[6~";
 const HOME = "\x1b[H";
 const CTRL_T = "\x14";
 const CTRL_Y = "\x19";
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 
 describe("structured-prompt form", () => {
 	test("submits entered section values from the review screen", () => {
@@ -64,6 +66,94 @@ describe("structured-prompt form", () => {
 			kind: "submitted",
 			values: expect.arrayContaining([
 				{ sectionId: "goal", value: "Line one\nLine two" },
+			]),
+		});
+	});
+
+	test("keeps bracketed pasted filename and backslash render-safe", () => {
+		// Purpose: pasted filename text must not leak terminal paste control bytes into the editor.
+		// Input and expected output: bracketed paste plus backslash renders within width and submits plain text.
+		// Edge case: the cursor is after a trailing backslash.
+		// Dependencies: this test uses fake TUI rendering and visible width measurement.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+		const filename = "pi-package/README.md";
+
+		form.handleInput(
+			`${BRACKETED_PASTE_START}${filename}${BRACKETED_PASTE_END}`,
+		);
+		form.handleInput("\\");
+		const rows = form.render(120);
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		form.handleInput(ENTER);
+
+		const renderedText = rows.join("\n");
+		expect(renderedText).toContain(`${filename}\\`);
+		expect(renderedText).not.toContain(BRACKETED_PASTE_START);
+		expect(renderedText).not.toContain(BRACKETED_PASTE_END);
+		expect(rows.every((row) => visibleWidth(row) <= 120)).toBe(true);
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: `${filename}\\` },
+			]),
+		});
+	});
+
+	test("keeps fragmented bracketed pasted filename render-safe", () => {
+		// Purpose: paste control handling must survive terminals that split paste into chunks.
+		// Input and expected output: fragmented bracketed paste plus backslash submits plain text.
+		// Edge case: the paste start and paste end markers arrive in different input chunks.
+		// Dependencies: this test uses fake TUI rendering and visible width measurement.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+		const filename = "README.md";
+
+		form.handleInput(`${BRACKETED_PASTE_START}READ`);
+		form.handleInput(`ME.md${BRACKETED_PASTE_END}`);
+		form.handleInput("\\");
+		const rows = form.render(80);
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		form.handleInput(ENTER);
+
+		const renderedText = rows.join("\n");
+		expect(renderedText).toContain(`${filename}\\`);
+		expect(renderedText).not.toContain(BRACKETED_PASTE_START);
+		expect(renderedText).not.toContain(BRACKETED_PASTE_END);
+		expect(rows.every((row) => visibleWidth(row) <= 80)).toBe(true);
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: `${filename}\\` },
+			]),
+		});
+	});
+
+	test("submits expanded content from large bracketed paste", () => {
+		// Purpose: large pasted text must not be submitted as an internal paste marker.
+		// Input and expected output: bracketed paste with many lines submits the original text.
+		// Edge case: Pi Editor may render a compact paste marker for large paste.
+		// Dependencies: this test checks the form result, not the editor display string.
+		const observedResults: StructuredPromptFormResult[] = [];
+		const form = createForm((result) => observedResults.push(result));
+		const pastedText = numberedLines(12);
+
+		form.handleInput(
+			`${BRACKETED_PASTE_START}${pastedText}${BRACKETED_PASTE_END}`,
+		);
+		for (const _section of PROMPT_SECTIONS) {
+			form.handleInput(ENTER);
+		}
+		form.handleInput(ENTER);
+
+		expect(observedResults[0]).toEqual({
+			kind: "submitted",
+			values: expect.arrayContaining([
+				{ sectionId: "goal", value: pastedText },
 			]),
 		});
 	});

--- a/pi-package/extensions/structured-prompt/form.ts
+++ b/pi-package/extensions/structured-prompt/form.ts
@@ -49,6 +49,8 @@ const FRAME_SIDE_WIDTH = 2;
 const FRAME_HORIZONTAL_PADDING = 2;
 const FRAME_DECORATION_WIDTH = FRAME_SIDE_WIDTH + FRAME_HORIZONTAL_PADDING;
 const REVIEW_NON_PREVIEW_ROWS = 6;
+const BRACKETED_PASTE_START = "\x1b[200~";
+const BRACKETED_PASTE_END = "\x1b[201~";
 
 /** Captures section text first, then requires a review confirmation before submit. */
 export class StructuredPromptForm implements Component {
@@ -67,6 +69,7 @@ export class StructuredPromptForm implements Component {
 	private reviewMaxScrollOffset = 0;
 	private reviewPageRows = 1;
 	private copyInProgress = false;
+	private editorPasteInProgress = false;
 
 	/** Creates the form with a Pi editor for multi-line section input. */
 	public constructor(options: StructuredPromptFormOptions) {
@@ -117,7 +120,10 @@ export class StructuredPromptForm implements Component {
 			return;
 		}
 
-		if (data.length > 1 && parseKey(data) === undefined) {
+		if (this.shouldRouteToEditorPaste(data)) {
+			this.editor.handleInput(data);
+			this.updateEditorPasteState(data);
+		} else if (data.length > 1 && parseKey(data) === undefined) {
 			this.editor.insertTextAtCursor(data);
 		} else {
 			this.editor.handleInput(data);
@@ -282,6 +288,34 @@ export class StructuredPromptForm implements Component {
 		}
 	}
 
+	/** Routes bracketed paste chunks through the editor so terminal control bytes are handled as paste metadata. */
+	private shouldRouteToEditorPaste(data: string): boolean {
+		return (
+			this.editorPasteInProgress ||
+			data.includes(BRACKETED_PASTE_START) ||
+			data.includes(BRACKETED_PASTE_END)
+		);
+	}
+
+	/** Tracks bracketed paste across terminal chunks until the paste end marker arrives. */
+	private updateEditorPasteState(data: string): void {
+		let cursor = 0;
+		while (cursor < data.length) {
+			const nextStart = data.indexOf(BRACKETED_PASTE_START, cursor);
+			const nextEnd = data.indexOf(BRACKETED_PASTE_END, cursor);
+			if (nextStart === -1 && nextEnd === -1) {
+				break;
+			}
+			if (nextEnd === -1 || (nextStart !== -1 && nextStart < nextEnd)) {
+				this.editorPasteInProgress = true;
+				cursor = nextStart + BRACKETED_PASTE_START.length;
+			} else {
+				this.editorPasteInProgress = false;
+				cursor = nextEnd + BRACKETED_PASTE_END.length;
+			}
+		}
+	}
+
 	/** Starts clipboard copy and blocks send actions until the copy attempt finishes. */
 	private copyCurrentPrompt(): void {
 		if (this.copyInProgress) {
@@ -311,7 +345,7 @@ export class StructuredPromptForm implements Component {
 
 		const section = this.currentSection();
 		if (section !== undefined) {
-			this.values.set(section.id, this.editor.getText());
+			this.values.set(section.id, this.editor.getExpandedText());
 		}
 		this.sectionIndex += 1;
 		if (this.sectionIndex >= this.sections.length) {

--- a/pi-package/extensions/structured-prompt/form.ts
+++ b/pi-package/extensions/structured-prompt/form.ts
@@ -1,5 +1,6 @@
 import type { ThemeColor } from "@earendil-works/pi-coding-agent";
 import {
+	type AutocompleteProvider,
 	type Component,
 	Editor,
 	type EditorTheme,
@@ -37,6 +38,7 @@ export interface StructuredPromptFormOptions {
 	readonly tui: TUI;
 	readonly theme: PromptFormTheme;
 	readonly sections: readonly PromptSection[];
+	readonly autocompleteProvider?: AutocompleteProvider;
 	readonly onCopyPrompt?:
 		| ((promptText: string) => Promise<void> | void)
 		| undefined;
@@ -79,6 +81,9 @@ export class StructuredPromptForm implements Component {
 		this.onCopyPrompt = options.onCopyPrompt;
 		this.onDone = options.onDone;
 		this.editor = new Editor(this.tui, this.createEditorTheme());
+		if (options.autocompleteProvider !== undefined) {
+			this.editor.setAutocompleteProvider(options.autocompleteProvider);
+		}
 	}
 
 	/** Renders either the active section editor or the final prompt preview. */
@@ -98,6 +103,15 @@ export class StructuredPromptForm implements Component {
 	/** Routes cancel and step confirmation keys before passing text input to the editor. */
 	public handleInput(data: string): void {
 		if (this.mode === "closed") {
+			return;
+		}
+		if (
+			this.mode === "edit" &&
+			this.editor.isShowingAutocomplete() &&
+			(matchesKey(data, Key.escape) || matchesKey(data, Key.enter))
+		) {
+			this.editor.handleInput(data);
+			this.tui.requestRender();
 			return;
 		}
 		if (matchesKey(data, Key.escape)) {

--- a/pi-package/extensions/structured-prompt/index.test.ts
+++ b/pi-package/extensions/structured-prompt/index.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage.ts";
 import type { StructuredPromptFormResult } from "./form.ts";
@@ -44,9 +45,11 @@ interface PromptExtensionApiFake {
 
 interface StructuredPromptDependenciesFake {
 	readonly copyToClipboard?: (text: string) => Promise<void>;
+	readonly resolveFdPath?: () => string | null;
 }
 
 interface CustomComponentFake {
+	render(width: number): string[];
 	handleInput(data: string): Promise<void> | void;
 }
 
@@ -62,6 +65,7 @@ interface PromptCommandContextFake {
 	}>;
 	readonly customOptions: unknown[];
 	readonly editorTexts: string[];
+	readonly cwd: string;
 	ui: {
 		notify(message: string, type?: string): void;
 		confirm(title: string, message: string): Promise<boolean>;
@@ -69,6 +73,7 @@ interface PromptCommandContextFake {
 		setEditorText(text: string): void;
 	};
 	isIdle(): boolean;
+	getLastCustomComponent(): CustomComponentFake | undefined;
 	triggerLastReviewCopy(): Promise<void>;
 }
 
@@ -196,6 +201,116 @@ describe("structured-prompt extension", () => {
 			expect(ctx.notifications).toEqual([
 				{ message: "Prompt form requires interactive mode.", type: "warning" },
 			]);
+		});
+	});
+
+	test("wires @ file autocomplete through the runtime fd path", async () => {
+		// Purpose: the command must give the form a Pi TUI file autocomplete provider.
+		// Input and expected output: @ renders the README.md suggestion from fd-backed completion.
+		// Edge case: slash commands are not part of the form provider because the provider is created with no commands.
+		// Dependencies: this test uses a temporary fake fd executable and a captured custom component.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await mkdtemp(
+				join(tmpdir(), "structured-prompt-project-"),
+			);
+			tempDirs.push(projectDir);
+			await writeFile(join(projectDir, "README.md"), "# Fixture\n");
+			const binDir = await mkdtemp(join(tmpdir(), "structured-prompt-bin-"));
+			tempDirs.push(binDir);
+			const fdPath = join(binDir, "fd");
+			await writeFile(fdPath, "#!/bin/sh\nprintf 'README.md\\n'\n");
+			await chmod(fdPath, 0o755);
+
+			const pi = createExtensionApiFake();
+			const dependencies: StructuredPromptDependenciesFake = {
+				resolveFdPath: () => fdPath,
+			};
+			const ctx = createCommandContextFake({
+				cwd: projectDir,
+				formResult: { kind: "cancelled" },
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI, dependencies);
+
+			await getPromptCommand(pi).handler("", ctx);
+			const component = ctx.getLastCustomComponent();
+			expect(component).toBeDefined();
+			if (component === undefined) {
+				throw new Error("structured prompt form was not opened");
+			}
+
+			typeCharacters(component, "@");
+			const rows = await waitForRenderedText(component, "README.md");
+
+			expect(rows.join("\n")).toContain("README.md");
+		});
+	});
+
+	test("keeps normal submission when runtime fd is unavailable", async () => {
+		// Purpose: file autocomplete depends on fd, but prompt delivery must not depend on it.
+		// Input and expected output: fd resolution returns null and the submitted form still sends the prompt.
+		// Edge case: no autocomplete provider is passed to the form.
+		// Dependencies: this test uses fake UI result and fake user-message delivery.
+		await withIsolatedSuiteDir(async () => {
+			const pi = createExtensionApiFake();
+			const dependencies: StructuredPromptDependenciesFake = {
+				resolveFdPath: () => null,
+			};
+			const ctx = createCommandContextFake({
+				formResult: submittedFormResult(),
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI, dependencies);
+
+			await getPromptCommand(pi).handler("", ctx);
+
+			expect(pi.sentUserMessages).toEqual([
+				{
+					content: ["## Goal", "Create structured requests"].join("\n"),
+					options: undefined,
+				},
+			]);
+		});
+	});
+
+	test("keeps slash commands disabled inside the form editor", async () => {
+		// Purpose: section text must not show command completion or consume Enter for slash commands.
+		// Input and expected output: typing / then Enter moves from Goal to Task.
+		// Edge case: the provider is fd-backed but has no command list.
+		// Dependencies: this test uses a temporary fake fd executable and a captured custom component.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await mkdtemp(
+				join(tmpdir(), "structured-prompt-project-"),
+			);
+			tempDirs.push(projectDir);
+			const binDir = await mkdtemp(join(tmpdir(), "structured-prompt-bin-"));
+			tempDirs.push(binDir);
+			const fdPath = join(binDir, "fd");
+			await writeFile(fdPath, "#!/bin/sh\nprintf ''\n");
+			await chmod(fdPath, 0o755);
+			const pi = createExtensionApiFake();
+			const dependencies: StructuredPromptDependenciesFake = {
+				resolveFdPath: () => fdPath,
+			};
+			const ctx = createCommandContextFake({
+				cwd: projectDir,
+				formResult: { kind: "cancelled" },
+				idle: true,
+			});
+			prompt(pi as unknown as ExtensionAPI, dependencies);
+
+			await getPromptCommand(pi).handler("", ctx);
+			const component = ctx.getLastCustomComponent();
+			expect(component).toBeDefined();
+			if (component === undefined) {
+				throw new Error("structured prompt form was not opened");
+			}
+
+			typeCharacters(component, "/");
+			await delay(30);
+			component.handleInput(ENTER);
+
+			expect(component.render(80).join("\n")).toContain("2/6: Task");
 		});
 	});
 
@@ -382,6 +497,7 @@ function createExtensionApiFake(): PromptExtensionApiFake {
 }
 
 function createCommandContextFake(options: {
+	readonly cwd?: string;
 	readonly formResult: StructuredPromptFormResult;
 	readonly hasUI?: boolean;
 	readonly idle: boolean;
@@ -404,6 +520,7 @@ function createCommandContextFake(options: {
 		confirmations,
 		customOptions,
 		editorTexts,
+		cwd: options.cwd ?? process.cwd(),
 		ui: {
 			notify(message: string, type?: string): void {
 				notifications.push({ message, type });
@@ -439,6 +556,9 @@ function createCommandContextFake(options: {
 		},
 		isIdle(): boolean {
 			return options.idle;
+		},
+		getLastCustomComponent(): CustomComponentFake | undefined {
+			return lastCustomComponent;
 		},
 		async triggerLastReviewCopy(): Promise<void> {
 			if (lastCustomComponent === undefined) {
@@ -489,6 +609,27 @@ function getPromptShortcut(pi: PromptExtensionApiFake): RegisteredShortcutFake {
 		throw new Error("prompt shortcut was not registered");
 	}
 	return shortcut;
+}
+
+function typeCharacters(component: CustomComponentFake, value: string): void {
+	for (const char of value) {
+		component.handleInput(char);
+	}
+}
+
+async function waitForRenderedText(
+	component: CustomComponentFake,
+	text: string,
+): Promise<string[]> {
+	let latestRows = component.render(80);
+	for (let attempt = 0; attempt < 50; attempt += 1) {
+		if (latestRows.join("\n").includes(text)) {
+			return latestRows;
+		}
+		await delay(10);
+		latestRows = component.render(80);
+	}
+	return latestRows;
 }
 
 async function withIsolatedSuiteDir(

--- a/pi-package/extensions/structured-prompt/index.ts
+++ b/pi-package/extensions/structured-prompt/index.ts
@@ -1,11 +1,18 @@
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
 import {
 	copyToClipboard as defaultCopyToClipboard,
 	type ExtensionAPI,
 	type ExtensionCommandContext,
 	type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
-import { Key } from "@earendil-works/pi-tui";
+import {
+	type AutocompleteProvider,
+	CombinedAutocompleteProvider,
+	Key,
+} from "@earendil-works/pi-tui";
 import { readPromptConfig } from "./config.ts";
+import { readPathEnvironment } from "./environment.ts";
 import {
 	StructuredPromptForm,
 	type StructuredPromptFormResult,
@@ -21,6 +28,7 @@ const PROMPT_OVERLAY_OPTIONS = {
 
 interface StructuredPromptDependencies {
 	readonly copyToClipboard?: (text: string) => Promise<void>;
+	readonly resolveFdPath?: () => string | null;
 }
 
 /** Registers the structured prompt form command and shortcut when the extension is enabled. */
@@ -35,18 +43,19 @@ export default function prompt(
 
 	const copyToClipboard =
 		dependencies.copyToClipboard ?? defaultCopyToClipboard;
+	const resolveFdPath = dependencies.resolveFdPath ?? resolveFdPathFromPath;
 
 	pi.registerCommand(PROMPT_COMMAND, {
 		description: "Open a structured prompt form",
 		handler: async (_args, ctx) => {
-			await openPromptForm(pi, ctx, copyToClipboard);
+			await openPromptForm(pi, ctx, copyToClipboard, resolveFdPath);
 		},
 	});
 
 	pi.registerShortcut(PROMPT_SHORTCUT, {
 		description: "Open a structured prompt form",
 		handler: async (ctx) => {
-			await openPromptForm(pi, ctx, copyToClipboard);
+			await openPromptForm(pi, ctx, copyToClipboard, resolveFdPath);
 		},
 	});
 }
@@ -55,18 +64,24 @@ async function openPromptForm(
 	pi: ExtensionAPI,
 	ctx: ExtensionCommandContext | ExtensionContext,
 	copyToClipboard: (text: string) => Promise<void>,
+	resolveFdPath: () => string | null,
 ): Promise<void> {
 	if (!ctx.hasUI) {
 		ctx.ui.notify("Prompt form requires interactive mode.", "warning");
 		return;
 	}
 
+	const autocompleteProvider = createAutocompleteProvider(
+		ctx.cwd,
+		resolveFdPath(),
+	);
 	const result = await ctx.ui.custom<StructuredPromptFormResult>(
 		(tui, theme, _keybindings, done) =>
 			new StructuredPromptForm({
 				tui,
 				theme,
 				sections: PROMPT_SECTIONS,
+				...(autocompleteProvider === undefined ? {} : { autocompleteProvider }),
 				onCopyPrompt: (promptText) =>
 					copyPromptToClipboard(ctx, copyToClipboard, promptText),
 				onDone: done,
@@ -102,6 +117,39 @@ async function openPromptForm(
 	}
 
 	pi.sendUserMessage(promptText, { deliverAs: "followUp" });
+}
+
+/** Creates a Pi TUI CombinedAutocompleteProvider for form file references when fd is available. */
+function createAutocompleteProvider(
+	cwd: string,
+	fdPath: string | null,
+): AutocompleteProvider | undefined {
+	if (fdPath === null) {
+		return undefined;
+	}
+	return new CombinedAutocompleteProvider([], cwd, fdPath);
+}
+
+/** Finds an executable fd on PATH for Pi TUI file autocomplete. */
+function resolveFdPathFromPath(): string | null {
+	const pathValue = readPathEnvironment();
+	if (pathValue === undefined || pathValue.length === 0) {
+		return null;
+	}
+
+	for (const directory of pathValue.split(delimiter)) {
+		if (directory.length === 0) {
+			continue;
+		}
+		const candidate = join(directory, "fd");
+		try {
+			accessSync(candidate, constants.X_OK);
+			return candidate;
+		} catch {
+			// Keep scanning PATH entries until an executable fd is found.
+		}
+	}
+	return null;
 }
 
 async function copyPromptToClipboard(


### PR DESCRIPTION
Enhance form submissions by preserving bracketed paste content and introduce file autocomplete for `@file` references in section editors when `fd` is available. This improves user experience and functionality in structured prompts.