### PR TITLE
Add project-rules extension for system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Recommended MCP servers:
 | Extension | Default behavior | What it does | Quick settings | Details |
 | --- | --- | --- | --- | --- |
 | `system-prompt` | Enabled | Replaces pi's base system prompt with a Markdown template and runtime variables. | `system-prompt/config.json`: `enabled`, `templateFile`. | [docs/extensions/system-prompt.md](docs/extensions/system-prompt.md) |
+| `project-rules` | Enabled | Appends recursive project Markdown rules from `.pi` to the final system prompt. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
 | `mcp-wrapper` | No MCP tools until configured | Registers tools from configured MCP servers and caches tool metadata. | `mcp-wrapper/config.json`: `settings.enabled`, `settings.timeouts`, `mcpServers`. | [docs/extensions/mcp-wrapper.md](docs/extensions/mcp-wrapper.md) |
 | `enable-tools` | Enabled | Enables configured built-in tools such as `grep`, `find`, and `ls`. | `enable-tools/config.json`: `enabled`, `include`, `exclude`. | [docs/extensions/enable-tools.md](docs/extensions/enable-tools.md) |
 | `footer` | Enabled | Shows project, quota, cost, selected agent, model, projection, MCP errors, and context usage. | `footer/config.json`: `enabled`, `showProvider`, `showModel`, `showThinkingLevel`, `showApiCost`. | [docs/extensions/footer.md](docs/extensions/footer.md) |

--- a/docs/extensions/project-rules.md
+++ b/docs/extensions/project-rules.md
@@ -1,0 +1,81 @@
+# project-rules
+
+## Purpose
+
+`project-rules` appends Markdown rule files from a project-local directory to the final system prompt.
+
+## Behavior
+
+- Handles `before_agent_start`.
+- Reads configuration from `~/.pi/agent/agent-suite/project-rules/config.json`.
+- Is enabled by default when `config.json` is missing.
+- Uses `.pi` as the default rules directory.
+- Resolves `rulesDir` relative to pi's current working directory.
+- Requires `rulesDir` to be a relative path.
+- Rejects `rulesDir` values that contain parent directory traversal.
+- Reads `*.md` files recursively under `rulesDir`.
+- Matches `*.md` against the visible path under `rulesDir`.
+- Follows symlinked `rulesDir` directories.
+- Follows symlinked files and directories inside `rulesDir`.
+- Allows symlink targets outside the current working directory.
+- Skips repeated real directory paths during recursion to avoid symlink cycles.
+- Sorts rules by visible path before rendering.
+- Skips empty files and files that contain only whitespace.
+- Does not append `<project_rules>` when no non-empty Markdown rules are found.
+- Leaves the system prompt unchanged when config validation or rule loading fails.
+- Warns when config validation or rule loading fails.
+- Runs after `system-prompt`, so `system-prompt` template replacement does not overwrite project rules.
+- Runs before `mcp-wrapper`, so MCP instructions are appended after project rules.
+
+Symlink targets can point to any readable local file or directory. A matching symlink can therefore add content from outside the current working directory to the prompt.
+
+## Configuration
+
+File: `~/.pi/agent/agent-suite/project-rules/config.json`.
+
+```json
+{
+  "enabled": true,
+  "rulesDir": ".pi"
+}
+```
+
+Fields:
+
+- `enabled`: optional. Default `true`. Set to `false` to skip project rule loading.
+- `rulesDir`: optional relative path to the rules directory. Default `.pi`.
+
+## Prompt format
+
+Example output:
+
+```xml
+<project_rules>
+  <project_rule path=".pi/rules.md">
+Project rule text.
+  </project_rule>
+  <project_rule path=".pi/nested/extra.md">
+Nested project rule text.
+  </project_rule>
+</project_rules>
+```
+
+The `path` attribute uses the visible path under `rulesDir`. Rule file content is inserted unchanged.
+
+## Verification
+
+Tests must verify:
+
+- default config values when config is missing;
+- rejection of unsupported config keys;
+- rejection of invalid `enabled` and `rulesDir` values;
+- rejection of absolute `rulesDir` and parent directory traversal;
+- recursive Markdown discovery;
+- deterministic path ordering;
+- skipping empty and whitespace-only files;
+- symlinked rules directory support;
+- symlinked file and directory support;
+- directory cycle protection;
+- no prompt change when disabled, missing, or empty;
+- fail-closed behavior and warning on invalid config or rule loading failure;
+- package composition order with `system-prompt` and `mcp-wrapper`.

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -64,6 +64,7 @@ Recommended MCP servers:
 | Extension | Default behavior | What it does | Quick settings | Details |
 | --- | --- | --- | --- | --- |
 | `system-prompt` | Enabled | Replaces pi's base system prompt with a Markdown template and runtime variables. | `system-prompt/config.json`: `enabled`, `templateFile`. | [docs/extensions/system-prompt.md](docs/extensions/system-prompt.md) |
+| `project-rules` | Enabled | Appends recursive project Markdown rules from `.pi` to the final system prompt. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
 | `mcp-wrapper` | No MCP tools until configured | Registers tools from configured MCP servers and caches tool metadata. | `mcp-wrapper/config.json`: `settings.enabled`, `settings.timeouts`, `mcpServers`. | [docs/extensions/mcp-wrapper.md](docs/extensions/mcp-wrapper.md) |
 | `enable-tools` | Enabled | Enables configured built-in tools such as `grep`, `find`, and `ls`. | `enable-tools/config.json`: `enabled`, `include`, `exclude`. | [docs/extensions/enable-tools.md](docs/extensions/enable-tools.md) |
 | `footer` | Enabled | Shows project, quota, cost, selected agent, model, projection, MCP errors, and context usage. | `footer/config.json`: `enabled`, `showProvider`, `showModel`, `showThinkingLevel`, `showApiCost`. | [docs/extensions/footer.md](docs/extensions/footer.md) |

