### PR TITLE
Restore runtime settings during workflow branch navigation

### DIFF
--- a/docs/extensions/workflow.md
+++ b/docs/extensions/workflow.md
@@ -259,7 +259,9 @@ The active branch reconstructs state on session start and branch changes:
 - `activated` restores catalog-backed active state and its restoration settings;
 - `created` restores dynamic active state and its restoration settings;
 - `transitioned` updates the route of the preceding snapshot;
-- `completed` restores completed state without applying workflow model settings.
+- `completed` restores completed state and the persisted pre-workflow runtime settings without applying final-stage settings.
+
+When tree navigation leaves an active workflow, the extension reconstructs the target branch model from `model_change` entries or assistant messages and its thinking level from `thinking_level_change` entries. Target branch entries override the abandoned workflow restoration snapshot independently, so a branch that changes only model or only thinking retains that explicit value.
 
 The latest valid active snapshot remains available under every resolved policy after its catalog file is removed or the catalog becomes invalid. An invalid catalog prevents new creation and activation but does not block transitions of that saved active workflow. Earlier replaced dynamic workflows do not appear in activation options and cannot be reactivated.
 

--- a/docs/specs/issues/workflow-runtime-settings-restoration/technical-solution.md
+++ b/docs/specs/issues/workflow-runtime-settings-restoration/technical-solution.md
@@ -5,6 +5,7 @@
 - PRB-02: The final stage model and thinking level remain active when the next agent run starts.
 - PRB-03: The runtime has no persisted restoration snapshot for the model and thinking level that were active before workflow activation.
 - PRB-04: A solution based on a TUI dialog or message classification cannot serve autonomous subagents, RPC sessions, or print mode.
+- PRB-05: Pi tree navigation restores branch messages but can leave the model and thinking level from the abandoned workflow branch active.
 
 ## Proposed Solution
 
@@ -35,7 +36,7 @@
 
 ### SOL-04: Completed workflow projection
 - A completed workflow must not be projected as `<active_workflow>` in the next agent context.
-- The workflow extension must not apply completed-workflow model settings during `session_start` or `session_tree`.
+- The workflow extension must not apply final-stage settings for a completed workflow during `session_start` or `session_tree`; it applies the persisted restoration snapshot instead.
 - Workflow tools must expose only the operations allowed by the completed state. The completed route remains available for rework transitions.
 - A rework transition from a completed workflow changes the state back to `active`, applies the target stage settings, and persists the new route.
 - After rework, the workflow context contains the target stage instructions and available transitions again.
@@ -63,7 +64,18 @@
 - Add a replay test: a completed entry restores completed state and does not apply final-stage settings during session synchronization.
 - Add a rework test: a completed route can transition through an allowed rework edge and applies the target stage settings.
 - Add a non-interactive test covering a subagent or a context without UI methods. Completion must not call TUI APIs.
+- Add a branch-navigation test in which leaving an active workflow restores the model and thinking level selected by the target branch.
+- Add a partial branch-settings test in which a target `thinking_level_change` overrides thinking while the activation snapshot supplies the model.
 - Run the existing workflow, model-runtime, type-check, lint, and full validation suites after implementation.
+
+### SOL-08: Branch runtime reconciliation
+- Before replaying workflow state on `session_tree`, retain the state of the abandoned branch as a restoration fallback.
+- Reconstruct target-branch model selection from `model_change` entries and assistant-message provider/model fields, matching Pi session context semantics.
+- Reconstruct target-branch thinking from `thinking_level_change` entries that satisfy the shared reasoning-level contract.
+- Overlay target-branch entries on the abandoned workflow restoration snapshot so independently recorded model and thinking changes remain effective.
+- When the target branch has no active workflow, apply the reconstructed target settings through the workflow model restoration operation.
+- When the target branch contains a completed workflow, apply its persisted restoration snapshot instead of final-stage settings.
+- When the target branch contains an active workflow, apply the active stage settings through the existing workflow, agent, and restoration precedence.
 
 ## Overengineering and Overspecification Considerations
 - Completion is driven by the existing `agent_settled` lifecycle event and does not introduce a new classifier, model request, or user prompt.

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -1110,6 +1110,56 @@ describe("workflow extension lifecycle", () => {
 		).toEqual(["activated", "transitioned", "completed"]);
 	});
 
