### PR TITLE
fix(project-rules): scope and bound rule loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Recommended MCP servers:
 | Extension | Default behavior | What it does | Quick settings | Details |
 | --- | --- | --- | --- | --- |
 | `system-prompt` | Enabled | Replaces pi's base system prompt with a Markdown template and runtime variables. | `system-prompt/config.json`: `enabled`, `templateFile`. | [docs/extensions/system-prompt.md](docs/extensions/system-prompt.md) |
-| `project-rules` | Enabled | Appends recursive project Markdown rules from `.pi` to the final system prompt. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
+| `project-rules` | Enabled | Appends bounded recursive Markdown rules from `.pi/rules`; limit failures reject the section without truncation. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
 | `mcp-wrapper` | No MCP tools until configured | Registers tools from configured MCP servers, caches tool metadata, and adds `/mcp-refresh`. | `mcp-wrapper/config.json`: `settings.enabled`, `settings.timeouts`, `mcpServers`. | [docs/extensions/mcp-wrapper.md](docs/extensions/mcp-wrapper.md) |
 | `enable-tools` | Enabled | Enables configured built-in tools such as `grep`, `find`, and `ls`. | `enable-tools/config.json`: `enabled`, `include`, `exclude`. | [docs/extensions/enable-tools.md](docs/extensions/enable-tools.md) |
 | `footer` | Enabled | Shows project, quota, cost, selected agent, model, projection, MCP errors, and context usage. | `footer/config.json`: `enabled`, `showProvider`, `showModel`, `showThinkingLevel`, `showApiCost`. | [docs/extensions/footer.md](docs/extensions/footer.md) |

--- a/docs/extensions/project-rules.md
+++ b/docs/extensions/project-rules.md
@@ -25,7 +25,7 @@ $PI_AGENT_SUITE_DIR/project-rules/config.json
 ```json
 {
   "enabled": true,
-  "rulesDir": ".pi"
+  "rulesDir": ".pi/rules"
 }
 ```
 
@@ -40,7 +40,7 @@ $PI_AGENT_SUITE_DIR/project-rules/config.json
 - `rulesDir`
   - Required: no.
   - Type: string.
-  - Default: `.pi`.
+  - Default: `.pi/rules`.
   - Meaning: path to the directory that contains project rule files.
   - The path is resolved relative to pi's current working directory.
   - The value must be a non-empty relative path.
@@ -50,7 +50,16 @@ Only `enabled` and `rulesDir` are allowed in the config file.
 
 ## Rule files
 
-- The extension reads non-empty `*.md` files under `rulesDir` recursively.
-- Files that are empty or contain only whitespace are ignored.
+- The extension reads `*.md` candidates under `rulesDir` recursively, follows symlinks, prevents real-directory cycles, and uses deterministic visible-path order.
+- Files that are empty or contain only whitespace are counted against the limits but are not rendered.
 - A missing `rulesDir` directory adds no project rules.
 - Invalid configuration or rule loading failure leaves the system prompt unchanged and reports a warning.
+
+The fixed safety limits are:
+
+- At most 64 KiB (65,536 UTF-8 bytes) per Markdown candidate.
+- At most 64 Markdown candidates, including empty and whitespace-only files.
+- At most 256 KiB (262,144 UTF-8 bytes) of aggregate candidate content, including empty and whitespace-only files.
+- At most 320 KiB (327,680 JavaScript string characters) in the rendered `<project_rules>` section.
+
+Values exactly at each limit are accepted. If any limit is exceeded, the extension rejects the complete `<project_rules>` section, leaves the prompt unchanged, and emits one warning. It does not truncate files or the rendered section.

--- a/pi-package/README.md
+++ b/pi-package/README.md
@@ -65,7 +65,7 @@ Recommended MCP servers:
 | Extension | Default behavior | What it does | Quick settings | Details |
 | --- | --- | --- | --- | --- |
 | `system-prompt` | Enabled | Replaces pi's base system prompt with a Markdown template and runtime variables. | `system-prompt/config.json`: `enabled`, `templateFile`. | [docs/extensions/system-prompt.md](docs/extensions/system-prompt.md) |
