### PR TITLE
Add cooperative planning yields to custom compaction

### DIFF
--- a/docs/extensions/custom-compaction.md
+++ b/docs/extensions/custom-compaction.md
@@ -112,6 +112,7 @@ Interactive Pi sessions receive informational messages for:
 
 - forced compaction-source projection progress and retries;
 - adaptive compaction start;
+- planning compaction budgets;
 - the number of original blocks in each preliminary range;
 - oversized-block fragment count and each fragment position;
 - previous_summary normalization;
@@ -122,7 +123,7 @@ Interactive Pi sessions receive informational messages for:
 
 The successful outcome states whether the direct or adaptive path ran and reports applicable counts for projected tool results, reduced blocks, preliminary ranges, oversized blocks, fragments, normalizations, merges, logical model requests, and retries.
 
-A logical model request is counted once even when it is retried. Retries are reported separately. Start and outcome notifications yield one event-loop turn so Pi can repaint them before synchronous planning or lifecycle completion continues. Non-interactive runs emit no progress notifications.
+A logical model request is counted once even when it is retried. Retries are reported separately. Start, planning, and outcome notifications yield one event-loop turn so Pi can repaint them before planning continues or lifecycle completion replaces them. Non-interactive runs emit no progress notifications.
 
 The terminal success or standard-compaction fallback is also stored as a `custom-compaction-outcome` custom entry with a dedicated TUI renderer. This TUI-only entry survives transcript redraw and session reload but does not participate in LLM context. Intermediate progress remains transient and is not persisted.
 

--- a/docs/specs/issues/pi-compact-hang/prd.md
+++ b/docs/specs/issues/pi-compact-hang/prd.md
@@ -1,0 +1,33 @@
+# Idea: Non-blocking planning phase in custom-compaction
+
+## Definitions
+- **custom-compaction** — pi-agent-suite extension that replaces standard context compaction with adaptive summarization. See the Domain Glossary in `problem-statement.md`.
+- **planning phase** — synchronous computation of adaptive compaction budgets before LLM requests.
+
+## Context and Problem
+Manual `/compact` on a context of ≥ ~500k tokens freezes the Pi TUI for 30–90+ seconds: the spinner stops, escape does not work, and the progress message becomes stale. The cause is synchronous CPU-bound tokenization in the planning phase, which blocks the Pi event loop.
+
+## Goal
+The planning phase becomes non-blocking: the Pi spinner animates continuously, a message about the running operation is displayed, and cancel works. The compaction result does not change.
+
+## Scenarios
+- The user runs `/compact` manually on a large context (~556k tokens, 89 history blocks).
+- During planning, the user sees a progress message and a live spinner.
+- The user presses escape during planning — the operation is interrupted, as on other compaction stages.
+
+## Scope and Non-Scope
+**In scope:** the planning phase of adaptive compaction in `custom-compaction`; releasing the event loop; a progress message; cancel.
+**Out of scope:** tokenization optimization (caching, worker thread, tokenizer replacement, removing the 3-encoding fallback); changing the budget calculation algorithm; speeding up the first large LLM request.
+
+## Requirements
+
+- REQ-01: When the planning phase starts, one progress message about the running operation is shown (by analogy with existing messages, e.g. "planning compaction budgets…"), and it remains on screen until the phase ends.
+- REQ-02: During the planning phase, the event loop is not blocked for longer than ~200 ms at a time — the Pi spinner animates continuously and the UI stays responsive.
+- REQ-03: Escape during the planning phase interrupts the compaction (cancel works, as on other stages).
+- REQ-04: The compaction result (final summary, selected ranges, request count) does not change relative to current behavior.
+
+## Open Questions
+No blocking open questions.
+
+## References
+- `docs/specs/issues/pi-compact-hang/problem-statement.md` — Problem Statement and Domain Glossary.

