### PR TITLE
Merge startup and background refresh caches in MCP wrapper

### DIFF
--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -13,6 +13,7 @@ import type { McpServerConfig } from "./config.ts";
 import mcpWrapper from "./index.ts";
 import {
 	computeMcpServerConfigHash,
+	loadMcpWrapperCache,
 	saveMcpWrapperCache,
 } from "./metadata-cache.ts";
 
@@ -709,11 +710,25 @@ describe("mcp-wrapper extension", () => {
 				},
 			},
 		});
+		const backgroundRefreshSaved = deferred<void>();
 		const discoveredServerMaps: Readonly<Record<string, McpServerConfig>>[] =
 			[];
+		let saveCount = 0;
 		const manager = {
 			discoverServers: async (servers) => {
 				discoveredServerMaps.push(servers);
+				if (servers["cached"] !== undefined) {
+					return {
+						serverToolLists: [
+							{
+								serverKey: "cached",
+								tools: [{ name: "read", inputSchema: { type: "object" } }],
+							},
+						],
+						serverInstructions: [],
+						failures: [],
+					};
+				}
 				return {
 					serverToolLists: [
 						{
@@ -746,6 +761,13 @@ describe("mcp-wrapper extension", () => {
 				},
 			}),
 			createManager: () => managerWithCleanup(manager),
+			saveCache: async (cache) => {
+				saveCount += 1;
+				await saveMcpWrapperCache(cache);
+				if (saveCount === 2) {
+					backgroundRefreshSaved.resolve();
+				}
+			},
 		});
 
 		await runSessionStart(pi, notifications);
@@ -760,6 +782,13 @@ describe("mcp-wrapper extension", () => {
 				"[mcp-wrapper] MCP cache is missing for 1 server. Discovering MCP tools before startup continues: missing",
 			type: "info",
 		});
+		expect(discoveredServerMaps[1]).toEqual({ cached: cachedConfig });
+		expect(await resolvesWithin(backgroundRefreshSaved.promise, 25)).toBe(true);
+		const cache = await loadMcpWrapperCache();
+		expect(Object.keys(cache?.servers ?? {}).sort()).toEqual([
+			"cached",
+			"missing",
+		]);
 	});
 
 	test("uses fallback prompt snippet when MCP tool has no description", async () => {

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -178,21 +178,26 @@ async function handleSessionStart(
 			type?: "info" | "warning",
 		) => void,
 	);
-	await saveStartupCache(configResult.config.mcpServers, startup, options);
+	const startupCache = await saveStartupCache(
+		configResult.config.mcpServers,
+		startup,
+		options,
+	);
 	const cachedServers = pickServers(
 		configResult.config.mcpServers,
 		startup.cachedServerKeys,
 	);
 	if (Object.keys(cachedServers).length > 0) {
-		refreshCacheInBackground(
-			options.createManager(configResult.config),
-			cachedServers,
-			options.saveCache,
-			options.ctx.ui.notify.bind(options.ctx.ui) as (
+		refreshCacheInBackground({
+			manager: options.createManager(configResult.config),
+			servers: cachedServers,
+			startupCache,
+			saveCache: options.saveCache,
+			notify: options.ctx.ui.notify.bind(options.ctx.ui) as (
 				message: string,
 				type?: "info" | "warning",
 			) => void,
-		);
+		});
 	}
 
 	const catalog = buildPiToolCatalog(startup.serverToolLists);
@@ -380,15 +385,17 @@ async function saveStartupCache(
 	servers: Readonly<Record<string, McpServerConfig>>,
 	startup: StartupMetadata,
 	options: Pick<HandleSessionStartOptions, "ctx" | "saveCache">,
-): Promise<void> {
+): Promise<McpWrapperMetadataCache> {
+	const cache = buildCacheFromStartup(servers, startup);
 	try {
-		await options.saveCache(buildCacheFromStartup(servers, startup));
+		await options.saveCache(cache);
 	} catch (error) {
 		options.ctx.ui.notify(
 			`${ISSUE_PREFIX} failed to save MCP metadata cache: ${formatError(error)}`,
 			"warning",
 		);
 	}
+	return cache;
 }
 
 function reportStatuses(
@@ -433,31 +440,48 @@ function pickServers(
 	);
 }
 
-function refreshCacheInBackground(
-	manager: McpManagerLike,
-	servers: Readonly<Record<string, McpServerConfig>>,
-	saveCache: (cache: McpWrapperMetadataCache) => Promise<void>,
-	notify: (message: string, type?: "info" | "warning") => void,
-): void {
-	if (Object.keys(servers).length === 0) {
+function refreshCacheInBackground({
+	manager,
+	servers,
+	startupCache,
+	saveCache,
+	notify,
+}: {
+	readonly manager: McpManagerLike;
+	readonly servers: Readonly<Record<string, McpServerConfig>>;
+	readonly startupCache: McpWrapperMetadataCache;
+	readonly saveCache: (cache: McpWrapperMetadataCache) => Promise<void>;
+	readonly notify: (message: string, type?: "info" | "warning") => void;
+}): void {
+	const refreshedServerKeys = new Set(Object.keys(servers));
+	if (refreshedServerKeys.size === 0) {
 		return;
 	}
 
 	manager
 		.discoverServers(servers)
-		.then((discovery) =>
-			saveCache(
-				buildCacheFromStartup(servers, {
-					serverToolLists: discovery.serverToolLists,
-					serverInstructions: discovery.serverInstructions,
-					failures: discovery.failures,
-					cachedServerKeys: [],
-					discoveredServerKeys: discovery.serverToolLists.map(
-						(serverToolList) => serverToolList.serverKey,
+		.then((discovery) => {
+			const refreshedCache = buildCacheFromStartup(servers, {
+				serverToolLists: discovery.serverToolLists,
+				serverInstructions: discovery.serverInstructions,
+				failures: discovery.failures,
+				cachedServerKeys: [],
+				discoveredServerKeys: discovery.serverToolLists.map(
+					(serverToolList) => serverToolList.serverKey,
+				),
+			});
+			return saveCache({
+				version: startupCache.version,
+				servers: {
+					...Object.fromEntries(
+						Object.entries(startupCache.servers).filter(
+							([serverKey]) => !refreshedServerKeys.has(serverKey),
+						),
 					),
-				}),
-			),
-		)
+					...refreshedCache.servers,
+				},
+			});
+		})
 		.catch((error: unknown) => {
 			notify(
 				`${ISSUE_PREFIX} failed to refresh MCP metadata cache: ${formatError(error)}`,


### PR DESCRIPTION
Combine the startup cache with the background refresh cache to ensure all servers are preserved during the caching process. This change enhances the efficiency of server discovery and cache management.