### PR TITLE
Fix case sensitivity for agentId matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -536,13 +536,13 @@ Options:
 
 Tool input:
 
-- `agentId`: subagent to run.
+- `agentId`: subagent to run. Matching does not depend on letter case.
 - `prompt`: task for the subagent.
 
 How it works:
 
 - Shows callable subagents to the main model.
-- Allows only subagents permitted by the selected main agent.
+- Allows only subagents permitted by the selected main agent. Allowlist matching does not depend on letter case.
 - Starts a separate pi process for the selected subagent.
 - Applies the subagent's model, thinking level, and tools.
 - Reads oversized child RPC progress.

--- a/docs/extensions/main-agent-selection.md
+++ b/docs/extensions/main-agent-selection.md
@@ -19,6 +19,7 @@
 - Owns selected-agent state under `~/.pi/agent/agent-suite/agent-selection/state/`.
 - Stores only `cwd` and `activeAgentId` in the state file.
 - Stores `activeAgentId: null` for the explicit no-agent state.
+- Matches `activeAgentId` without case sensitivity and keeps the stored agent ID casing after selection.
 - Does not store model, thinking level, or tools in the state file.
 - Applies `model` only when the agent defines `model.id`.
 - Applies thinking level only when the agent defines `model.thinking`.
@@ -90,6 +91,7 @@ Tests must verify:
 
 - no command or shortcut registration when `enabled` is `false`;
 - agent selection through `/agent`;
+- case-insensitive agent ID matching that keeps stored agent ID casing;
 - no-agent selection through `/agent none` and the interactive `No agent` option;
 - current selection restoration when opening `/agent` without arguments;
 - agent selection through `Ctrl+Shift+A`;

--- a/docs/extensions/run-subagent.md
+++ b/docs/extensions/run-subagent.md
@@ -9,6 +9,8 @@
 - Is enabled by default when `config.json` is missing.
 - Registers tool `run_subagent`.
 - Accepts `agentId` and `prompt`.
+- Matches `agentId` and selected main-agent `agents` allowlist entries without case sensitivity.
+- Keeps the stored agent ID casing in the child process environment.
 - Runs one callable agent per tool call.
 - Publishes the callable-agent list into the model context.
 - Restores the selected main agent before building the callable-agent prompt.
@@ -114,6 +116,7 @@ Tests must verify:
 - omission of callable-agent guidance at `maxDepth`;
 - contribution publication to `Agent Runtime Composition` without direct `pi.setActiveTools()` calls;
 - callable-agent prompt filtering from the selected main agent's `agents` allowlist;
+- case-insensitive `agentId` and `agents` allowlist matching;
 - execution rejection for callable agents blocked by the selected main agent's `agents` allowlist;
 - TUI progress rendering that does not expose raw `text_delta` chunks;
 - final output extraction from completed assistant `message_end` events before `agent_end`;

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -536,13 +536,13 @@ Options:
 
 Tool input:
 
-- `agentId`: subagent to run.
+- `agentId`: subagent to run. Matching does not depend on letter case.
 - `prompt`: task for the subagent.
 
 How it works:
 
 - Shows callable subagents to the main model.
-- Allows only subagents permitted by the selected main agent.
+- Allows only subagents permitted by the selected main agent. Allowlist matching does not depend on letter case.
 - Starts a separate pi process for the selected subagent.
 - Applies the subagent's model, thinking level, and tools.
 - Reads oversized child RPC progress.