--- a/docs/specs/issues/pi-compact-hang/problem-statement.md
+++ b/docs/specs/issues/pi-compact-hang/problem-statement.md
@@ -1,0 +1,73 @@
+# Problem Statement
+
+## Context
+The `custom-compaction` extension (pi-agent-suite) replaces Pi's standard context compaction with adaptive summarization. On large contexts, after tool-result projection, the extension runs a budget-planning phase for the adaptive compaction.
+
+## Problem Statement
+Manual `/compact` on a context of ≥ ~500k tokens freezes the Pi TUI for tens of seconds to minutes: the spinner stops, cancel (escape) does not respond, and the user sees a stale progress message. The cause is synchronous CPU-bound tokenization in the adaptive compaction planning phase, which blocks the Pi event loop.
+
+## Who is affected
+Users of Pi with large contexts who run `/compact` manually. The whole Pi TUI is affected, not just the extension.
+
+## Evidence
+- Session `019fdca2-fd41-71ae-b9ce-6cf5c836b807`: two compactions; in both, after 14 tool-result projections there is a ~4.5-minute gap with zero completed model requests; the user observes a frozen spinner at `projecting compaction source: 13/14 tool results`.
+- Benchmark: `calculateCommonNodeBudget` alone = 36.6–68.5 s of pure CPU; a 10 ms heartbeat timer received 0 ticks during the run → the event loop is fully blocked.
+- Static analysis: the whole planning chain (`buildSummarySource` → `calculateFinalSummaryBudget` → `doesFinalRequestFit` → `calculateCommonNodeBudget` → dry-run binary search) is synchronous; there is no `await` between the single event-loop yield and the first LLM request.
+- For provider `opencode-go` (not in the OpenAI family), every token count runs 3 tiktoken encodings and takes the maximum, about 3× slower than a known encoding (measured 2050 ms vs 627 ms for a 12 MB text).
+- The Pi spinner is a `Loader` from pi-tui animated via `setInterval(80ms)`; a blocked event loop freezes it.
+
+## Impact
+- User time loss: 1–2 min of frozen UI per compaction on large contexts, plus ~3 min for the first large async request (during which the spinner animates).
+- The operation looks hung; cancel does not respond during the block.
+- Reduced trust: compaction at ~500k+ tokens is perceived as broken.
+
+## Reproduction Steps
+Run `/compact` manually with a context of ~556k tokens, 89 history blocks, model `deepseek-v4-flash` (provider `opencode-go`), with the `custom-compaction` extension enabled.
+
+## Current State
+Planning runs as one synchronous block: a single `setTimeout(0)` yield before it, then 30–90+ seconds without releasing the event loop and without any progress notifications.
+
+## Desired Outcome
+During planning, the Pi spinner keeps animating, a message about the running operation is shown (e.g., "planning compaction budgets…"), the UI stays responsive, and escape works.
+
+## Success Metrics
+- No event-loop blocking period longer than ~200 ms in the planning phase (measured with a heartbeat timer or by UI responsiveness).
+- A progress message is visible during the whole planning phase.
+- The compaction result (final summary, range selection, request count) does not change relative to current behavior.
+
+## Scope
+Only the planning phase of adaptive compaction in `custom-compaction`: releasing the event loop at an interval that prevents visible blocking, and progress notifications. Only what is required for "progress message + live spinner".
+
+## Out of Scope / Non-Goals
+- Optimizing tokenization itself (caching, worker thread, tokenizer replacement, removing the 3-encoding fallback).
+- Changing the budget calculation algorithm or compaction results.
+- Speeding up the first large LLM request.
+
+## Constraints
+- No overengineering (KISS/YAGNI) — only the minimal change for the Desired Outcome.
+- Planning behavior and numbers must stay deterministic and equivalent to current behavior.
+- The extension runs in the Pi main process; `js-tiktoken` is synchronous.
+
+## Assumptions
+- The blocking cause is CPU-bound tokenization, not network latency (supported by benchmark and static analysis). Verification: additional heartbeat measurement during reproduction.
+- Inserting yields will not change computation results (deterministic pure functions).
+- Verification: unit test on responsiveness and notification order per AGENTS.md.
+
+## Open Questions
+- Is progress inside planning needed (e.g., an iteration counter update) or is one start message plus a live spinner enough? Clarify in PRD.
+- Acceptable blocking threshold: "no visible hang at all" — confirm when formulating requirements.
+
+# Domain Glossary
+
+| Term | Definition |
+|---|---|
+| custom-compaction | Pi-agent-suite extension that replaces standard context compaction with adaptive summarization. |
+| adaptive compaction | Compaction path that, when a direct final request does not fit, reduces history in stages (preliminary ranges, merges, final summary). |
+| planning phase | Synchronous computation of compaction budgets (`calculateCommonNodeBudget` and related functions) before LLM requests. |
+| dry-run | Simulation of history reduction without LLM requests; used in the binary search for a feasible node budget. |
+| tokenization | Encoding text into tokens via `js-tiktoken`; synchronous CPU-bound work. |
+| event loop | Single-threaded JS execution loop in Pi; blocking it freezes the whole TUI. |
+| Loader / spinner | pi-tui progress indicator animated via `setInterval(80ms)`. |
+| progress notification | Status-line message emitted through `session.ui.notify`. |
+| tool-result projection | Replacement of large tool results with concise LLM-generated summaries. |
+| first large request | Async LLM request that reduces the whole history corpus (~500k input tokens), executed after planning. |