-| `project-rules` | Enabled | Appends recursive project Markdown rules from `.pi` to the final system prompt. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
+| `project-rules` | Enabled | Appends bounded recursive Markdown rules from `.pi/rules`; limit failures reject the section without truncation. | `project-rules/config.json`: `enabled`, `rulesDir`. | [docs/extensions/project-rules.md](docs/extensions/project-rules.md) |
 | `mcp-wrapper` | No MCP tools until configured | Registers tools from configured MCP servers, caches tool metadata, and adds `/mcp-refresh`. | `mcp-wrapper/config.json`: `settings.enabled`, `settings.timeouts`, `mcpServers`. | [docs/extensions/mcp-wrapper.md](docs/extensions/mcp-wrapper.md) |
 | `enable-tools` | Enabled | Enables configured built-in tools such as `grep`, `find`, and `ls`. | `enable-tools/config.json`: `enabled`, `include`, `exclude`. | [docs/extensions/enable-tools.md](docs/extensions/enable-tools.md) |
 | `footer` | Enabled | Shows project, quota, cost, selected agent, model, projection, MCP errors, and context usage. | `footer/config.json`: `enabled`, `showProvider`, `showModel`, `showThinkingLevel`, `showApiCost`. | [docs/extensions/footer.md](docs/extensions/footer.md) |