--- a/pi-package/extensions/project-rules/config.test.ts
+++ b/pi-package/extensions/project-rules/config.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage";
+import { parseProjectRulesConfig, readProjectRulesConfig } from "./config";
+
+const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	if (previousAgentSuiteDir === undefined) {
+		delete process.env[AGENT_SUITE_DIR_ENV];
+	} else {
+		process.env[AGENT_SUITE_DIR_ENV] = previousAgentSuiteDir;
+	}
+
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("project-rules config", () => {
+	test("uses enabled true and .pi rules directory when config is missing", async () => {
+		// Purpose: project rules must work without setup by reading the default repository rules directory.
+		// Input and expected output: no config file returns enabled true and rulesDir .pi.
+		// Edge case: the suite config directory is absent.
+		// Dependencies: this test uses only temporary suite storage.
+		await withIsolatedSuiteDir(async () => {
+			const result = readProjectRulesConfig();
+
+			expect(result).toEqual({
+				kind: "valid",
+				config: { enabled: true, rulesDir: ".pi" },
+			});
+		});
+	});
+
+	test("accepts supported keys and applies defaults", () => {
+		// Purpose: users need stable config keys for enabling and selecting the rules directory.
+		// Input and expected output: supported keys are preserved, omitted keys use defaults.
+		// Edge case: enabled false is preserved and does not default back to true.
+		// Dependencies: this test exercises the pure parser only.
+		expect(parseProjectRulesConfig({})).toEqual({
+			kind: "valid",
+			config: { enabled: true, rulesDir: ".pi" },
+		});
+		expect(parseProjectRulesConfig({ enabled: false })).toEqual({
+			kind: "valid",
+			config: { enabled: false, rulesDir: ".pi" },
+		});
+		expect(parseProjectRulesConfig({ rulesDir: "rules" })).toEqual({
+			kind: "valid",
+			config: { enabled: true, rulesDir: "rules" },
+		});
+	});
+
+	test("rejects unsupported keys and invalid field values", () => {
+		// Purpose: config validation must fail closed for unsupported public contract changes.
+		// Input and expected output: unsupported keys, non-boolean enabled, and non-string rulesDir are invalid.
+		// Edge case: non-object values are invalid before field parsing.
+		// Dependencies: this test exercises the pure parser only.
+		expect(parseProjectRulesConfig({ recursive: true }).kind).toBe("invalid");
+		expect(parseProjectRulesConfig({ enabled: "true" }).kind).toBe("invalid");
+		expect(parseProjectRulesConfig({ rulesDir: [".pi"] }).kind).toBe("invalid");
+		expect(parseProjectRulesConfig(null).kind).toBe("invalid");
+	});
+
+	test("rejects absolute rulesDir and path traversal", () => {
+		// Purpose: rulesDir must stay a cwd-relative entry point even when symlink targets may point anywhere.
+		// Input and expected output: absolute and parent-traversing paths are invalid.
+		// Edge case: nested relative directories are accepted.
+		// Dependencies: this test exercises the pure parser only.
+		expect(parseProjectRulesConfig({ rulesDir: "/tmp/rules" }).kind).toBe(
+			"invalid",
+		);
+		expect(parseProjectRulesConfig({ rulesDir: "../rules" }).kind).toBe(
+			"invalid",
+		);
+		expect(parseProjectRulesConfig({ rulesDir: "rules/../other" }).kind).toBe(
+			"invalid",
+		);
+		expect(parseProjectRulesConfig({ rulesDir: "nested/rules" }).kind).toBe(
+			"valid",
+		);
+	});
+
+	test("reports malformed JSON as invalid", async () => {
+		// Purpose: a broken config file must not append partially configured project rules.
+		// Input and expected output: malformed JSON returns an invalid result.
+		// Edge case: the file exists but cannot be parsed.
+		// Dependencies: this test uses only temporary suite storage.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			await writeProjectRulesConfigText(suiteDir, "{");
+
+			const result = readProjectRulesConfig();
+
+			expect(result.kind).toBe("invalid");
+		});
+	});
+});
+
+async function withIsolatedSuiteDir(
+	testBody: (suiteDir: string) => Promise<void>,
+): Promise<void> {
+	const suiteDir = await mkdtemp(join(tmpdir(), "project-rules-config-"));
+	tempDirs.push(suiteDir);
+	process.env[AGENT_SUITE_DIR_ENV] = suiteDir;
+	await testBody(suiteDir);
+}
+
+async function writeProjectRulesConfigText(
+	suiteDir: string,
+	content: string,
+): Promise<void> {
+	const configDir = join(suiteDir, "project-rules");
+	await mkdir(configDir, { recursive: true });
+	await writeFile(join(configDir, "config.json"), content);
+}