--- a/docs/specs/issues/pi-compact-hang/technical-solution.md
+++ b/docs/specs/issues/pi-compact-hang/technical-solution.md
@@ -1,0 +1,52 @@
+# Technical Solution: Non-blocking planning phase in custom-compaction
+
+## Problem Statement
+- PRB-01: During manual `/compact` on contexts ≥ ~500k tokens, the adaptive compaction planning phase blocks the Pi event loop for 30–90+ seconds: the spinner freezes, escape does not respond, and the progress message goes stale (session `019fdca2-fd41-71ae-b9ce-6cf5c836b807`; measured `calculateCommonNodeBudget` = 36.6–68.5 s of pure CPU with 0 heartbeat ticks).
+- PRB-02: The planning phase is one synchronous stretch with only a single `setTimeout(0)` yield (`adaptive-compaction.ts:133`) between the "start" notification and the first LLM request.
+- PRB-03: For the non-OpenAI provider (`opencode-go`), every token count runs 3 synchronous tiktoken encodings (`context-size.ts:188-192`), multiplying the CPU cost.
+
+## Proposed Solution
+
+### SOL-01: Progress message at planning start (REQ-01)
+- Add a new progress event `{ type: "planning" }` to `AdaptiveCompactionProgressEvent` (`adaptive-compaction.ts`).
+- Emit it in `adaptiveCompactHistory` immediately before `calculateFinalSummaryBudget`.
+- Format it in `formatProgressMessage` (`index.ts`) as `planning compaction budgets...`.
+- Add `planning` to the event set in `reportProgress` that performs `yieldToEventLoop()` (`index.ts:732-740`), so the message is painted before the long synchronous phase.
+- `planning` is not an `operation`, so it does not increment `modelRequests` statistics (REQ-04).
+
+### SOL-02: Cooperative event-loop yields (REQ-02)
+- Add an optional `onStep?: () => Promise<void>` field to `AdaptiveCompactionOptions`.
+- `adaptiveCompactHistory` builds a throttled step implementation: always check `options.signal.throwIfAborted()`; yield via `yieldToEventLoop()` at most once per ~100 ms of elapsed time.
+- Convert the following planning functions to `async` and `await options.onStep?.()` at their loop boundaries:
+  - `calculateFinalSummaryBudget` — between its two main-input tokenizations.
+  - `doesFinalRequestFit` — after the full-corpus tokenization.
+  - `findLargestFeasibleNodeBudget` — each outer binary-search iteration.
+  - `isNodeBudgetFeasible` — each inner `while` pass.
+  - `findLargestFittingOriginalPrefix` (`adaptive-compaction-reduction.ts`) — each binary-search probe.
+- All call sites (in `adaptive-compaction.ts`, `adaptive-compaction-budget.ts`, `adaptive-compaction-reduction.ts`) become `await` calls; computation order and values stay identical.
+- Result: the 30–90 s block becomes a sequence of short steps; the spinner animates (its `Loader` interval is 80 ms) and the UI stays responsive.
+
+### SOL-03: Cancel during planning (REQ-03)
+- The step implementation calls `options.signal.throwIfAborted()`; an aborted signal (escape → `abortCompaction()` → `_compactionAbortController.abort()`, already wired by pi) throws `AbortError`.
+- The `AbortError` propagates through the existing catch in `handleSessionBeforeCompact` (`index.ts`), which follows the same path as cancel during an LLM request (REQ-03: cancel works as on other stages).
+
+### TRD-01: Residual single-tokenization block (decision: accepted)
+- One full-corpus 3-encoding tokenization (~556k tokens ≈ 2.2 MB) is ~370 ms — a single irreducible step slightly above the ~200 ms target from REQ-02.
+- Decision: accepted. The spinner briefly stutters (~4 missed frames) instead of freezing; this happens a handful of times at the start of planning and is far below the current 30–90 s freeze.
+- The alternative (splitting the 3-encoding computation with yields between encodings, result-identical) would touch the shared `context-size.ts` module and is explicitly deferred.
+
+### TRD-02: No algorithm or result change (REQ-04)
+- Yields only interleave execution; no computation, ordering, or token-count value changes. No caching, worker threads, or tokenizer changes are introduced (KISS; per PRD out of scope).
+
+## Overengineering and Overspecification Considerations
+- The change is limited to the custom-compaction extension; the shared `context-size.ts` module is untouched.
+- No worker threads, no token-count caching, no changes to the budget algorithm.
+- The step callback is optional and throttled, so test callers without it keep identical behavior.
+
+## Open Questions
+No open questions.
+
+## References
+- `docs/specs/issues/pi-compact-hang/problem-statement.md` — Problem Statement, Domain Glossary.
+- `docs/specs/issues/pi-compact-hang/prd.md` — REQ-01..REQ-04.
+- pi dist: `agent-session.js:1397,1488-1491` — compaction abort wiring; `pi-tui loader.js` — spinner `setInterval(80ms)`.