--- a/pi-package/extensions/project-rules/config.test.ts
+++ b/pi-package/extensions/project-rules/config.test.ts
@@ -21,9 +21,9 @@ afterEach(async () => {
 });
 
 describe("project-rules config", () => {
-	test("uses enabled true and .pi rules directory when config is missing", async () => {
+	test("uses enabled true and .pi/rules directory when config is missing", async () => {
 		// Purpose: project rules must work without setup by reading the default repository rules directory.
-		// Input and expected output: no config file returns enabled true and rulesDir .pi.
+		// Input and expected output: no config file returns enabled true and rulesDir .pi/rules.
 		// Edge case: the suite config directory is absent.
 		// Dependencies: this test uses only temporary suite storage.
 		await withIsolatedSuiteDir(async () => {
@@ -31,7 +31,7 @@ describe("project-rules config", () => {
 
 			expect(result).toEqual({
 				kind: "valid",
-				config: { enabled: true, rulesDir: ".pi" },
+				config: { enabled: true, rulesDir: ".pi/rules" },
 			});
 		});
 	});
@@ -43,11 +43,11 @@ describe("project-rules config", () => {
 		// Dependencies: this test exercises the pure parser only.
 		expect(parseProjectRulesConfig({})).toEqual({
 			kind: "valid",
-			config: { enabled: true, rulesDir: ".pi" },
+			config: { enabled: true, rulesDir: ".pi/rules" },
 		});
 		expect(parseProjectRulesConfig({ enabled: false })).toEqual({
 			kind: "valid",
-			config: { enabled: false, rulesDir: ".pi" },
+			config: { enabled: false, rulesDir: ".pi/rules" },
 		});
 		expect(parseProjectRulesConfig({ rulesDir: "rules" })).toEqual({
 			kind: "valid",

--- a/pi-package/extensions/project-rules/config.ts
+++ b/pi-package/extensions/project-rules/config.ts
@@ -10,7 +10,7 @@ export const PROJECT_RULES_EXTENSION_DIR = "project-rules";
 const ENABLED_CONFIG_KEY = "enabled";
 const RULES_DIR_CONFIG_KEY = "rulesDir";
 const CONFIG_KEYS = [ENABLED_CONFIG_KEY, RULES_DIR_CONFIG_KEY] as const;
-const DEFAULT_RULES_DIR = ".pi";
+const DEFAULT_RULES_DIR = ".pi/rules";
 const PATH_PART_SEPARATOR = /[\\/]+/;
 
 interface ProjectRulesRawConfig {

--- a/pi-package/extensions/project-rules/index.test.ts
+++ b/pi-package/extensions/project-rules/index.test.ts
@@ -7,10 +7,14 @@ import type {
 	ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage";
-import projectRules from "./index";
+import projectRules, { renderProjectRules } from "./index";
 
 const previousAgentSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
 const tempDirs: string[] = [];
+
+const KIBIBYTE = 1024;
+const MAX_RULE_FILE_BYTES = 64 * KIBIBYTE;
+const MAX_RENDERED_PROJECT_RULES_LENGTH = 320 * KIBIBYTE;
 
 interface RegisteredHandler {
 	readonly eventName: string;
@@ -65,7 +69,7 @@ describe("project-rules", () => {
 		// Dependencies: this test uses temporary project files and in-memory lifecycle fakes.
 		await withIsolatedSuiteDir(async () => {
 			const projectDir = await createTempDir("project-rules-project-");
-			const rulesDir = join(projectDir, ".pi");
+			const rulesDir = join(projectDir, ".pi", "rules");
 			await mkdir(join(rulesDir, "nested"), { recursive: true });
 			await writeFile(join(rulesDir, "z.md"), "Z rule");
 			await writeFile(join(rulesDir, "nested", "a.md"), "A rule");
@@ -88,14 +92,119 @@ describe("project-rules", () => {
 					"Original pi prompt",
 					"",
 					"<project_rules>",
-					'  <project_rule path=".pi/nested/a.md">',
+					'  <project_rule path=".pi/rules/nested/a.md">',
 					"A rule",
 					"  </project_rule>",
-					'  <project_rule path=".pi/z.md">',
+					'  <project_rule path=".pi/rules/z.md">',
 					"Z rule",
 					"  </project_rule>",
 					"</project_rules>",
 				].join("\n"),
+			);
+		});
+	});
+
+	test("ignores Markdown under .pi outside the default rules directory", async () => {
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-outside-");
+			await mkdir(join(projectDir, ".pi"));
+			await writeFile(join(projectDir, ".pi", "outside.md"), "Outside marker");
+
+			const prompt = await renderPrompt(projectDir);
+
+			expect(prompt).toBe("Original pi prompt");
+			expect(prompt).not.toContain("Outside marker");
+		});
+	});
+
+	test("accepts 65,536-byte files and rejects 65,537-byte files", async () => {
+		await expectBoundary({
+			fileSizes: [MAX_RULE_FILE_BYTES],
+			expectedIssue: undefined,
+		});
+		await expectBoundary({
+			fileSizes: [MAX_RULE_FILE_BYTES + 1],
+			expectedIssue: "rule file exceeds 64 KiB limit",
+		});
+	});
+
+	test("accepts 64 candidates and rejects 65 candidates including empty files", async () => {
+		await expectBoundary({
+			fileSizes: Array(64).fill(0),
+			expectedIssue: undefined,
+		});
+		await expectBoundary({
+			fileSizes: Array(65).fill(0),
+			expectedIssue: "rule file count exceeds 64",
+		});
+	});
+
+	test("accepts 262,144 aggregate bytes and rejects 262,145 bytes", async () => {
+		await expectBoundary({
+			fileSizes: Array(4).fill(MAX_RULE_FILE_BYTES),
+			expectedIssue: undefined,
+		});
+		await expectBoundary({
+			fileSizes: [
+				MAX_RULE_FILE_BYTES,
+				MAX_RULE_FILE_BYTES,
+				MAX_RULE_FILE_BYTES,
+				MAX_RULE_FILE_BYTES,
+				1,
+			],
+			expectedIssue: "total rule content exceeds 256 KiB limit",
+		});
+	});
+
+	test("accepts a 327,680-character rendered section and rejects 327,681", () => {
+		const emptyLength = renderProjectRules([
+			{ path: "x.md", content: "" },
+		]).length;
+		expect(
+			renderProjectRules([
+				{
+					path: "x.md",
+					content: "x".repeat(MAX_RENDERED_PROJECT_RULES_LENGTH - emptyLength),
+				},
+			]),
+		).toHaveLength(MAX_RENDERED_PROJECT_RULES_LENGTH);
+		expect(() =>
+			renderProjectRules([
+				{
+					path: "x.md",
+					content: "x".repeat(
+						MAX_RENDERED_PROJECT_RULES_LENGTH - emptyLength + 1,
+					),
+				},
+			]),
+		).toThrow("rendered project rules exceed 320 KiB limit");
+	});
+
+	test("reports one fixed safe warning and leaves the prompt unchanged", async () => {
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir("project-rules-safe-warning-");
+			const rulesDir = join(projectDir, ".pi", "rules");
+			await mkdir(rulesDir, { recursive: true });
+			await writeFile(
+				join(rulesDir, "unique-path-marker.md"),
+				"unique-content-marker".repeat(4_000),
+			);
+			const context = createContextFake(projectDir);
+
+			expect(await renderPrompt(projectDir, context)).toBe(
+				"Original pi prompt",
+			);
+			expect(context.notifications).toEqual([
+				{
+					message: "[project-rules] rule file exceeds 64 KiB limit",
+					type: "warning",
+				},
+			]);
+			expect(context.notifications[0]?.message).not.toContain(
+				"unique-path-marker",
+			);
+			expect(context.notifications[0]?.message).not.toContain(
+				"unique-content-marker",
 			);
 		});
 	});
@@ -119,7 +228,8 @@ describe("project-rules", () => {
 				join(externalDir, "shared-dir", "nested.md"),
 				"Linked dir rule",
 			);
-			await symlink(realRulesDir, join(projectDir, ".pi"), "dir");
+			await mkdir(join(projectDir, ".pi"));
+			await symlink(realRulesDir, join(projectDir, ".pi", "rules"), "dir");
 			await symlink(
 				join(externalDir, "shared-source.txt"),
 				join(realRulesDir, "shared.md"),
@@ -141,11 +251,11 @@ describe("project-rules", () => {
 				context.ctx,
 			);
 
-			expect(prompt).toContain('path=".pi/root.md"');
+			expect(prompt).toContain('path=".pi/rules/root.md"');
 			expect(prompt).toContain("Root rule");
-			expect(prompt).toContain('path=".pi/shared-dir/nested.md"');
+			expect(prompt).toContain('path=".pi/rules/shared-dir/nested.md"');
 			expect(prompt).toContain("Linked dir rule");
-			expect(prompt).toContain('path=".pi/shared.md"');
+			expect(prompt).toContain('path=".pi/rules/shared.md"');
 			expect(prompt).toContain("Linked file rule");
 			expect(prompt.match(/Root rule/g)).toHaveLength(1);
 		});
@@ -159,15 +269,15 @@ describe("project-rules", () => {
 		await withIsolatedSuiteDir(async () => {
 			const projectDir = await createTempDir("project-rules-repeat-project-");
 			const sharedDir = await createTempDir("project-rules-repeat-shared-");
-			await mkdir(join(projectDir, ".pi"));
+			await mkdir(join(projectDir, ".pi", "rules"), { recursive: true });
 			await writeFile(join(sharedDir, "rule.md"), "Shared rule");
-			await symlink(sharedDir, join(projectDir, ".pi", "a"), "dir");
-			await symlink(sharedDir, join(projectDir, ".pi", "b"), "dir");
+			await symlink(sharedDir, join(projectDir, ".pi", "rules", "a"), "dir");
+			await symlink(sharedDir, join(projectDir, ".pi", "rules", "b"), "dir");
 
 			const prompt = await renderPrompt(projectDir);
 
-			expect(prompt).toContain('path=".pi/a/rule.md"');
-			expect(prompt).not.toContain('path=".pi/b/rule.md"');
+			expect(prompt).toContain('path=".pi/rules/a/rule.md"');
+			expect(prompt).not.toContain('path=".pi/rules/b/rule.md"');
 			expect(prompt.match(/Shared rule/g)).toHaveLength(1);
 		});
 	});
@@ -187,20 +297,79 @@ describe("project-rules", () => {
 			expect(await renderPrompt(missingProjectDir)).toBe("Original pi prompt");
 
 			const emptyProjectDir = await createTempDir("project-rules-empty-");
-			await mkdir(join(emptyProjectDir, ".pi"));
-			await writeFile(join(emptyProjectDir, ".pi", "empty.md"), "\n\t ");
+			await mkdir(join(emptyProjectDir, ".pi", "rules"), { recursive: true });
+			await writeFile(
+				join(emptyProjectDir, ".pi", "rules", "empty.md"),
+				"\n\t ",
+			);
 			expect(await renderPrompt(emptyProjectDir)).toBe("Original pi prompt");
+		});
+	});
+
+	test("warns when the default rulesDir is missing through a broken ancestor symlink", async () => {
+		await withIsolatedSuiteDir(async () => {
+			const projectDir = await createTempDir(
+				"project-rules-broken-default-ancestor-",
+			);
+			await symlink(join(projectDir, "missing-pi"), join(projectDir, ".pi"));
+			const context = createContextFake(projectDir);
+
+			expect(await renderPrompt(projectDir, context)).toBe(
+				"Original pi prompt",
+			);
+			expect(context.notifications).toHaveLength(1);
+		});
+	});
+
+	test("warns when a configured nested rulesDir is missing through a broken ancestor symlink", async () => {
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			const projectDir = await createTempDir(
+				"project-rules-broken-nested-ancestor-",
+			);
+			await mkdir(join(projectDir, "config"));
+			await symlink(
+				join(projectDir, "missing-rules"),
+				join(projectDir, "config", "rules"),
+			);
+			await writeProjectRulesConfig(suiteDir, {
+				rulesDir: "config/rules/nested",
+			});
+			const context = createContextFake(projectDir);
+
+			expect(await renderPrompt(projectDir, context)).toBe(
+				"Original pi prompt",
+			);
+			expect(context.notifications).toHaveLength(1);
+		});
+	});
+
+	test("keeps an ordinarily missing configured rulesDir ancestor silent", async () => {
+		await withIsolatedSuiteDir(async (suiteDir) => {
+			const projectDir = await createTempDir("project-rules-missing-ancestor-");
+			await writeProjectRulesConfig(suiteDir, {
+				rulesDir: "config/rules/nested",
+			});
+			const context = createContextFake(projectDir);
+
+			expect(await renderPrompt(projectDir, context)).toBe(
+				"Original pi prompt",
+			);
+			expect(context.notifications).toHaveLength(0);
 		});
 	});
 
 	test("fails the whole section and warns when rulesDir itself is a broken symlink", async () => {
 		// Purpose: a broken rulesDir symlink must not silently disable project rules.
-		// Input and expected output: .pi points to a missing directory, so the prompt is unchanged and one warning is emitted.
-		// Edge case: a genuinely missing .pi directory remains a no-op in a separate test.
+		// Input and expected output: .pi/rules points to a missing directory, so the prompt is unchanged and one warning is emitted.
+		// Edge case: a genuinely missing .pi/rules directory remains a no-op in a separate test.
 		// Dependencies: this test uses a filesystem symlink in a temporary project directory.
 		await withIsolatedSuiteDir(async () => {
 			const projectDir = await createTempDir("project-rules-broken-root-");
-			await symlink(join(projectDir, "missing-rules"), join(projectDir, ".pi"));
+			await mkdir(join(projectDir, ".pi"));
+			await symlink(
+				join(projectDir, "missing-rules"),
+				join(projectDir, ".pi", "rules"),
+			);
 			const context = createContextFake(projectDir);
 
 			expect(await renderPrompt(projectDir, context)).toBe(
@@ -230,14 +399,16 @@ describe("project-rules", () => {
 			const brokenSymlinkProjectDir = await createTempDir(
 				"project-rules-broken-symlink-",
 			);
-			await mkdir(join(brokenSymlinkProjectDir, ".pi"));
+			await mkdir(join(brokenSymlinkProjectDir, ".pi", "rules"), {
+				recursive: true,
+			});
 			await writeFile(
-				join(brokenSymlinkProjectDir, ".pi", "valid.md"),
+				join(brokenSymlinkProjectDir, ".pi", "rules", "valid.md"),
 				"Valid",
 			);
 			await symlink(
 				join(brokenSymlinkProjectDir, "missing.md"),
-				join(brokenSymlinkProjectDir, ".pi", "broken.md"),
+				join(brokenSymlinkProjectDir, ".pi", "rules", "broken.md"),
 			);
 			const brokenSymlinkContext = createContextFake(brokenSymlinkProjectDir);
 			expect(
@@ -247,6 +418,42 @@ describe("project-rules", () => {
 		});
 	});
 });
+
+async function expectBoundary(options: {
+	readonly fileSizes: readonly number[];
+	readonly expectedIssue: string | undefined;
+}): Promise<void> {
+	await withIsolatedSuiteDir(async () => {
+		const projectDir = await createTempDir("project-rules-boundary-");
+		const rulesDir = join(projectDir, ".pi", "rules");
+		await mkdir(rulesDir, { recursive: true });
+		await Promise.all(
+			options.fileSizes.map((size, index) =>
+				writeFile(
+					join(rulesDir, `${index.toString().padStart(2, "0")}.md`),
+					"x".repeat(size),
+				),
+			),
+		);
+		const context = createContextFake(projectDir);
+		const prompt = await renderPrompt(projectDir, context);
+
+		if (options.expectedIssue === undefined) {
+			expect(context.notifications).toHaveLength(0);
+			if (options.fileSizes.some((size) => size > 0)) {
+				expect(prompt).toContain("<project_rules>");
+			} else {
+				expect(prompt).toBe("Original pi prompt");
+			}
+			return;
+		}
+
+		expect(prompt).toBe("Original pi prompt");
+		expect(context.notifications).toEqual([
+			{ message: `[project-rules] ${options.expectedIssue}`, type: "warning" },
+		]);
+	});
+}
 
 function createExtensionApiFake(): ExtensionApiFake {
 	const handlers: RegisteredHandler[] = [];

--- a/pi-package/extensions/project-rules/index.ts
+++ b/pi-package/extensions/project-rules/index.ts
@@ -1,6 +1,6 @@
 import type { Dirent } from "node:fs";
 import { lstat, readdir, readFile, realpath, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { join, normalize, sep } from "node:path";
 import type {
 	BuildSystemPromptOptions,
 	ExtensionAPI,
@@ -9,6 +9,21 @@ import { readProjectRulesConfig } from "./config";
 
 const ISSUE_PREFIX = "[project-rules]";
 const MARKDOWN_EXTENSION = ".md";
+const BYTES_PER_KIBIBYTE = 1024;
+const MAX_RULE_FILE_KIBIBYTES = 64;
+const MAX_RULE_FILE_COUNT = 64;
+const MAX_TOTAL_RULE_CONTENT_KIBIBYTES = 256;
+const MAX_RENDERED_PROJECT_RULES_KIBIBYTES = 320;
+const MAX_RULE_FILE_BYTES = MAX_RULE_FILE_KIBIBYTES * BYTES_PER_KIBIBYTE;
+const MAX_TOTAL_RULE_CONTENT_BYTES =
+	MAX_TOTAL_RULE_CONTENT_KIBIBYTES * BYTES_PER_KIBIBYTE;
+const MAX_RENDERED_PROJECT_RULES_LENGTH =
+	MAX_RENDERED_PROJECT_RULES_KIBIBYTES * BYTES_PER_KIBIBYTE;
+const RULE_FILE_SIZE_ISSUE = "rule file exceeds 64 KiB limit";
+const RULE_FILE_COUNT_ISSUE = "rule file count exceeds 64";
+const TOTAL_RULE_CONTENT_ISSUE = "total rule content exceeds 256 KiB limit";
+const RENDERED_PROJECT_RULES_ISSUE =
+	"rendered project rules exceed 320 KiB limit";
 
 interface SessionContextLike {
 	readonly hasUI?: boolean;
@@ -27,8 +42,17 @@ interface ProjectRule {
 	readonly content: string;
 }
 
+interface RuleLoadBudget {
+	candidateCount: number;
+	totalContentBytes: number;
+}
+
 type ProjectRulesReadResult =
 	| { readonly kind: "valid"; readonly rules: readonly ProjectRule[] }
+	| { readonly kind: "invalid"; readonly issue: string };
+
+type MissingDirectoryStatus =
+	| { readonly kind: "missing" }
 	| { readonly kind: "invalid"; readonly issue: string };
 
 /** Appends project-local Markdown rules after the base system prompt is assembled. */
@@ -56,8 +80,19 @@ export default function projectRules(pi: ExtensionAPI): void {
 			return undefined;
 		}
 
+		let renderedRules: string;
+		try {
+			renderedRules = renderProjectRules(rulesResult.rules);
+		} catch (error) {
+			reportIssue(
+				ctx as SessionContextLike,
+				error instanceof Error ? error.message : RENDERED_PROJECT_RULES_ISSUE,
+			);
+			return undefined;
+		}
+
 		return {
-			systemPrompt: `${typedEvent.systemPrompt}\n\n${renderProjectRules(rulesResult.rules)}`,
+			systemPrompt: `${typedEvent.systemPrompt}\n\n${renderedRules}`,
 		};
 	});
 }
@@ -70,8 +105,9 @@ async function readProjectRules(
 	const rootDir = join(cwd, rulesDir);
 	const visitedRealDirs = new Set<string>();
 	const rules: ProjectRule[] = [];
+	const budget: RuleLoadBudget = { candidateCount: 0, totalContentBytes: 0 };
 
-	const rootStatus = await resolveDirectoryStatus(rootDir);
+	const rootStatus = await resolveDirectoryStatus(rootDir, cwd, rulesDir);
 	if (rootStatus.kind === "missing") {
 		return { kind: "valid", rules: [] };
 	}
@@ -84,6 +120,7 @@ async function readProjectRules(
 		visibleDir: toPromptPath(rulesDir),
 		visitedRealDirs,
 		rules,
+		budget,
 	});
 	if (walkResult.kind === "invalid") {
 		return walkResult;
@@ -98,6 +135,8 @@ async function readProjectRules(
 /** Distinguishes absent default rules from unreadable or non-directory entry points. */
 async function resolveDirectoryStatus(
 	directory: string,
+	cwd: string,
+	rulesDir: string,
 ): Promise<
 	| { readonly kind: "valid" }
 	| { readonly kind: "missing" }
@@ -120,25 +159,32 @@ async function resolveDirectoryStatus(
 			};
 		}
 
-		return inspectMissingDirectoryPath(directory);
+		return inspectMissingDirectoryPath(cwd, rulesDir);
 	}
 }
 
-/** Separates an absent rulesDir from a broken symlink at the rulesDir path. */
+/** Separates an absent rulesDir from a broken symlink in its project-relative path. */
 async function inspectMissingDirectoryPath(
-	directory: string,
-): Promise<
-	| { readonly kind: "missing" }
-	| { readonly kind: "invalid"; readonly issue: string }
-> {
+	cwd: string,
+	rulesDir: string,
+): Promise<MissingDirectoryStatus> {
+	return inspectMissingPathComponents(cwd, normalize(rulesDir).split(sep));
+}
+
+/** Inspects configured path components in order so an absent parent stops probing. */
+async function inspectMissingPathComponents(
+	parentPath: string,
+	components: readonly string[],
+): Promise<MissingDirectoryStatus> {
+	const [component, ...remainingComponents] = components;
+	if (component === undefined) {
+		return { kind: "missing" };
+	}
+
+	const currentPath = join(parentPath, component);
+	let linkStat: Awaited<ReturnType<typeof lstat>>;
 	try {
-		const linkStat = await lstat(directory);
-		return {
-			kind: "invalid",
-			issue: linkStat.isSymbolicLink()
-				? "rulesDir symlink target does not exist"
-				: "rulesDir could not be inspected",
-		};
+		linkStat = await lstat(currentPath);
 	} catch (error) {
 		if (isFileNotFoundError(error)) {
 			return { kind: "missing" };
@@ -149,6 +195,21 @@ async function inspectMissingDirectoryPath(
 			issue: `failed to inspect rulesDir: ${formatError(error)}`,
 		};
 	}
+
+	if (linkStat.isSymbolicLink()) {
+		try {
+			await stat(currentPath);
+		} catch (error) {
+			return {
+				kind: "invalid",
+				issue: isFileNotFoundError(error)
+					? "rulesDir symlink target does not exist"
+					: `failed to inspect rulesDir: ${formatError(error)}`,
+			};
+		}
+	}
+
+	return inspectMissingPathComponents(currentPath, remainingComponents);
 }
 
 /** Recursively walks directories and records non-empty Markdown files by visible path. */
@@ -157,6 +218,7 @@ async function walkRulesDirectory(options: {
 	readonly visibleDir: string;
 	readonly visitedRealDirs: Set<string>;
 	readonly rules: ProjectRule[];
+	readonly budget: RuleLoadBudget;
 }): Promise<
 	| { readonly kind: "valid" }
 	| { readonly kind: "invalid"; readonly issue: string }
@@ -214,6 +276,7 @@ async function processDirectoryEntry(
 	options: {
 		readonly visitedRealDirs: Set<string>;
 		readonly rules: ProjectRule[];
+		readonly budget: RuleLoadBudget;
 	},
 ): Promise<
 	| { readonly kind: "valid" }
@@ -235,11 +298,20 @@ async function processDirectoryEntry(
 			visibleDir: visiblePath,
 			visitedRealDirs: options.visitedRealDirs,
 			rules: options.rules,
+			budget: options.budget,
 		});
 	}
 
 	if (!entryStat.isFile() || !visiblePath.endsWith(MARKDOWN_EXTENSION)) {
 		return { kind: "valid" };
+	}
+
+	options.budget.candidateCount += 1;
+	if (options.budget.candidateCount > MAX_RULE_FILE_COUNT) {
+		return { kind: "invalid", issue: RULE_FILE_COUNT_ISSUE };
+	}
+	if (entryStat.size > MAX_RULE_FILE_BYTES) {
+		return { kind: "invalid", issue: RULE_FILE_SIZE_ISSUE };
 	}
 
 	let content: string;
@@ -251,6 +323,14 @@ async function processDirectoryEntry(
 			issue: `failed to read rule file: ${formatError(error)}`,
 		};
 	}
+	const contentBytes = Buffer.byteLength(content, "utf8");
+	if (contentBytes > MAX_RULE_FILE_BYTES) {
+		return { kind: "invalid", issue: RULE_FILE_SIZE_ISSUE };
+	}
+	options.budget.totalContentBytes += contentBytes;
+	if (options.budget.totalContentBytes > MAX_TOTAL_RULE_CONTENT_BYTES) {
+		return { kind: "invalid", issue: TOTAL_RULE_CONTENT_ISSUE };
+	}
 	if (content.trim().length === 0) {
 		return { kind: "valid" };
 	}
@@ -260,8 +340,8 @@ async function processDirectoryEntry(
 }
 
 /** Renders a stable XML-like block without changing rule file contents. */
-function renderProjectRules(rules: readonly ProjectRule[]): string {
-	return [
+export function renderProjectRules(rules: readonly ProjectRule[]): string {
+	const rendered = [
 		"<project_rules>",
 		...rules.flatMap((rule) => [
 			`  <project_rule path="${escapeAttribute(rule.path)}">`,
@@ -270,6 +350,11 @@ function renderProjectRules(rules: readonly ProjectRule[]): string {
 		]),
 		"</project_rules>",
 	].join("\n");
+	if (rendered.length > MAX_RENDERED_PROJECT_RULES_LENGTH) {
+		throw new Error(RENDERED_PROJECT_RULES_ISSUE);
+	}
+
+	return rendered;
 }
 
 /** Normalizes visible paths to prompt-friendly slash separators. */

--- a/test/integration/mcp-wrapper-system-prompt.test.ts
+++ b/test/integration/mcp-wrapper-system-prompt.test.ts
@@ -183,8 +183,11 @@ describe("mcp-wrapper and system-prompt integration", () => {
 				join(suiteDir, "system-prompt", "config.json"),
 				JSON.stringify({ templateFile }),
 			);
-			await mkdir(join(projectDir, ".pi"));
-			await writeFile(join(projectDir, ".pi", "rules.md"), "Project rule");
+			await mkdir(join(projectDir, ".pi", "rules"), { recursive: true });
+			await writeFile(
+				join(projectDir, ".pi", "rules", "rules.md"),
+				"Project rule",
+			);
 
 			const pi = createExtensionApiFake();
 			const manager = {
@@ -237,7 +240,7 @@ describe("mcp-wrapper and system-prompt integration", () => {
 			).toBe(`Suite template for ${projectDir}
 
 <project_rules>
-  <project_rule path=".pi/rules.md">
+  <project_rule path=".pi/rules/rules.md">
 Project rule
   </project_rule>
 </project_rules>


### PR DESCRIPTION
## Summary
- change the default rules directory from `.pi` to `.pi/rules`
- stop unrelated `.pi` Markdown from entering the system prompt
- reject the complete project-rules section instead of truncating when any safety limit is exceeded
- preserve deterministic recursive loading, symlink support, duplicate-target handling, and cycle protection
- fail closed when a missing nested path is caused by a broken ancestor symlink

## Safety limits
- 64 KiB UTF-8 per Markdown file
- 64 Markdown candidates
- 256 KiB aggregate Markdown content
- 320 KiB rendered `<project_rules>` section

## Breaking change
The default location is now `.pi/rules`. There is no fallback scan of Markdown directly under `.pi`.

## Validation
- focused project-rules and integration tests — 23 passed
- `bun run typecheck`
- `bun run check`