--- a/pi-package/extensions/project-rules/config.ts
+++ b/pi-package/extensions/project-rules/config.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from "node:fs";
+import { isAbsolute, normalize, sep } from "node:path";
+import {
+	getSuiteConfigLocation,
+	isFileNotFoundError,
+} from "../../shared/agent-suite-storage";
+
+export const PROJECT_RULES_EXTENSION_DIR = "project-rules";
+
+const ENABLED_CONFIG_KEY = "enabled";
+const RULES_DIR_CONFIG_KEY = "rulesDir";
+const CONFIG_KEYS = [ENABLED_CONFIG_KEY, RULES_DIR_CONFIG_KEY] as const;
+const DEFAULT_RULES_DIR = ".pi";
+const PATH_PART_SEPARATOR = /[\\/]+/;
+
+interface ProjectRulesRawConfig {
+	readonly enabled?: boolean;
+	readonly rulesDir?: string;
+}
+
+export interface ProjectRulesConfig {
+	readonly enabled: boolean;
+	readonly rulesDir: string;
+}
+
+export type ProjectRulesConfigResult =
+	| { readonly kind: "valid"; readonly config: ProjectRulesConfig }
+	| { readonly kind: "invalid"; readonly issue: string };
+
+type UnknownRecord = Record<string, unknown>;
+
+/** Reads suite-owned config and applies project-rules defaults when config is absent. */
+export function readProjectRulesConfig(): ProjectRulesConfigResult {
+	const configLocation = getSuiteConfigLocation(PROJECT_RULES_EXTENSION_DIR);
+	let content: string;
+	try {
+		content = readFileSync(configLocation.path, "utf8");
+	} catch (error) {
+		if (isFileNotFoundError(error)) {
+			return parseProjectRulesConfig({});
+		}
+
+		return invalidConfig(`failed to read config: ${formatError(error)}`);
+	}
+
+	try {
+		return parseProjectRulesConfig(JSON.parse(content));
+	} catch (error) {
+		return invalidConfig(`failed to parse config: ${formatError(error)}`);
+	}
+}
+
+/** Parses unknown JSON before file loading uses user-controlled paths. */
+export function parseProjectRulesConfig(
+	config: unknown,
+): ProjectRulesConfigResult {
+	if (!isRecord(config)) {
+		return invalidConfig("config must be an object");
+	}
+
+	const unsupportedKey = Object.keys(config).find(
+		(key) => !CONFIG_KEYS.includes(key as (typeof CONFIG_KEYS)[number]),
+	);
+	if (unsupportedKey !== undefined) {
+		return invalidConfig("config contains unsupported keys");
+	}
+
+	const rawConfig = parseProjectRulesFields(config);
+	if (rawConfig.kind === "invalid") {
+		return rawConfig;
+	}
+
+	return {
+		kind: "valid",
+		config: buildProjectRulesConfig(rawConfig.config),
+	};
+}
+
+/** Parses supported fields after object shape and key ownership are known. */
+function parseProjectRulesFields(
+	config: UnknownRecord,
+):
+	| { readonly kind: "valid"; readonly config: ProjectRulesRawConfig }
+	| { readonly kind: "invalid"; readonly issue: string } {
+	const enabled = config[ENABLED_CONFIG_KEY];
+	if (enabled !== undefined && typeof enabled !== "boolean") {
+		return invalidConfig("enabled must be a boolean");
+	}
+
+	const rulesDir = config[RULES_DIR_CONFIG_KEY];
+	if (rulesDir !== undefined && typeof rulesDir !== "string") {
+		return invalidConfig("rulesDir must be a string");
+	}
+	if (rulesDir !== undefined) {
+		const validationIssue = validateRulesDir(rulesDir);
+		if (validationIssue !== undefined) {
+			return invalidConfig(validationIssue);
+		}
+	}
+
+	return {
+		kind: "valid",
+		config: {
+			...(enabled === undefined ? {} : { enabled }),
+			...(rulesDir === undefined ? {} : { rulesDir }),
+		},
+	};
+}
+
+/** Keeps the configured entry point relative to cwd before symlinks are followed. */
+function validateRulesDir(rulesDir: string): string | undefined {
+	if (rulesDir.trim().length === 0) {
+		return "rulesDir must not be empty";
+	}
+	if (isAbsolute(rulesDir)) {
+		return "rulesDir must be a relative path";
+	}
+
+	const rawParts = rulesDir.split(PATH_PART_SEPARATOR);
+	if (rawParts.includes("..")) {
+		return "rulesDir must not contain parent directory traversal";
+	}
+
+	const normalizedParts = normalize(rulesDir).split(sep);
+	if (normalizedParts.includes("..")) {
+		return "rulesDir must not contain parent directory traversal";
+	}
+
+	return undefined;
+}
+
+/** Builds effective config by applying extension defaults to omitted fields. */
+function buildProjectRulesConfig(
+	config: ProjectRulesRawConfig,
+): ProjectRulesConfig {
+	return {
+		enabled: config.enabled ?? true,
+		rulesDir: config.rulesDir ?? DEFAULT_RULES_DIR,
+	};
+}
+
+/** Builds fail-closed config results with messages safe for UI warnings. */
+function invalidConfig(
+	issue: string,
+): ProjectRulesConfigResult & { readonly kind: "invalid" } {
+	return { kind: "invalid", issue };
+}
+
+/** Returns true when dynamic property reads are safe. */
+function isRecord(value: unknown): value is UnknownRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Converts unknown failures into short diagnostics without exposing file contents. */
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/pi-package/extensions/project-rules/index.test.ts
+++ b/pi-package/extensions/project-rules/index.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	BuildSystemPromptOptions,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage";
+import projectRules from "./index";
+
+const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
+const tempDirs: string[] = [];
+
+interface RegisteredHandler {
+	readonly eventName: string;
+	readonly handler: unknown;
+}
+
+interface Notification {
+	readonly message: string;
+	readonly type: string | undefined;
+}
+
+interface ExtensionApiFake extends ExtensionAPI {
+	readonly handlers: RegisteredHandler[];
+}
+
+interface ContextFake {
+	readonly notifications: Notification[];
+	readonly ctx: {
+		readonly cwd: string;
+		readonly hasUI?: boolean;
+		readonly ui: {
+			notify(message: string, type: string | undefined): void;
+		};
+	};
+}
+
+interface BeforeAgentStartEventFake {
+	readonly type: "before_agent_start";
+	readonly prompt: string;
+	readonly images: readonly unknown[];
+	readonly systemPrompt: string;
+	readonly systemPromptOptions: BuildSystemPromptOptions;
+}
+
+afterEach(async () => {
+	if (previousAgentSuiteDir === undefined) {
+		delete process.env[AGENT_SUITE_DIR_ENV];
+	} else {
+		process.env[AGENT_SUITE_DIR_ENV] = previousAgentSuiteDir;
+	}
+
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("project-rules", () => {
+	test("appends recursive non-empty Markdown rules in deterministic visible-path order", async () => {
+		// Purpose: project rule files must become a separate prompt section after the existing system prompt.
+		// Input and expected output: direct and nested Markdown files are sorted by their visible path and appended.
+		// Edge case: empty, whitespace-only, and non-Markdown files do not create project_rule blocks.
+		// Dependencies: this test uses temporary project files and in-memory lifecycle fakes.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-project-");
+			const rulesDir = join(projectDir, ".pi");
+			await mkdir(join(rulesDir, "nested"), { recursive: true });
+			await writeFile(join(rulesDir, "z.md"), "Z rule");
+			await writeFile(join(rulesDir, "nested", "a.md"), "A rule");
+			await writeFile(join(rulesDir, "empty.md"), "");
+			await writeFile(join(rulesDir, "space.md"), "  \n\t");
+			await writeFile(join(rulesDir, "note.txt"), "Ignored");
+			const pi = createExtensionApiFake();
+			const context = createContextFake(projectDir);
+
+			projectRules(pi);
+
+			const prompt = await runBeforeAgentStartHandlers(
+				pi,
+				createBeforeAgentStartEvent(projectDir),
+				context.ctx,
+			);
+
+			expect(prompt).toBe(
+				[
+					"Original pi prompt",
+					"",
+					"<project_rules>",
+					'  <project_rule path=".pi/nested/a.md">',
+					"A rule",
+					"  </project_rule>",
+					'  <project_rule path=".pi/z.md">',
+					"Z rule",
+					"  </project_rule>",
+					"</project_rules>",
+				].join("\n"),
+			);
+		});
+	});
+
+	test("follows symlinked rules directory, files, and subdirectories while avoiding directory cycles", async () => {
+		// Purpose: approved symlink behavior must allow shared rule files outside the cwd.
+		// Input and expected output: rulesDir symlink, file symlink, and directory symlink are followed once.
+		// Edge case: a symlink cycle must not repeat files or loop forever.
+		// Dependencies: this test uses filesystem symlinks in temporary directories.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-project-");
+			const realRulesDir = await createTempDir("project-rules-real-");
+			const externalDir = await createTempDir("project-rules-external-");
+			await writeFile(join(realRulesDir, "root.md"), "Root rule");
+			await writeFile(
+				join(externalDir, "shared-source.txt"),
+				"Linked file rule",
+			);
+			await mkdir(join(externalDir, "shared-dir"));
+			await writeFile(
+				join(externalDir, "shared-dir", "nested.md"),
+				"Linked dir rule",
+			);
+			await symlink(realRulesDir, join(projectDir, ".pi"), "dir");
+			await symlink(
+				join(externalDir, "shared-source.txt"),
+				join(realRulesDir, "shared.md"),
+			);
+			await symlink(
+				join(externalDir, "shared-dir"),
+				join(realRulesDir, "shared-dir"),
+				"dir",
+			);
+			await symlink(realRulesDir, join(realRulesDir, "cycle"), "dir");
+			const pi = createExtensionApiFake();
+			const context = createContextFake(projectDir);
+
+			projectRules(pi);
+
+			const prompt = await runBeforeAgentStartHandlers(
+				pi,
+				createBeforeAgentStartEvent(projectDir),
+				context.ctx,
+			);
+
+			expect(prompt).toContain('path=".pi/root.md"');
+			expect(prompt).toContain("Root rule");
+			expect(prompt).toContain('path=".pi/shared-dir/nested.md"');
+			expect(prompt).toContain("Linked dir rule");
+			expect(prompt).toContain('path=".pi/shared.md"');
+			expect(prompt).toContain("Linked file rule");
+			expect(prompt.match(/Root rule/g)).toHaveLength(1);
+		});
+	});
+
+	test("uses the first visible symlinked directory path when targets repeat", async () => {
+		// Purpose: duplicate symlinked directories must produce deterministic visible paths.
+		// Input and expected output: two sorted links to one real directory include only the first visible path.
+		// Edge case: directory cycle protection must not let filesystem timing choose the visible path.
+		// Dependencies: this test uses filesystem symlinks in temporary directories.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-repeat-project-");
+			const sharedDir = await createTempDir("project-rules-repeat-shared-");
+			await mkdir(join(projectDir, ".pi"));
+			await writeFile(join(sharedDir, "rule.md"), "Shared rule");
+			await symlink(sharedDir, join(projectDir, ".pi", "a"), "dir");
+			await symlink(sharedDir, join(projectDir, ".pi", "b"), "dir");
+
+			const prompt = await renderPrompt(projectDir);
+
+			expect(prompt).toContain('path=".pi/a/rule.md"');
+			expect(prompt).not.toContain('path=".pi/b/rule.md"');
+			expect(prompt.match(/Shared rule/g)).toHaveLength(1);
+		});
+	});
+
+	test("does not append project_rules when disabled, missing, empty, or only empty files", async () => {
+		// Purpose: the extension must avoid empty prompt wrappers when no rule content is available.
+		// Input and expected output: disabled config, missing rulesDir, and whitespace-only rules keep the original prompt.
+		// Edge case: an existing rulesDir with no non-empty Markdown files behaves like no rules.
+		// Dependencies: this test uses temporary suite and project directories.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			const disabledProjectDir = await createTempDir("project-rules-disabled-");
+			await writeProjectRulesConfig(suiteDir, { enabled: false });
+			expect(await renderPrompt(disabledProjectDir)).toBe("Original pi prompt");
+
+			const missingProjectDir = await createTempDir("project-rules-missing-");
+			await writeProjectRulesConfig(suiteDir, { enabled: true });
+			expect(await renderPrompt(missingProjectDir)).toBe("Original pi prompt");
+
+			const emptyProjectDir = await createTempDir("project-rules-empty-");
+			await mkdir(join(emptyProjectDir, ".pi"));
+			await writeFile(join(emptyProjectDir, ".pi", "empty.md"), "\n\t ");
+			expect(await renderPrompt(emptyProjectDir)).toBe("Original pi prompt");
+		});
+	});
+
+	test("fails the whole section and warns when rulesDir itself is a broken symlink", async () => {
+		// Purpose: a broken rulesDir symlink must not silently disable project rules.
+		// Input and expected output: .pi points to a missing directory, so the prompt is unchanged and one warning is emitted.
+		// Edge case: a genuinely missing .pi directory remains a no-op in a separate test.
+		// Dependencies: this test uses a filesystem symlink in a temporary project directory.
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-broken-root-");
+			await symlink(join(projectDir, "missing-rules"), join(projectDir, ".pi"));
+			const context = createContextFake(projectDir);
+
+			expect(await renderPrompt(projectDir, context)).toBe(
+				"Original pi prompt",
+			);
+			expect(context.notifications).toHaveLength(1);
+		});
+	});
+
+	test("fails the whole section and warns when config or rule loading fails", async () => {
+		// Purpose: partial project rules must not be appended when config or file loading is unreliable.
+		// Input and expected output: invalid config and broken symlink keep the original prompt and warn.
+		// Edge case: one broken rule prevents all project_rules output.
+		// Dependencies: this test uses temporary suite storage, symlinks, and in-memory notifications.
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			const invalidConfigProjectDir = await createTempDir(
+				"project-rules-invalid-config-",
+			);
+			await writeProjectRulesConfig(suiteDir, { enabled: "true" });
+			const invalidConfigContext = createContextFake(invalidConfigProjectDir);
+			expect(
+				await renderPrompt(invalidConfigProjectDir, invalidConfigContext),
+			).toBe("Original pi prompt");
+			expect(invalidConfigContext.notifications).toHaveLength(1);
+
+			await writeProjectRulesConfig(suiteDir, { enabled: true });
+			const brokenSymlinkProjectDir = await createTempDir(
+				"project-rules-broken-symlink-",
+			);
+			await mkdir(join(brokenSymlinkProjectDir, ".pi"));
+			await writeFile(
+				join(brokenSymlinkProjectDir, ".pi", "valid.md"),
+				"Valid",
+			);
+			await symlink(
+				join(brokenSymlinkProjectDir, "missing.md"),
+				join(brokenSymlinkProjectDir, ".pi", "broken.md"),
+			);
+			const brokenSymlinkContext = createContextFake(brokenSymlinkProjectDir);
+			expect(
+				await renderPrompt(brokenSymlinkProjectDir, brokenSymlinkContext),
+			).toBe("Original pi prompt");
+			expect(brokenSymlinkContext.notifications).toHaveLength(1);
+		});
+	});
+});
+
+function createExtensionApiFake(): ExtensionApiFake {
+	const handlers: RegisteredHandler[] = [];
+
+	return {
+		handlers,
+		on(eventName: string, handler: unknown): void {
+			handlers.push({ eventName, handler });
+		},
+	} as ExtensionApiFake;
+}
+
+function createContextFake(cwd: string, hasUI?: boolean): ContextFake {
+	const notifications: Notification[] = [];
+
+	return {
+		notifications,
+		ctx: {
+			cwd,
+			...(hasUI !== undefined ? { hasUI } : {}),
+			ui: {
+				notify(message: string, type: string | undefined): void {
+					notifications.push({ message, type });
+				},
+			},
+		},
+	};
+}
+
+async function runBeforeAgentStartHandlers(
+	pi: ExtensionApiFake,
+	event: BeforeAgentStartEventFake,
+	ctx: ContextFake["ctx"],
+): Promise<string> {
+	let currentEvent = event;
+	for (const item of pi.handlers.filter(
+		(handler) => handler.eventName === "before_agent_start",
+	)) {
+		if (typeof item.handler !== "function") {
+			continue;
+		}
+
+		const result = await item.handler(currentEvent, ctx);
+		if (isPromptResult(result)) {
+			currentEvent = { ...currentEvent, systemPrompt: result.systemPrompt };
+		}
+	}
+
+	return currentEvent.systemPrompt;
+}
+
+function isPromptResult(
+	value: unknown,
+): value is { readonly systemPrompt: string } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"systemPrompt" in value &&
+		typeof value.systemPrompt === "string"
+	);
+}
+
+function createBeforeAgentStartEvent(cwd: string): BeforeAgentStartEventFake {
+	return {
+		type: "before_agent_start",
+		prompt: "work",
+		images: [],
+		systemPrompt: "Original pi prompt",
+		systemPromptOptions: { cwd },
+	};
+}
+
+async function renderPrompt(
+	projectDir: string,
+	context = createContextFake(projectDir),
+): Promise<string> {
+	const pi = createExtensionApiFake();
+	projectRules(pi);
+	return runBeforeAgentStartHandlers(
+		pi,
+		createBeforeAgentStartEvent(projectDir),
+		context.ctx,
+	);
+}
+
+async function withIsolatedSuiteDir(
+	testBody: (suiteDir: string) => Promise<void>,
+): Promise<void> {
+	const suiteDir = await createTempDir("project-rules-suite-");
+	process.env[AGENT_SUITE_DIR_ENV] = suiteDir;
+	await testBody(suiteDir);
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function writeProjectRulesConfig(
+	suiteDir: string,
+	config: unknown,
+): Promise<void> {
+	const configDir = join(suiteDir, "project-rules");
+	await mkdir(configDir, { recursive: true });
+	await writeFile(join(configDir, "config.json"), JSON.stringify(config));
+}

--- a/pi-package/extensions/project-rules/index.ts
+++ b/pi-package/extensions/project-rules/index.ts
@@ -1,0 +1,311 @@
+import type { Dirent } from "node:fs";
+import { lstat, readdir, readFile, realpath, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+	BuildSystemPromptOptions,
+	ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { readProjectRulesConfig } from "./config";
+
+const ISSUE_PREFIX = "[project-rules]";
+const MARKDOWN_EXTENSION = ".md";
+
+interface SessionContextLike {
+	readonly hasUI?: boolean;
+	readonly ui?: {
+		notify(message: string, type: "warning"): void;
+	};
+}
+
+interface BeforeAgentStartEventLike {
+	readonly systemPrompt: string;
+	readonly systemPromptOptions: BuildSystemPromptOptions;
+}
+
+interface ProjectRule {
+	readonly path: string;
+	readonly content: string;
+}
+
+type ProjectRulesReadResult =
+	| { readonly kind: "valid"; readonly rules: readonly ProjectRule[] }
+	| { readonly kind: "invalid"; readonly issue: string };
+
+/** Appends project-local Markdown rules after the base system prompt is assembled. */
+export default function projectRules(pi: ExtensionAPI): void {
+	pi.on("before_agent_start", async (event, ctx) => {
+		const configResult = readProjectRulesConfig();
+		if (configResult.kind === "invalid") {
+			reportIssue(ctx as SessionContextLike, configResult.issue);
+			return undefined;
+		}
+		if (!configResult.config.enabled) {
+			return undefined;
+		}
+
+		const typedEvent = event as BeforeAgentStartEventLike;
+		const rulesResult = await readProjectRules(
+			typedEvent.systemPromptOptions.cwd,
+			configResult.config.rulesDir,
+		);
+		if (rulesResult.kind === "invalid") {
+			reportIssue(ctx as SessionContextLike, rulesResult.issue);
+			return undefined;
+		}
+		if (rulesResult.rules.length === 0) {
+			return undefined;
+		}
+
+		return {
+			systemPrompt: `${typedEvent.systemPrompt}\n\n${renderProjectRules(rulesResult.rules)}`,
+		};
+	});
+}
+
+/** Reads all visible *.md files under rulesDir while following approved symlink targets. */
+async function readProjectRules(
+	cwd: string,
+	rulesDir: string,
+): Promise<ProjectRulesReadResult> {
+	const rootDir = join(cwd, rulesDir);
+	const visitedRealDirs = new Set<string>();
+	const rules: ProjectRule[] = [];
+
+	const rootStatus = await resolveDirectoryStatus(rootDir);
+	if (rootStatus.kind === "missing") {
+		return { kind: "valid", rules: [] };
+	}
+	if (rootStatus.kind === "invalid") {
+		return rootStatus;
+	}
+
+	const walkResult = await walkRulesDirectory({
+		actualDir: rootDir,
+		visibleDir: toPromptPath(rulesDir),
+		visitedRealDirs,
+		rules,
+	});
+	if (walkResult.kind === "invalid") {
+		return walkResult;
+	}
+
+	return {
+		kind: "valid",
+		rules: rules.sort((left, right) => left.path.localeCompare(right.path)),
+	};
+}
+
+/** Distinguishes absent default rules from unreadable or non-directory entry points. */
+async function resolveDirectoryStatus(
+	directory: string,
+): Promise<
+	| { readonly kind: "valid" }
+	| { readonly kind: "missing" }
+	| { readonly kind: "invalid"; readonly issue: string }
+> {
+	try {
+		const directoryStat = await stat(directory);
+		if (!directoryStat.isDirectory()) {
+			return {
+				kind: "invalid",
+				issue: "rulesDir must point to a directory",
+			};
+		}
+		return { kind: "valid" };
+	} catch (error) {
+		if (!isFileNotFoundError(error)) {
+			return {
+				kind: "invalid",
+				issue: `failed to inspect rulesDir: ${formatError(error)}`,
+			};
+		}
+
+		return inspectMissingDirectoryPath(directory);
+	}
+}
+
+/** Separates an absent rulesDir from a broken symlink at the rulesDir path. */
+async function inspectMissingDirectoryPath(
+	directory: string,
+): Promise<
+	| { readonly kind: "missing" }
+	| { readonly kind: "invalid"; readonly issue: string }
+> {
+	try {
+		const linkStat = await lstat(directory);
+		return {
+			kind: "invalid",
+			issue: linkStat.isSymbolicLink()
+				? "rulesDir symlink target does not exist"
+				: "rulesDir could not be inspected",
+		};
+	} catch (error) {
+		if (isFileNotFoundError(error)) {
+			return { kind: "missing" };
+		}
+
+		return {
+			kind: "invalid",
+			issue: `failed to inspect rulesDir: ${formatError(error)}`,
+		};
+	}
+}
+
+/** Recursively walks directories and records non-empty Markdown files by visible path. */
+async function walkRulesDirectory(options: {
+	readonly actualDir: string;
+	readonly visibleDir: string;
+	readonly visitedRealDirs: Set<string>;
+	readonly rules: ProjectRule[];
+}): Promise<
+	| { readonly kind: "valid" }
+	| { readonly kind: "invalid"; readonly issue: string }
+> {
+	let realDir: string;
+	try {
+		realDir = await realpath(options.actualDir);
+	} catch (error) {
+		return {
+			kind: "invalid",
+			issue: `failed to resolve directory: ${formatError(error)}`,
+		};
+	}
+	if (options.visitedRealDirs.has(realDir)) {
+		return { kind: "valid" };
+	}
+	options.visitedRealDirs.add(realDir);
+
+	let entries: Dirent<string>[];
+	try {
+		entries = await readdir(options.actualDir, { withFileTypes: true });
+	} catch (error) {
+		return {
+			kind: "invalid",
+			issue: `failed to read directory: ${formatError(error)}`,
+		};
+	}
+
+	return entries
+		.sort((left, right) => left.name.localeCompare(right.name))
+		.reduce<
+			Promise<
+				| { readonly kind: "valid" }
+				| { readonly kind: "invalid"; readonly issue: string }
+			>
+		>(
+			async (previousResult, entry) => {
+				const result = await previousResult;
+				if (result.kind === "invalid") {
+					return result;
+				}
+
+				const actualPath = join(options.actualDir, entry.name);
+				const visiblePath = `${options.visibleDir}/${entry.name}`;
+				return processDirectoryEntry(actualPath, visiblePath, options);
+			},
+			Promise.resolve({ kind: "valid" }),
+		);
+}
+
+/** Applies Markdown filtering to visible paths while symlink targets decide file type. */
+async function processDirectoryEntry(
+	actualPath: string,
+	visiblePath: string,
+	options: {
+		readonly visitedRealDirs: Set<string>;
+		readonly rules: ProjectRule[];
+	},
+): Promise<
+	| { readonly kind: "valid" }
+	| { readonly kind: "invalid"; readonly issue: string }
+> {
+	let entryStat: Awaited<ReturnType<typeof stat>>;
+	try {
+		entryStat = await stat(actualPath);
+	} catch (error) {
+		return {
+			kind: "invalid",
+			issue: `failed to inspect rule entry: ${formatError(error)}`,
+		};
+	}
+
+	if (entryStat.isDirectory()) {
+		return walkRulesDirectory({
+			actualDir: actualPath,
+			visibleDir: visiblePath,
+			visitedRealDirs: options.visitedRealDirs,
+			rules: options.rules,
+		});
+	}
+
+	if (!entryStat.isFile() || !visiblePath.endsWith(MARKDOWN_EXTENSION)) {
+		return { kind: "valid" };
+	}
+
+	let content: string;
+	try {
+		content = await readFile(actualPath, "utf8");
+	} catch (error) {
+		return {
+			kind: "invalid",
+			issue: `failed to read rule file: ${formatError(error)}`,
+		};
+	}
+	if (content.trim().length === 0) {
+		return { kind: "valid" };
+	}
+
+	options.rules.push({ path: visiblePath, content });
+	return { kind: "valid" };
+}
+
+/** Renders a stable XML-like block without changing rule file contents. */
+function renderProjectRules(rules: readonly ProjectRule[]): string {
+	return [
+		"<project_rules>",
+		...rules.flatMap((rule) => [
+			`  <project_rule path="${escapeAttribute(rule.path)}">`,
+			rule.content,
+			"  </project_rule>",
+		]),
+		"</project_rules>",
+	].join("\n");
+}
+
+/** Normalizes visible paths to prompt-friendly slash separators. */
+function toPromptPath(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
+/** Escapes only XML attribute delimiters so rule text remains unchanged. */
+function escapeAttribute(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/"/g, "&quot;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;");
+}
+
+/** Reports one warning when project rules cannot be loaded safely. */
+function reportIssue(ctx: SessionContextLike, issue: string): void {
+	if (ctx.hasUI === false) {
+		return;
+	}
+
+	ctx.ui?.notify(`${ISSUE_PREFIX} ${issue}`, "warning");
+}
+
+/** Detects file-not-found errors without depending on platform-specific messages. */
+function isFileNotFoundError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		(error as { readonly code?: unknown }).code === "ENOENT"
+	);
+}
+
+/** Converts unknown failures into short diagnostics without exposing file contents. */
+function formatError(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/pi-package/package.json
+++ b/pi-package/package.json
@@ -26,6 +26,7 @@
 	"pi": {
 		"extensions": [
 			"./extensions/system-prompt/index.ts",
+			"./extensions/project-rules/index.ts",
 			"./extensions/mcp-wrapper/index.ts",
 			"./extensions/enable-tools/index.ts",
 			"./extensions/footer/index.ts",

--- a/test/integration/mcp-wrapper-system-prompt.test.ts
+++ b/test/integration/mcp-wrapper-system-prompt.test.ts
@@ -11,6 +11,7 @@ import { resolveCouncilToolArgsForNames } from "../../pi-package/extensions/conv
 import type { ConveneCouncilConfig } from "../../pi-package/extensions/convene-council/types";
 import type { McpClientManager } from "../../pi-package/extensions/mcp-wrapper/client-manager";
 import mcpWrapper from "../../pi-package/extensions/mcp-wrapper/index";
+import projectRules from "../../pi-package/extensions/project-rules/index";
 import systemPrompt from "../../pi-package/extensions/system-prompt/index";
 
 const AGENT_SUITE_DIR_ENV = "PI_AGENT_SUITE_DIR";
@@ -119,7 +120,10 @@ function toolNamesFromArgs(args: readonly string[]): readonly string[] {
 		: toolsValue.split(",").filter((toolName) => toolName.length > 0);
 }
 
-async function runBeforeAgentStart(pi: ExtensionApiFake): Promise<string> {
+async function runBeforeAgentStart(
+	pi: ExtensionApiFake,
+	cwd = "/tmp/project",
+): Promise<string> {
 	let currentPrompt = "Original prompt";
 	for (const item of pi.handlers.filter(
 		(handler) => handler.eventName === "before_agent_start",
@@ -131,7 +135,7 @@ async function runBeforeAgentStart(pi: ExtensionApiFake): Promise<string> {
 				images: [],
 				systemPrompt: currentPrompt,
 				systemPromptOptions: {
-					cwd: "/tmp/project",
+					cwd,
 					selectedTools: [],
 					toolSnippets: {},
 					promptGuidelines: [],
@@ -163,12 +167,13 @@ afterEach(() => {
 });
 
 describe("mcp-wrapper and system-prompt integration", () => {
-	test("appends MCP instructions after system-prompt replaces the base prompt", async () => {
-		// Purpose: MCP initialize instructions must survive the system-prompt template replacement.
-		// Input and expected output: system-prompt renders a template, then mcp-wrapper appends the approved mcp_instructions block.
-		// Edge case: handler order must preserve the template output and append MCP instructions after it.
-		// Dependencies: this test composes both extension entry points with in-memory fakes and temp suite config.
+	test("appends project rules and MCP instructions after system-prompt replaces the base prompt", async () => {
+		// Purpose: project rules and MCP initialize instructions must survive the system-prompt template replacement.
+		// Input and expected output: system-prompt renders a template, project-rules appends project_rules, then mcp-wrapper appends mcp_instructions.
+		// Edge case: handler order must preserve the template output and append each later section once.
+		// Dependencies: this test composes three extension entry points with in-memory fakes and temp suite config.
 		const suiteDir = await mkdtemp(join(tmpdir(), "pi-mcp-system-prompt-"));
+		const projectDir = await mkdtemp(join(tmpdir(), "pi-project-rules-order-"));
 		try {
 			process.env[AGENT_SUITE_DIR_ENV] = suiteDir;
 			const templateFile = join(suiteDir, "template.md");
@@ -178,6 +183,8 @@ describe("mcp-wrapper and system-prompt integration", () => {
 				join(suiteDir, "system-prompt", "config.json"),
 				JSON.stringify({ templateFile }),
 			);
+			await mkdir(join(projectDir, ".pi"));
+			await writeFile(join(projectDir, ".pi", "rules.md"), "Project rule");
 
 			const pi = createExtensionApiFake();
 			const manager = {
@@ -201,6 +208,7 @@ describe("mcp-wrapper and system-prompt integration", () => {
 			>;
 
 			systemPrompt(pi);
+			projectRules(pi);
 			mcpWrapper(pi, {
 				readConfig: async () => ({
 					kind: "valid",
@@ -225,8 +233,14 @@ describe("mcp-wrapper and system-prompt integration", () => {
 			pi.setActiveTools(["fetch_fetch"]);
 
 			expect(
-				await runBeforeAgentStart(pi),
-			).toBe(`Suite template for /tmp/project
+				await runBeforeAgentStart(pi, projectDir),
+			).toBe(`Suite template for ${projectDir}
+
+<project_rules>
+  <project_rule path=".pi/rules.md">
+Project rule
+  </project_rule>
+</project_rules>
 
 <mcp_instructions>
   <server name="fetch">
@@ -235,6 +249,7 @@ Use fetch for web pages.
 </mcp_instructions>`);
 		} finally {
 			await rm(suiteDir, { recursive: true, force: true });
+			await rm(projectDir, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
Introduce a new extension that appends project-specific Markdown rules to the system prompt, enhancing the customization and functionality of the prompt generation process. This extension reads rules from a designated directory and integrates them seamlessly with existing prompt behavior.