--- a/pi-package/extensions/main-agent-selection/index.ts
+++ b/pi-package/extensions/main-agent-selection/index.ts
@@ -17,6 +17,7 @@ import {
 } from "@earendil-works/pi-tui";
 import {
 	type AgentDefinition,
+	agentIdMatches,
 	loadAgentDefinitions,
 } from "../../shared/agent-registry";
 import {
@@ -462,9 +463,10 @@ async function restoreSessionReplacementMainAgent(
 		return true;
 	}
 
+	const activeAgentId = handoff.activeAgentId;
 	const agents = await loadSelectableAgents();
-	const agent = agents.find(
-		(candidate) => candidate.id === handoff.activeAgentId,
+	const agent = agents.find((candidate) =>
+		agentIdMatches(candidate.id, activeAgentId),
 	);
 	if (agent === undefined) {
 		reportIssue(
@@ -599,8 +601,9 @@ async function restoreSelectedMainAgent(
 		return;
 	}
 
-	const agent = agents.find(
-		(candidate) => candidate.id === state.state.activeAgentId,
+	const activeAgentId = state.state.activeAgentId;
+	const agent = agents.find((candidate) =>
+		agentIdMatches(candidate.id, activeAgentId),
 	);
 	if (agent === undefined) {
 		reportIssue(
@@ -635,7 +638,9 @@ async function selectMainAgent(
 		return;
 	}
 
-	const agent = agents.find((candidate) => candidate.id === selectedAgentId);
+	const agent = agents.find((candidate) =>
+		agentIdMatches(candidate.id, selectedAgentId),
+	);
 	if (agent === undefined) {
 		reportIssue(ctx, `agent ${selectedAgentId} was not found`);
 		return;

--- a/pi-package/extensions/run-subagent/index.ts
+++ b/pi-package/extensions/run-subagent/index.ts
@@ -11,7 +11,9 @@ import type {
 import { Type } from "typebox";
 import {
 	type AgentDefinition,
+	agentIdMatches,
 	loadAgentDefinitions,
+	toAgentIdMatchKey,
 } from "../../shared/agent-registry";
 import {
 	getAgentRuntimeComposition,
@@ -315,8 +317,8 @@ function buildRunSubagentPrompt({
 	});
 	const prompts: string[] = [];
 	if (childAgentId !== undefined) {
-		const childAgent = callableAgents.find(
-			(agent) => agent.id === childAgentId,
+		const childAgent = callableAgents.find((agent) =>
+			agentIdMatches(agent.id, childAgentId),
 		);
 		if (childAgent?.prompt) {
 			prompts.push(childAgent.prompt);
@@ -359,7 +361,7 @@ function resolveEffectiveAgentPolicy(
 		return mainAgent;
 	}
 
-	return callableAgents.find((agent) => agent.id === childAgentId);
+	return callableAgents.find((agent) => agentIdMatches(agent.id, childAgentId));
 }
 
 /** Applies the effective agent's explicit subagent allowlist to callable agents. */
@@ -371,8 +373,10 @@ function filterCallableAgents(
 		return callableAgents;
 	}
 
-	const allowedIds = new Set(effectiveAgent.agents);
-	return callableAgents.filter((agent) => allowedIds.has(agent.id));
+	const allowedIds = new Set(effectiveAgent.agents.map(toAgentIdMatchKey));
+	return callableAgents.filter((agent) =>
+		allowedIds.has(toAgentIdMatchKey(agent.id)),
+	);
 }
 
 /** Checks whether the effective agent can call run_subagent under its tool allowlist. */
@@ -511,8 +515,8 @@ async function resolveCallableAgent(
 		readSubagentAgentId(),
 	);
 	const allowedAgents = filterCallableAgents(agents, effectiveAgent);
-	const agent = allowedAgents.find(
-		(candidate) => candidate.id === params.agentId,
+	const agent = allowedAgents.find((candidate) =>
+		agentIdMatches(candidate.id, params.agentId),
 	);
 	return agent === undefined
 		? { result: errorResult(`agent ${params.agentId} was not found`) }

--- a/pi-package/shared/agent-registry.ts
+++ b/pi-package/shared/agent-registry.ts
@@ -44,6 +44,16 @@ export interface AgentDefinition {
 	readonly agents?: readonly string[];
 }
 
+/** Normalizes an agent ID for case-insensitive matching while preserving the stored ID for runtime state. */
+export function toAgentIdMatchKey(agentId: string): string {
+	return agentId.toLowerCase();
+}
+
+/** Compares agent IDs without requiring callers to know the stored ID casing. */
+export function agentIdMatches(left: string, right: string): boolean {
+	return toAgentIdMatchKey(left) === toAgentIdMatchKey(right);
+}
+
 /** Loads valid agent definitions from the isolated pi agent directory. */
 export async function loadAgentDefinitions(): Promise<AgentDefinition[]> {
 	const agentsDir = await resolveAgentsDir();

--- a/test/extensions/main-agent-selection/index.test.ts
+++ b/test/extensions/main-agent-selection/index.test.ts
@@ -876,13 +876,13 @@ describe("main-agent-selection", () => {
 
 	test("selects an agent through /agent, persists state, applies model and thinking, and publishes runtime contribution", async () => {
 		// Purpose: explicit /agent selection must apply only selected main-agent behavior and persist minimal state.
-		// Input and expected output: /agent builder selects builder, writes cwd and activeAgentId, sets model/thinking, tools, and prompt contribution.
-		// Edge case: state file must not contain model, thinking level, or tools.
+		// Input and expected output: /agent builder selects Builder, writes the stored activeAgentId, sets model/thinking, tools, and prompt contribution.
+		// Edge case: state file must preserve stored agent ID casing and omit model, thinking level, and tools.
 		// Dependencies: this test uses temp agent files, temp state, fake model calls, and runtime composition fake through ExtensionAPI.
 		await withIsolatedAgentDir(async (agentDir) => {
 			const model = createModel("openai", "gpt-test");
 			await writeAgent(agentDir, {
-				id: "builder",
+				id: "Builder",
 				description: "Builds code",
 				body: "Builder system prompt",
 				model: { id: "openai/gpt-test", thinking: "high" },
@@ -896,7 +896,7 @@ describe("main-agent-selection", () => {
 
 			expect(await readOnlyStateFile(agentDir)).toEqual({
 				cwd: "/tmp/project",
-				activeAgentId: "builder",
+				activeAgentId: "Builder",
 			});
 			expect(pi.setModelCalls).toEqual([model]);
 			expect(pi.thinkingCalls).toEqual(["high"]);
@@ -964,8 +964,8 @@ describe("main-agent-selection", () => {
 
 	test("reload rereads selected-agent state and updates runtime contribution", async () => {
 		// Purpose: /reload must be the boundary where persisted selected-agent state affects the running session.
-		// Input and expected output: missing state at startup then Sage state before reload publishes Sage prompt after reload.
-		// Edge case: reload uses the same extension instance in this unit test, matching the observable session_start contract.
+		// Input and expected output: missing state at startup then lowercase Sage state before reload publishes Sage prompt after reload.
+		// Edge case: reload preserves the stored agent ID casing in runtime contribution.
 		// Dependencies: this test writes only isolated agent definitions and selected-agent state files.
 		await withIsolatedAgentDir(async (agentDir) => {
 			await writeAgent(agentDir, {
@@ -989,7 +989,7 @@ describe("main-agent-selection", () => {
 			});
 			await writeSuiteSelectedAgentState(agentDir, "/tmp/project", {
 				cwd: "/tmp/project",
-				activeAgentId: "Sage",
+				activeAgentId: "sage",
 			});
 
 			await sessionStart({ type: "session_start", reason: "reload" }, ctx);

--- a/test/extensions/run-subagent/index.test.ts
+++ b/test/extensions/run-subagent/index.test.ts
@@ -633,12 +633,12 @@ describe("run-subagent", () => {
 
 	test("starts child pi with explicit model, thinking, tools, and subagent environment", async () => {
 		// Purpose: a valid callable agent must start an isolated child pi process with explicit runtime options.
-		// Input and expected output: subagent helper resolves tools, model, thinking, depth, env, prompt, and parses final assistant text.
-		// Edge case: wildcard tool pattern resolves narrowly and deduplicates with an exact tool.
+		// Input and expected output: subagent helper resolves Helper tools, model, thinking, depth, env, prompt, and parses final assistant text.
+		// Edge case: lowercase agentId input preserves stored agent ID casing in the child environment.
 		// Dependencies: this test uses temp agent files, fake tool registry, and fake child process output.
 		await withIsolatedEnvironment(async (agentDir) => {
 			await writeAgent(agentDir, {
-				id: "helper",
+				id: "Helper",
 				type: "subagent",
 				description: "Helps with code",
 				body: "Helper prompt",
@@ -699,7 +699,7 @@ describe("run-subagent", () => {
 			expect(spawn.calls[0]?.options.env[CHILD_AGENT_PROCESS_ENV]).toBe(
 				CHILD_AGENT_PROCESS_ENV_VALUE,
 			);
-			expect(spawn.calls[0]?.options.env[SUBAGENT_AGENT_ID_ENV]).toBe("helper");
+			expect(spawn.calls[0]?.options.env[SUBAGENT_AGENT_ID_ENV]).toBe("Helper");
 			expect(spawn.calls[0]?.options.env[SUBAGENT_DEPTH_ENV]).toBe("1");
 			expect(spawn.calls[0]?.options.env[SUBAGENT_TOOLS_ENV]).toBe("read,grep");
 			expect(spawn.calls[0]?.process.stdin.writes).toEqual([
@@ -724,8 +724,8 @@ describe("run-subagent", () => {
 			const renderedWidget = widget.render(24);
 			expect(renderedWidget).toContain("────────────────────────");
 			expect(renderedWidget.join("\n")).toContain("Subagents:");
-			expect(renderedWidget.join("\n")).toContain("helper");
-			expect(renderedWidget.join("\n")).not.toContain("helper: wor");
+			expect(renderedWidget.join("\n")).toContain("Helper");
+			expect(renderedWidget.join("\n")).not.toContain("Helper: wor");
 			expect(renderedWidget.every((line) => visibleWidth(line) <= 24)).toBe(
 				true,
 			);
@@ -4347,7 +4347,7 @@ describe("run-subagent", () => {
 
 	test("restores selected main-agent allowlist before exposing callable agents", async () => {
 		// Purpose: callable-agent prompt must use the persisted selected main agent after session_start restores it.
-		// Input and expected output: persisted TestAgent allows only SubAgentExtractor, so other callable agents and TestAgent itself are omitted.
+		// Input and expected output: persisted TestAgent allows only SubAgentExtractor through a lowercase allowlist, so other callable agents and TestAgent itself are omitted.
 		// Edge case: TestAgent has type both and would be globally callable without the selected main-agent allowlist.
 		// Dependencies: this test uses temp agent files, temp selected-agent state, main-agent-selection, and run-subagent composition.
 		await withIsolatedEnvironment(async (agentDir) => {
@@ -4375,7 +4375,7 @@ describe("run-subagent", () => {
 				description: "Agent for testing subagents subsystem.",
 				body: "Test agent prompt",
 				tools: ["run_subagent"],
-				agents: ["SubAgentExtractor"],
+				agents: ["subagentextractor"],
 			});
 			await writeSelectedAgentState(agentDir, "/tmp/project", "TestAgent");
 			const pi = createExtensionApiFake(["run_subagent"]);


### PR DESCRIPTION
Enhance agentId matching to be case-insensitive while preserving the original casing of stored IDs. This change improves usability and consistency in agent selection and management.