+	test("restores branch settings when leaving an active workflow branch", async () => {
+		// Purpose: session-tree navigation must restore the target branch runtime instead of leaking workflow settings.
+		// Inputs and expected output: a high-thinking branch activates an xhigh stage, then navigation before activation restores high.
+		// Edge case: the target branch contains no workflow-state entry.
+		// Dependencies: Pi session model/thinking entries, workflow activation, and lifecycle replay.
+		await createSuite(modelYaml());
+		const fake = await createFakePi();
+		fake.thinkingLevel = "high";
+		const branchBeforeActivation = [
+			{
+				type: "model_change",
+				provider: "openai",
+				modelId: "current-model",
+			},
+			{ type: "thinking_level_change", thinkingLevel: "high" },
+		];
+
+		await runLifecycle(fake, "session_start", branchBeforeActivation);
+		await requireTool(fake, "workflow_activate").execute("activate", {
+			workflowId: "delivery",
+		});
+		expect(fake.thinkingLevel).toBe("xhigh");
+
+		await runLifecycle(fake, "session_tree", branchBeforeActivation);
+
+		expect(fake.model?.id).toBe("current-model");
+		expect(fake.thinkingLevel).toBe("high");
+	});
+
+	test("merges partial branch settings with the workflow restoration snapshot", async () => {
+		// Purpose: branch navigation must preserve an explicit target thinking level even when that branch has no model entry.
+		// Inputs and expected output: activation captures current-model/high, while the target branch overrides only thinking to low.
+		// Edge case: model and thinking session entries are independently optional.
+		// Dependencies: workflow activation snapshot and lifecycle branch reconciliation.
+		await createSuite(modelYaml());
+		const fake = await createFakePi();
+		fake.thinkingLevel = "high";
+		await runLifecycle(fake, "session_start");
+		await requireTool(fake, "workflow_activate").execute("activate", {
+			workflowId: "delivery",
+		});
+
+		await runLifecycle(fake, "session_tree", [
+			{ type: "thinking_level_change", thinkingLevel: "low" },
+		]);
+
+		expect(fake.model?.id).toBe("current-model");
+		expect(fake.thinkingLevel).toBe("low");
+	});
+
 	/**
 	 * Proves replay of completed state does not reapply final-stage runtime settings.
 	 * Inputs and expected outputs: a completed branch is replayed into a fresh runtime and keeps the main model selected.

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -11,7 +11,10 @@ import {
 	MAIN_AGENT_CONTRIBUTION_CHANGE_EVENT,
 } from "../../shared/agent-runtime-composition";
 import { getSuiteExtensionDir } from "../../shared/agent-suite-storage";
-import type { ReasoningLevel } from "../../shared/reasoning-levels";
+import {
+	isReasoningLevel,
+	type ReasoningLevel,
+} from "../../shared/reasoning-levels";
 import {
 	singleLineTextSchema,
 	technicalIdentifierSchema,
@@ -72,6 +75,7 @@ import {
 	transitionWorkflow,
 	validateCreatedWorkflowDefinition,
 	type WorkflowDefinition,
+	type WorkflowRestorationSettings,
 	type WorkflowState,
 	withWorkflowRestoration,
 } from "./workflow";
@@ -545,9 +549,11 @@ function registerWorkflowLifecycle(options: WorkflowLifecycleOptions): void {
 			statusHolder.indicator ??= installWorkflowStatusIndicator(pi, ctx.ui);
 		}
 		try {
+			const branch = ctx.sessionManager.getBranch();
+			const previousState = runtime.state;
 			synchronizeWorkflowRuntime({
 				pi,
-				branch: ctx.sessionManager.getBranch(),
+				branch,
 				runtime,
 				catalogResult,
 				promptError,
@@ -555,7 +561,7 @@ function registerWorkflowLifecycle(options: WorkflowLifecycleOptions): void {
 				model: ctx.model,
 				modelRegistry: ctx.modelRegistry,
 			});
-			await synchronizeWorkflowModelRuntime(pi, runtime);
+			await synchronizeWorkflowModelRuntime(pi, runtime, branch, previousState);
 		} finally {
 			publishWorkflowStatus(statusHolder.indicator, runtime);
 		}
@@ -769,18 +775,87 @@ function synchronizeWorkflowRuntime(
 	}
 }
 
-/** Applies settings for the restored active stage without changing workflow state. */
+/** Reads the model selected by one session entry. */
+function readBranchModelId(candidate: unknown): string | undefined {
+	if (candidate === null || typeof candidate !== "object") {
+		return undefined;
+	}
+	const entry = candidate as Record<string, unknown>;
+	if (
+		entry["type"] === "model_change" &&
+		typeof entry["provider"] === "string" &&
+		typeof entry["modelId"] === "string"
+	) {
+		return `${entry["provider"]}/${entry["modelId"]}`;
+	}
+	const message = entry["message"];
+	if (
+		entry["type"] !== "message" ||
+		message === null ||
+		typeof message !== "object"
+	) {
+		return undefined;
+	}
+	const assistant = message as Record<string, unknown>;
+	return assistant["role"] === "assistant" &&
+		typeof assistant["provider"] === "string" &&
+		typeof assistant["model"] === "string"
+		? `${assistant["provider"]}/${assistant["model"]}`
+		: undefined;
+}
+
+/** Reads the thinking level selected by one session entry. */
+function readBranchThinking(candidate: unknown): ReasoningLevel | undefined {
+	if (candidate === null || typeof candidate !== "object") {
+		return undefined;
+	}
+	const entry = candidate as Record<string, unknown>;
+	return entry["type"] === "thinking_level_change" &&
+		isReasoningLevel(entry["thinkingLevel"])
+		? entry["thinkingLevel"]
+		: undefined;
+}
+
+/** Reconstructs target-branch runtime settings over the activation snapshot. */
+function resolveBranchRestoration(
+	branch: readonly unknown[],
+	fallback: WorkflowRestorationSettings | undefined,
+): WorkflowRestorationSettings | undefined {
+	let modelId = fallback?.modelId;
+	let thinking = fallback?.thinking;
+	for (const entry of branch) {
+		modelId = readBranchModelId(entry) ?? modelId;
+		thinking = readBranchThinking(entry) ?? thinking;
+	}
+	return modelId !== undefined && thinking !== undefined
+		? { modelId, thinking }
+		: undefined;
+}
+
 async function synchronizeWorkflowModelRuntime(
 	pi: ExtensionAPI,
 	runtime: WorkflowRuntime,
+	branch: readonly unknown[],
+	previousState: WorkflowState | undefined,
 ): Promise<void> {
 	const state = runtime.state;
-	const stageId = state?.route.at(-1);
-	if (
-		state === undefined ||
-		state.status === "completed" ||
-		stageId === undefined
-	) {
+	if (state === undefined || state.status === "completed") {
+		const restoration =
+			state?.restoration ??
+			resolveBranchRestoration(branch, previousState?.restoration);
+		if (restoration !== undefined) {
+			const application = await applyWorkflowModelRestoration(
+				pi,
+				runtime.modelRegistry,
+				runtime.currentModel,
+				restoration,
+			);
+			runtime.currentModel = application.currentModel;
+		}
+		return;
+	}
+	const stageId = state.route.at(-1);
+	if (stageId === undefined) {
 		return;
 	}
 	const resolution = resolveWorkflowModelSettings({


### PR DESCRIPTION
## Problem
Navigating away from an active workflow branch could leave its model and thinking level active, instead of restoring the settings selected by the target branch.

## Solution
Reconcile target-branch model and thinking entries with the workflow restoration snapshot during tree navigation. Restore completed workflows from their saved settings, preserve partial branch overrides, and document the behavior.

## Testing
- Added tests for restoring branch settings after leaving an active workflow.
- Added tests for merging partial branch settings with the workflow restoration snapshot.