--- a/pi-package/extensions/custom-compaction/adaptive-compaction-budget.ts
+++ b/pi-package/extensions/custom-compaction/adaptive-compaction-budget.ts
@@ -34,13 +34,14 @@ export interface CompactionBudgets extends FinalSummaryBudget {
 }
 
 /** Calculates only the budgets required to decide and execute the direct path. */
-export function calculateFinalSummaryBudget(
+export async function calculateFinalSummaryBudget(
 	options: AdaptiveCompactionOptions,
-): FinalSummaryBudget {
+): Promise<FinalSummaryBudget> {
 	const currentMainInputTokens = estimateMainInput(
 		options.currentProjectedMainMessages,
 		options,
 	);
+	await options.onStep?.();
 	const emptyProspectiveInputTokens = estimateProspectiveMainInput("", options);
 	const mainWindowInputLimit =
 		options.mainModel.contextWindow -
@@ -60,11 +61,11 @@ export function calculateFinalSummaryBudget(
 }
 
 /** Calculates the common node budget only after the complete direct request does not fit. */
-export function calculateCommonNodeBudget(
+export async function calculateCommonNodeBudget(
 	options: AdaptiveCompactionOptions,
 	items: readonly SourceItem[],
 	finalSummaryTokens: number,
-): number {
+): Promise<number> {
 	// Two bounded inputs plus one equally bounded output must fit every merge request.
 	const emptyMergeInputTokens = estimateSummaryInput(
 		buildSummaryContext(
@@ -86,7 +87,7 @@ export function calculateCommonNodeBudget(
 	const maximumNodeTokens = Math.floor(
 		Math.min(mergeNodeTokens, modelOutputLimit(options.summarizationModel)),
 	);
-	const summaryNodeTokens = findLargestFeasibleNodeBudget(
+	const summaryNodeTokens = await findLargestFeasibleNodeBudget(
 		maximumNodeTokens,
 		items,
 		finalSummaryTokens,
@@ -101,18 +102,23 @@ export function calculateCommonNodeBudget(
 }
 
 /** Finds the largest monotonic node cap whose dry-run reduction reaches a final-fit suffix. */
-function findLargestFeasibleNodeBudget(
+async function findLargestFeasibleNodeBudget(
 	maximumNodeTokens: number,
 	items: readonly SourceItem[],
 	finalSummaryTokens: number,
 	options: AdaptiveCompactionOptions,
-): number {
+): Promise<number> {
 	let low = 1;
 	let high = maximumNodeTokens;
 	let best = 0;
 	while (low <= high) {
+		// Sequential binary-search probes depend on each other; Promise.all cannot parallelize them.
+		// biome-ignore lint/performance/noAwaitInLoops: cooperative event-loop yield is the point of this loop.
+		await options.onStep?.();
 		const candidate = Math.floor((low + high) / 2);
-		if (isNodeBudgetFeasible(candidate, items, finalSummaryTokens, options)) {
+		if (
+			await isNodeBudgetFeasible(candidate, items, finalSummaryTokens, options)
+		) {
 			best = candidate;
 			low = candidate + 1;
 		} else {
@@ -123,12 +129,12 @@ function findLargestFeasibleNodeBudget(
 }
 
 /** Simulates worst-case cap-sized nodes without issuing model requests. */
-function isNodeBudgetFeasible(
+async function isNodeBudgetFeasible(
 	summaryNodeTokens: number,
 	items: readonly SourceItem[],
 	finalSummaryTokens: number,
 	options: AdaptiveCompactionOptions,
-): boolean {
+): Promise<boolean> {
 	const previousSummary = items.find(
 		(item): item is SummaryNode => item.id === "previousSummary",
 	);
@@ -150,6 +156,9 @@ function isNodeBudgetFeasible(
 	);
 	let hasSummaryNode = previousSummary !== undefined;
 	while (hasSummaryNode || remainingOriginals.length > 0) {
+		// Sequential dry-run passes depend on the previous prefix; Promise.all cannot parallelize them.
+		// biome-ignore lint/performance/noAwaitInLoops: cooperative event-loop yield is the point of this loop.
+		await options.onStep?.();
 		if (
 			hasSummaryNode &&
 			doesSimulatedFinalRequestFit(
@@ -164,7 +173,7 @@ function isNodeBudgetFeasible(
 		if (remainingOriginals.length === 0) {
 			return false;
 		}
-		const fittingCount = findLargestFittingOriginalPrefix({
+		const fittingCount = await findLargestFittingOriginalPrefix({
 			items: remainingOriginals,
 			startIndex: 0,
 			originalCount: remainingOriginals.length,
@@ -212,20 +221,20 @@ function doesSimulatedFinalRequestFit(
 }
 
 /** Checks a final request with its full reserved output rather than input alone. */
-export function doesFinalRequestFit(
+export async function doesFinalRequestFit(
 	items: readonly SourceItem[],
 	finalSummaryTokens: number,
 	options: AdaptiveCompactionOptions,
-): boolean {
+): Promise<boolean> {
 	const context = buildSummaryContext(
 		items,
 		options.finalPrompt,
 		options.summarySystemPrompt,
 	);
+	const estimatedInputTokens = estimateSummaryInput(context, options);
+	await options.onStep?.();
 	return (
-		estimateSummaryInput(context, options) +
-			finalSummaryTokens +
-			options.safetyMarginTokens <=
+		estimatedInputTokens + finalSummaryTokens + options.safetyMarginTokens <=
 		options.summarizationModel.contextWindow
 	);
 }

--- a/pi-package/extensions/custom-compaction/adaptive-compaction-reduction.ts
+++ b/pi-package/extensions/custom-compaction/adaptive-compaction-reduction.ts
@@ -118,17 +118,20 @@ interface OriginalPrefixSelection {
 }
 
 /** Selects the largest oldest contiguous original range that fits one reduction request. */
-export function findLargestFittingOriginalPrefix({
+export async function findLargestFittingOriginalPrefix({
 	items,
 	startIndex,
 	originalCount,
 	summaryNodeTokens,
 	options,
-}: OriginalPrefixSelection): number {
+}: OriginalPrefixSelection): Promise<number> {
 	let low = 1;
 	let high = originalCount;
 	let best = 0;
 	while (low <= high) {
+		// Sequential binary-search probes depend on each other; Promise.all cannot parallelize them.
+		// biome-ignore lint/performance/noAwaitInLoops: cooperative event-loop yield is the point of this loop.
+		await options.onStep?.();
 		const middle = Math.floor((low + high) / 2);
 		const candidate = items.slice(startIndex, startIndex + middle);
 		if (doesReductionRequestFit(candidate, summaryNodeTokens, options)) {

--- a/pi-package/extensions/custom-compaction/adaptive-compaction.test.ts
+++ b/pi-package/extensions/custom-compaction/adaptive-compaction.test.ts
@@ -11,6 +11,7 @@ import {
 	type AdaptiveCompactionProgressEvent,
 	type AdaptiveCompactionRequest,
 	adaptiveCompactHistory,
+	createThrottledPlanningStep,
 } from "./adaptive-compaction";
 
 /** Detects useful whitespace inside serialized fragment text. */
@@ -264,6 +265,7 @@ describe("adaptiveCompactHistory", () => {
 		);
 		expect(progressEvents).toEqual([
 			{ type: "start" },
+			{ type: "planning" },
 			{ type: "operation", operation: "final" },
 			{ type: "complete", completedRequests: 1 },
 		]);
@@ -498,7 +500,8 @@ describe("adaptiveCompactHistory", () => {
 			remaining = remaining.slice(fragment.length);
 		}
 		expect(remaining).toBe("");
-	});
+		// Dense CJK tokenization exceeds Bun's 5s default test timeout once planning yields to the event loop.
+	}, 30_000);
 
 	/** Proves hierarchical merges reject non-reducing output through the configured retry policy. */
 	test("retries non-reducing adjacent merges without accepting a partial tree", async () => {
@@ -644,6 +647,7 @@ describe("adaptiveCompactHistory", () => {
 		);
 		expect(progressEvents).toEqual([
 			{ type: "start" },
+			{ type: "planning" },
 			{ type: "operation", operation: "final" },
 			{
 				type: "retry",
@@ -864,6 +868,121 @@ describe("adaptiveCompactHistory", () => {
 		await expect(adaptiveCompactHistory(options)).rejects.toThrow(
 			"common summary_node budget",
 		);
+		expect(requests).toHaveLength(0);
+	});
+
+	/** Proves planning calls the injected step callback while adaptive budgets are computed. */
+	test("invokes the injected step callback during budget computation", async () => {
+		// Purpose: planning must offer cooperative yield points so the event loop stays responsive.
+		// Input and expected output: an injected step callback is invoked while adaptive budgets are computed.
+		// Edge case: adaptive planning runs binary searches that previously had no yield points.
+		// Dependencies: the engine fixture and a deterministic step counter.
+		let stepCalls = 0;
+		const { options, progressEvents, requests } = createOptions({
+			preparation: {
+				messagesToSummarize: Array.from({ length: 20 }, (_, index) =>
+					userMessage(`BLOCK_${index}_${"old ".repeat(170)}`, index),
+				),
+				turnPrefixMessages: [],
+				tokensBefore: 10_000,
+			},
+			summarizationModel: {
+				id: "gpt-5",
+				provider: "openai",
+				contextWindow: 1_050,
+				maxTokens: 96,
+			},
+			onStep: async () => {
+				stepCalls += 1;
+			},
+			complete: async (request) => {
+				requests.push(request);
+				if (request.operation === "preliminary") {
+					return response(`INTERMEDIATE_${"compressed ".repeat(70)}`);
+				}
+				return response("adaptive-final");
+			},
+		});
+
+		// ACT: Compact through adaptive planning with an injected step observer.
+		await adaptiveCompactHistory(options);
+
+		// ASSERT: The step callback ran during planning and the planning event preceded every operation.
+		expect(stepCalls).toBeGreaterThan(0);
+		const planningIndex = progressEvents.findIndex(
+			(event) => event.type === "planning",
+		);
+		expect(planningIndex).toBeGreaterThanOrEqual(0);
+		const firstOperationIndex = progressEvents.findIndex(
+			(event) => event.type === "operation",
+		);
+		expect(planningIndex).toBeLessThan(firstOperationIndex);
+	});
+
+	/** Proves the default step actually releases the event loop during planning. */
+	test("yields to the event loop during planning through the default step", async () => {
+		// Purpose: the production default step (no injected onStep) must let a macrotask run before the first model request.
+		// Input and expected output: a setTimeout flag armed on the planning event fires before the first completion.
+		// Edge case: removing the default step's setTimeout yield keeps the promise chain microtask-only and leaves the flag unset.
+		// Dependencies: the synchronous engine fixture and the default throttled step.
+		let macrotaskFired = false;
+		let firedBeforeCompletion = false;
+		const { options, requests } = createOptions({
+			onProgress: (event) => {
+				if (event.type === "planning") {
+					setTimeout(() => {
+						macrotaskFired = true;
+					}, 0);
+				}
+			},
+			complete: async (request) => {
+				requests.push(request);
+				firedBeforeCompletion = macrotaskFired;
+				return response("final-summary");
+			},
+		});
+
+		// ACT: Compact through the direct path with only the default step.
+		await adaptiveCompactHistory(options);
+
+		// ASSERT: A macrotask queued by planning ran before the first model completion.
+		expect(firedBeforeCompletion).toBeTrue();
+		expect(requests).toHaveLength(1);
+	});
+
+	/** Proves the default step throws when the signal is already aborted. */
+	test("aborts the default throttled step on an aborted signal", async () => {
+		// Purpose: the production default step must honor the shared abort signal on every call.
+		// Input and expected output: a pre-aborted signal makes the step reject with AbortError.
+		// Edge case: the step is the only planning-time guard; model requests carry the same signal too.
+		// Dependencies: one pre-aborted AbortController and the exported step factory.
+		const controller = new AbortController();
+		controller.abort();
+		const step = createThrottledPlanningStep(controller.signal);
+
+		// ACT and ASSERT: The step throws AbortError without touching the event loop.
+		await expect(step()).rejects.toMatchObject({ name: "AbortError" });
+	});
+
+	/** Proves an aborted planning phase stops before any model request. */
+	test("aborts planning when the step observes an aborted signal", async () => {
+		// Purpose: escape must interrupt compaction while planning occupies the event loop.
+		// Input and expected output: a signal aborted inside the injected step stops planning before completion.
+		// Edge case: abort is delivered through the same signal that guards model requests.
+		// Dependencies: the engine fixture, one AbortController, and a step callback that aborts it.
+		const controller = new AbortController();
+		const { options, requests } = createOptions({
+			signal: controller.signal,
+			onStep: async () => {
+				controller.abort();
+				controller.signal.throwIfAborted();
+			},
+		});
+
+		// ACT and ASSERT: Planning rejects with AbortError and no model request starts.
+		await expect(adaptiveCompactHistory(options)).rejects.toMatchObject({
+			name: "AbortError",
+		});
 		expect(requests).toHaveLength(0);
 	});
 });

--- a/pi-package/extensions/custom-compaction/adaptive-compaction.ts
+++ b/pi-package/extensions/custom-compaction/adaptive-compaction.ts
@@ -44,6 +44,7 @@ export type AdaptiveCompactionOperation =
 /** Progress emitted by the functional core without depending on Pi UI contracts. */
 export type AdaptiveCompactionProgressEvent =
 	| { readonly type: "start" }
+	| { readonly type: "planning" }
 	| {
 			readonly type: "operation";
 			readonly operation: AdaptiveCompactionOperation;
@@ -108,6 +109,8 @@ export interface AdaptiveCompactionOptions {
 	readonly onProgress?: (
 		event: AdaptiveCompactionProgressEvent,
 	) => void | Promise<void>;
+	/** Cooperative event-loop yield invoked by planning and reduction loops during heavy computation. */
+	readonly onStep?: () => Promise<void>;
 	readonly complete: (
 		request: AdaptiveCompactionRequest,
 	) => Promise<AssistantMessage>;
@@ -129,6 +132,7 @@ export async function adaptiveCompactHistory(
 	const runtimeOptions: AdaptiveCompactionOptions = {
 		...options,
 		onProgress: emitProgress,
+		onStep: options.onStep ?? createThrottledPlanningStep(options.signal),
 	};
 	await emitProgress({ type: "start" });
 	validateOptions(runtimeOptions);
@@ -139,18 +143,23 @@ export async function adaptiveCompactHistory(
 	if (items.length === 0) {
 		throw new Error("adaptive compaction summary source is empty");
 	}
-	const finalBudget = calculateFinalSummaryBudget(runtimeOptions);
+	await emitProgress({ type: "planning" });
+	const finalBudget = await calculateFinalSummaryBudget(runtimeOptions);
 
 	// Direct final summarization is preferred because it avoids every lossy reduction step.
 	let summary: string;
 	if (
-		doesFinalRequestFit(items, finalBudget.finalSummaryTokens, runtimeOptions)
+		await doesFinalRequestFit(
+			items,
+			finalBudget.finalSummaryTokens,
+			runtimeOptions,
+		)
 	) {
 		summary = await executeFinalSummary(items, finalBudget, runtimeOptions);
 	} else {
 		const budgets: CompactionBudgets = {
 			...finalBudget,
-			summaryNodeTokens: calculateCommonNodeBudget(
+			summaryNodeTokens: await calculateCommonNodeBudget(
 				runtimeOptions,
 				items,
 				finalBudget.finalSummaryTokens,
@@ -169,6 +178,25 @@ export async function adaptiveCompactHistory(
 		completedRequests: logicalRequestCount,
 	});
 	return summary;
+}
+
+/** Minimum elapsed time between cooperative planning yields. */
+const PLANNING_YIELD_INTERVAL_MS = 100;
+
+/** Returns a throttled step that honors abort requests and yields to the event loop. */
+export function createThrottledPlanningStep(
+	signal: AbortSignal,
+): () => Promise<void> {
+	let lastYieldAt = 0;
+	return async () => {
+		signal.throwIfAborted();
+		const now = performance.now();
+		if (now - lastYieldAt < PLANNING_YIELD_INTERVAL_MS) {
+			return;
+		}
+		lastYieldAt = now;
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+	};
 }
 
 /** Normalizes the oldest previous summary before any original history reduction. */
@@ -199,7 +227,7 @@ async function reduceUntilFinalFits(
 	budgets: CompactionBudgets,
 	options: AdaptiveCompactionOptions,
 ): Promise<SourceItem[]> {
-	if (doesFinalRequestFit(items, budgets.finalSummaryTokens, options)) {
+	if (await doesFinalRequestFit(items, budgets.finalSummaryTokens, options)) {
 		return items;
 	}
 	if (findAdjacentSummaryNodes(items) >= 0) {
@@ -230,7 +258,7 @@ async function reduceOldestOriginalRange(
 	summaryNodeTokens: number,
 	options: AdaptiveCompactionOptions,
 ): Promise<void> {
-	const fittingCount = findLargestFittingOriginalPrefix({
+	const fittingCount = await findLargestFittingOriginalPrefix({
 		items,
 		startIndex: firstOriginalIndex,
 		originalCount: countContiguousOriginals(items, firstOriginalIndex),

--- a/pi-package/extensions/custom-compaction/index.test.ts
+++ b/pi-package/extensions/custom-compaction/index.test.ts
@@ -716,6 +716,10 @@ describe("custom-compaction", () => {
 					type: "info",
 				},
 				{
+					message: "[custom-compaction] planning compaction budgets...",
+					type: "info",
+				},
+				{
 					message: "[custom-compaction] creating final summary...",
 					type: "info",
 				},
@@ -1110,6 +1114,10 @@ describe("custom-compaction", () => {
 					type: "info",
 				},
 				{
+					message: "[custom-compaction] planning compaction budgets...",
+					type: "info",
+				},
+				{
 					message: "[custom-compaction] creating final summary...",
 					type: "info",
 				},
@@ -1161,6 +1169,10 @@ describe("custom-compaction", () => {
 			expect(session.notifications).toEqual([
 				{
 					message: "[custom-compaction] adaptive compaction started",
+					type: "info",
+				},
+				{
+					message: "[custom-compaction] planning compaction budgets...",
 					type: "info",
 				},
 				{

--- a/pi-package/extensions/custom-compaction/index.ts
+++ b/pi-package/extensions/custom-compaction/index.ts
@@ -731,10 +731,11 @@ async function reportProgress(
 	session.ui.notify(`${ISSUE_PREFIX} ${message}`, "info");
 	if (
 		event.type === "start" ||
+		event.type === "planning" ||
 		event.type === "complete" ||
 		(event.type === "source-projection" && event.completed === 0)
 	) {
-		// Pi repaints start and outcome states before synchronous work or lifecycle completion replaces them.
+		// Pi repaints start, planning, and outcome states before the next work phase or lifecycle completion replaces them.
 		await yieldToEventLoop();
 	}
 }
@@ -756,6 +757,8 @@ function formatProgressMessage(
 			return `retrying compaction-source projection: attempt ${event.nextAttempt}/${event.totalAttempts}`;
 		case "start":
 			return "adaptive compaction started";
+		case "planning":
+			return "planning compaction budgets...";
 		case "split":
 			return `splitting oversized history block into ${event.fragments} fragments`;
 		case "operation":


### PR DESCRIPTION
## Problem

During manual `/compact` on large sessions (~556k tokens), the adaptive compaction planning phase ran as one long synchronous CPU-bound stretch: it tokenized the whole corpus thousands of times (3 encodings per count for non-OpenAI providers) without yielding to the event loop. This blocked the Pi TUI for 30–90+ seconds: the spinner froze, escape did not respond, and the progress message went stale.

Root cause was verified by measurement: `calculateCommonNodeBudget` alone took 36.6–68.5 s of pure CPU with 0 heartbeat ticks during the run.

## Changes

### Responsive planning (`adaptive-compaction.ts`, `adaptive-compaction-budget.ts`, `adaptive-compaction-reduction.ts`)

- Added an optional `onStep?: () => Promise<void>` callback to `AdaptiveCompactionOptions`.
- `adaptiveCompactHistory` builds a default throttled step (`createThrottledPlanningStep`, ~100 ms interval) that checks `signal.throwIfAborted()` on every call and yields to the event loop once per interval.
- Planning functions (`calculateFinalSummaryBudget`, `doesFinalRequestFit`, `calculateCommonNodeBudget`, `findLargestFeasibleNodeBudget`, `isNodeBudgetFeasible`, `findLargestFittingOriginalPrefix`) are now async and await `options.onStep?.()` at their loop boundaries.
- Result: the 30–90 s block becomes a sequence of short steps; the spinner animates and the UI stays responsive. Computation order and values are unchanged — only scheduling is interleaved.

### Progress message (`adaptive-compaction.ts`, `index.ts`)

- New `{ type: "planning" }` progress event, emitted right before budget calculation.
- Rendered as `planning compaction budgets...` and included in the notification-yield set, so the message is painted before planning starts.
- Not counted as a model request — result statistics and outcome messages are unchanged.

### Abort during planning

- The default step runs `signal.throwIfAborted()` on every call, so escape (already wired through the compaction abort controller) now interrupts planning, not only LLM requests. `AbortError` propagates through the existing fallback path.

### Tests (`adaptive-compaction.test.ts`, `index.test.ts`)

- Updated progress-event and notification sequences for the new `planning` event.
- Added tests proving:
  - the injected step callback runs during budget computation;
  - the default throttled step actually yields a macrotask before the first model request (deterministic flag observer);
  - the default step throws `AbortError` on an aborted signal (direct unit test of the exported factory);
  - planning abort stops before any model request.
- Added a 30 s per-test timeout to the dense-tokenization test, which exceeds Bun's 5 s default once planning yields honestly to the event loop.

### Docs (`docs/extensions/custom-compaction.md`)

- Documented the new `planning compaction budgets...` message and that start, planning, and outcome notifications each yield one event-loop turn.

## Design notes

- The core builds the default step itself; `index.ts` does not inject it (dependency direction `index.ts` → core).
- Throttling is required: unthrottled yields at ~3–4k call sites would add seconds of overhead; the ~100 ms interval adds ~0.4–1.5 s for a 36 s planning run.
- A single full-corpus tokenization (~370 ms) remains an irreducible peak block — accepted by design (spinner briefly stutters, does not freeze).
- No changes to tokenization, budget algorithm, or shared `context-size.ts`.

## Verification

- `bun run verify` passes: **1175 tests pass / 0 fail**, `tsc --noEmit` clean, Biome clean (3 `noAwaitInLoops` warnings suppressed with `biome-ignore` justification — sequential dependent binary-search iterations, `Promise.all` impossible).
- Mutation testing proved the new abort and yield tests catch regressions in the default step.

## Out of scope (known follow-up)

- Reduction-phase tokenization (`splitOversizedText` for dense blocks) still runs synchronously — a separate future task.
- Live TUI spinner check in a real `pi` session is recommended before release.