### PR TITLE
Add on-demand MCP toolsets and unified tool composition

### DIFF
--- a/docs/extensions/mcp-wrapper.md
+++ b/docs/extensions/mcp-wrapper.md
@@ -34,7 +34,8 @@ By default, place the configuration at `agent-suite/mcp-wrapper/config.json`. If
       "onDemand": {
         "name": "workspace-files",
         "description": "Activate for workspace file operations."
-      }
+      },
+      "additionalInstructions": "Use file tools for workspace operations.\nKeep changes scoped to the requested files."
     },
     "docs": {
       "type": "streamableHttp",
@@ -95,6 +96,7 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `env` | No | Object with string values | `{}` | Environment variables for the server process. Values are literal strings. Configured values override inherited environment variables with the same name. |
 | `cwd` | No | String | Not set by the extension | Working directory for the server process. |
 | `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
+| `additionalInstructions` | No | String | Not set | Local instructions shown only when a tool from this server is final-active. JSON `\n` escapes represent newlines. |
 
 `streamableHttp` server parameters:
 
@@ -104,12 +106,17 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `url` | Yes | Non-empty string | None | MCP server URL. |
 | `headers` | No | Object with string values | `{}` | HTTP headers sent to the MCP server. Values are literal strings. |
 | `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
+| `additionalInstructions` | No | String | Not set | Local instructions shown only when a tool from this server is final-active. JSON `\n` escapes represent newlines. |
 
 ## Config rules
 
 - Only the parameters listed above are supported.
 - Placeholders such as `${VAR}` and `$env:VAR` are not expanded.
 - Commands, arguments, environment values, headers, and URLs are used as written.
+- `additionalInstructions` is omitted when absent, empty, or whitespace-only. Nonblank text is preserved as written, including surrounding whitespace and newlines.
+- When both server-provided MCP instructions and `additionalInstructions` exist, server-provided text comes first, followed by one blank line and local text.
+- Local instructions are included only when at least one generated Pi tool from that server remains in the runtime's final active tool set. Registration alone is not sufficient.
+- Changing only `additionalInstructions` does not invalidate cached MCP metadata or trigger discovery; the text is read from configuration on the next startup.
 - Changing only `onDemand.name` or `onDemand.description` does not invalidate cached MCP metadata.
 
 ## On-demand toolsets

--- a/docs/extensions/mcp-wrapper.md
+++ b/docs/extensions/mcp-wrapper.md
@@ -30,7 +30,11 @@ By default, place the configuration at `agent-suite/mcp-wrapper/config.json`. If
       "env": {
         "EXAMPLE_TOKEN": "value"
       },
-      "cwd": "/tmp"
+      "cwd": "/tmp",
+      "onDemand": {
+        "name": "workspace-files",
+        "description": "Activate for workspace file operations."
+      }
     },
     "docs": {
       "type": "streamableHttp",
@@ -90,6 +94,7 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `args` | No | Array of strings | `[]` | Arguments passed to `command` unchanged. |
 | `env` | No | Object with string values | `{}` | Environment variables for the server process. Values are literal strings. Configured values override inherited environment variables with the same name. |
 | `cwd` | No | String | Not set by the extension | Working directory for the server process. |
+| `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
 
 `streamableHttp` server parameters:
 
@@ -98,18 +103,45 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `type` | Yes | `"streamableHttp"` | None | Connects to an MCP server over streamable HTTP. |
 | `url` | Yes | Non-empty string | None | MCP server URL. |
 | `headers` | No | Object with string values | `{}` | HTTP headers sent to the MCP server. Values are literal strings. |
+| `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
 
 ## Config rules
 
 - Only the parameters listed above are supported.
 - Placeholders such as `${VAR}` and `$env:VAR` are not expanded.
 - Commands, arguments, environment values, headers, and URLs are used as written.
+- Changing only `onDemand.name` or `onDemand.description` does not invalidate cached MCP metadata.
+
+## On-demand toolsets
+
+Add `onDemand` to a `stdio` or `streamableHttp` server to defer that server's tools until the model activates its toolset:
+
+```json
+"onDemand": {
+  "name": "workspace-files",
+  "description": "Activate for workspace file operations."
+}
+```
+
+`onDemand` accepts exactly `name` and `description`. Each is a trimmed, non-empty string. Names are unique across `mcpServers` with exact, case-sensitive matching. Invalid declarations disable `mcp-wrapper` for the session and show its startup warning; pi continues to start.
+
+A server without `onDemand` is eager: its loaded tools are available under the normal MCP behavior. A deferred server's generated definitions are registered once its metadata loads, but its tools and MCP instructions remain unavailable until activation. A deferred server with unavailable metadata has no trigger or activation route; normal MCP startup diagnostics report the metadata failure.
+
+`activate_toolset` is available only if it is allowed for the current agent and a loaded, still-deferred toolset has at least one tool allowed for that agent. Activation is exact and case-sensitive. It exposes only that agent's allowed tools, is idempotent for an active toolset, and leaves the toolset deferred when activation fails. It disappears after the final eligible toolset is activated. Activation state is local to the pi session and active history branch; main and subagent sessions do not share it. A resumed branch restores its last valid activation snapshot; stale names from changed configuration are warned about and ignored.
+
+The activation result gives the model the status and complete list of currently available tool names, without tool parameters or descriptions. In both main-agent and subagent screens, collapsed rendering shows the status, count, and shortened list; expanded rendering shows the complete list.
+
+Activation uses already loaded MCP metadata. It does not create a separate MCP connection; normal MCP tool execution retains connection readiness and routing behavior.
 
 ## Manual cache refresh
 
 Use `/mcp-refresh` to rebuild cached MCP tool metadata from the configured servers.
 
-The command ignores the existing cache, discovers tools from every configured server, writes a new `cache.json`, and reloads the pi runtime. The reload applies added tools and removes tools that no longer exist.
+The command ignores the existing cache, discovers tools from every configured server, writes a new `cache.json`, and reloads the pi runtime. The replacement catalog applies additions and suppresses removed or obsolete MCP tool names. A newly loaded deferred server can then acquire a trigger; a removed or unavailable deferred server has none.
+
+## Active-tool composition
+
+`AgentRuntimeComposition` is the single owner of final active-tool reconciliation. It starts with a stable baseline order and applies main-agent, child/depth, workflow, vision, and deferred-toolset restrictions as remove-only layers. A tool restored after a restriction is lifted returns to its baseline position; no layer can add or reorder an upstream-excluded tool.
 
 ## Tool names
 

--- a/docs/extensions/mcp-wrapper.md
+++ b/docs/extensions/mcp-wrapper.md
@@ -129,7 +129,7 @@ A server without `onDemand` is eager: its loaded tools are available under the n
 
 `activate_toolset` is available only if it is allowed for the current agent and a loaded, still-deferred toolset has at least one tool allowed for that agent. Activation is exact and case-sensitive. It exposes only that agent's allowed tools, is idempotent for an active toolset, and leaves the toolset deferred when activation fails. It disappears after the final eligible toolset is activated. Activation state is local to the pi session and active history branch; main and subagent sessions do not share it. A resumed branch restores its last valid activation snapshot; stale names from changed configuration are warned about and ignored.
 
-The activation result gives the model the status and complete list of currently available tool names, without tool parameters or descriptions. In both main-agent and subagent screens, collapsed rendering shows the status, count, and shortened list; expanded rendering shows the complete list.
+The activation result gives the model the status and complete list of currently available tool names, without tool parameters or descriptions. Main-agent and subagent screens render the status followed by comma-separated tool names. Collapsed rendering shows at most two wrapped content lines, adds an ellipsis when content is hidden, and reports the exact number of hidden lines; expanded rendering shows the complete wrapped list without truncation.
 
 Activation uses already loaded MCP metadata. It does not create a separate MCP connection; normal MCP tool execution retains connection readiness and routing behavior.
 

--- a/docs/extensions/run-subagent.md
+++ b/docs/extensions/run-subagent.md
@@ -381,6 +381,8 @@ A timeout, a no-active result, or feedback from an unselected child does not cha
 
 ## Pi cancellation
 
+When the main Pi agent run ends with a final assistant `stopReason` of `aborted`, the root runtime stops every active child in its complete ownership hierarchy. Active waits cease, each affected invocation becomes terminal abort, forced-abort feedback is withheld, and saved logical sessions remain available for later continuation. The root runtime and its writer remain active for the next user prompt; only `session_shutdown` disposes them.
+
 Pi cancellation uses one ordering boundary for each root or nested operation:
 
 - A start or terminal-session steer is ordered against prompt acceptance.

--- a/docs/extensions/run-subagent.md
+++ b/docs/extensions/run-subagent.md
@@ -357,7 +357,7 @@ The auxiliary model request runs in the Pi process of the calling agent. That pr
 
 The same root transport also carries closed knowledge read, mutation-acquire, mutation-release, and cancellation requests. Knowledge payloads never include model credentials or prompts. The root knowledge coordinator releases queued or active work when a child runtime disconnects or stops.
 
-The query does not retry, truncate the branch, read process-local projection replacements, or merge current loaded-skill state. A missing or empty saved session, invalid branch, unavailable model or authentication, oversized input, provider failure, or empty text response fails with `query_failed`.
+The query does not retry, truncate the branch, read process-local projection replacements, or merge current loaded-skill state. A missing or empty saved session, invalid branch, unavailable model or authentication, oversized input, provider failure, or empty text response fails with `query_failed`. Provider error responses and completion exceptions retain their available diagnostic message after the public error sanitization boundary.
 
 ## Feedback delivery
 

--- a/docs/extensions/system-prompt.md
+++ b/docs/extensions/system-prompt.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`system-prompt` replaces pi's base system prompt with a Markdown template. The template can include runtime values such as the current date, working directory, active tool text, and loaded project context.
+`system-prompt` replaces pi's base system prompt with a Markdown template. The template can include runtime values such as the current date, working directory, active tool text, deferred-toolset triggers, and loaded project context.
 
 ## Configuration
 
@@ -39,17 +39,21 @@ Supported variables:
 | `{{date}}` | Local date in `YYYY-MM-DD` format. |
 | `{{cwd}}` | Current working directory with `/` path separators. |
 | `{{tools}}` | Active tools that have prompt text, formatted as `- name: text`. If no matching tools are available, inserts `(none)`. |
+| `{{toolsets}}` | Eligible deferred toolsets as `<toolsets>` XML, one `<toolset name="…" description="…"/>` per entry. It is empty when none are eligible. Attribute values XML-escape `&`, `<`, `>`, `"`, and `'`. |
 | `{{toolGuidelines}}` | Prompt guidelines supplied by active tools or extensions, one bullet per guideline. |
 | `{{appendSystemPrompt}}` | Text passed through pi append-system-prompt inputs. |
 | `{{contextFiles}}` | Loaded context files inside `<project_specific_instructions>` XML-style blocks. |
 | `{{skills}}` | Loaded skills formatted by pi when the `read` tool is active. |
 
-Unsupported variables are removed from the rendered prompt.
+Unsupported variables are removed from the rendered prompt. `{{toolsets}}` is expanded only where the template contains it: a custom template that omits it receives no trigger catalog. Before values are built, active tools are reconciled; the catalog contains only loaded, still-deferred toolsets with at least one tool allowed for the current agent.
 
 ## Template example
 
 ```md
 You are an expert coding assistant.
+
+Available toolsets:
+{{toolsets}}
 
 Available tools:
 {{tools}}

--- a/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_plan.md
+++ b/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_plan.md
@@ -1,0 +1,243 @@
+# Delivery Plan: Conditional Local Instructions for MCP Servers
+
+Implement the approved `additionalInstructions` configuration field without changing MCP discovery, active-tool reconciliation, or the metadata cache schema.
+
+## Key Definitions and Abbreviations
+
+- DEF-01: **Local MCP instructions** are the nonblank `additionalInstructions` string from one parsed MCP server configuration.
+- DEF-02: **Server-provided MCP instructions** are instructions returned by the MCP server during initialization.
+- DEF-03: **Eligible server** is an MCP server with at least one accepted Pi tool in the runtime catalog.
+- DEF-04: **Visible server** is an eligible server with at least one Pi tool in the current runtime's final `pi.getActiveTools()` result.
+
+## Delivery Strategy
+
+- STR-01: Ship the behavior as an additive configuration capability controlled by the presence of `mcpServers.<server>.additionalInstructions`; no feature flag or data migration is needed.
+- STR-02: Keep local MCP instructions in parsed configuration state and out of discovered metadata and persisted metadata cache state.
+- STR-03: Follow RED-GREEN-REFACTOR because the change affects configuration parsing and runtime system-prompt behavior.
+
+## Approach Evaluation
+
+### APP-01: Extend the Existing Instruction Record Builder — Selected
+
+- APP-01-C: Complexity is low: update the strict parser, cache hash projection, instruction record builder, and one caller.
+- APP-01-M: Maintainability is high because one record, one active-tool filter, and one renderer remain responsible for both instruction sources.
+- APP-01-P: Runtime cost remains one startup-time grouping pass and one existing prompt-time active-tool scan; the design adds no I/O or event handler.
+- APP-01-R: The main risks are source ordering, whitespace preservation, and accidental cache coupling; focused behavior tests cover each risk.
+
+### APP-02: Add a Separate Local-Instruction Prompt Handler — Rejected
+
+- APP-02-C: Complexity is higher because state clearing, server-to-tool mapping, active-tool filtering, escaping, and rendering are duplicated.
+- APP-02-M: Maintainability is lower because two handlers can produce duplicate `<mcp_instructions>` or `<server>` blocks.
+- APP-02-P: Every prompt start performs an additional scan and render path.
+- APP-02-R: Handler ordering becomes a new behavior contract without solving a product requirement.
+
+### APP-03: Inject Local Instructions into Discovery Metadata — Rejected
+
+- APP-03-C: Complexity is higher because local-only servers still require reconstruction after discovery or cache loading.
+- APP-03-M: Maintainability is lower because configuration-authored prompt text becomes coupled to MCP discovery and persisted metadata.
+- APP-03-P: Runtime cost is similar to APP-01, but cache identity and refresh behavior become easier to regress.
+- APP-03-R: The approach conflicts with the requirement that local instructions neither enter the metadata cache nor invalidate it.
+
+## Main Changes
+
+- CHG-01: Extend `McpServerConfig` and both transport parsers in [`config.ts`](../../../../pi-package/extensions/mcp-wrapper/config.ts) with strict `additionalInstructions` handling.
+- CHG-02: Exclude `additionalInstructions` from `computeMcpServerConfigHash` in [`metadata-cache.ts`](../../../../pi-package/extensions/mcp-wrapper/metadata-cache.ts).
+- CHG-03: Extend `buildActiveServerInstructions` and its session-start caller in [`index.ts`](../../../../pi-package/extensions/mcp-wrapper/index.ts) to assemble one combined record per eligible server.
+- CHG-04: Preserve `registerMcpInstructionPromptHandler`, `renderMcpInstructions`, and final active-tool ownership in [`agent-runtime-composition.ts`](../../../../pi-package/shared/agent-runtime-composition.ts).
+- CHG-05: Update behavior tests and [`docs/extensions/mcp-wrapper.md`](../../../extensions/mcp-wrapper.md).
+
+## Entities and Invariants
+
+- INV-01: A server contributes at most one `ServerInstructionRecord`.
+- INV-02: Server-provided text precedes local text; two present sources are separated by exactly one blank line.
+- INV-03: `trim()` determines only whether local text is blank. A nonblank value retains its original bytes for rendering.
+- INV-04: A record exists only for an eligible server with at least one nonblank instruction source.
+- INV-05: A record renders only for a visible server.
+- INV-06: `CachedMcpServerMetadata` and the metadata cache version do not change.
+
+## New Folders and Components
+
+- NEW-01: No new production folder, component, event handler, cache field, or composition layer is introduced.
+
+## Phased Plan
+
+### Phase Tree
+
+```mermaid
+---
+config:
+  layout: elk
+  flowchart:
+    wrappingWidth: 700
+    htmlLabels: true
+---
+flowchart TD
+  P1["`**PH-01**
+  RED tests`"] --> P2["`**PH-02**
+  GREEN implementation`"]
+  P2 --> P3["`**PH-03**
+  Refactor and cleanup`"]
+  P3 --> P4["`**PH-04**
+  Independent verification`"]
+```
+
+### Decomposition Justification
+
+- DEC-01: PH-01 intentionally ends with assertion failures because a passing RED phase would not prove that the tests exercise missing behavior.
+- DEC-02: Parser, cache identity, and record assembly enter GREEN together because they form one configuration-to-prompt path; splitting them would create nonfunctional intermediate production states.
+- DEC-03: Refactoring, documentation, and cleanup follow GREEN so behavior-preserving changes run against passing tests.
+- DEC-04: Independent verification remains separate from implementation to test package loading and real runtime prompt/tool state rather than only unit-test fakes.
+
+## Overengineering and Overspecification Considerations
+
+- OVR-01: The plan reuses the existing parser patterns, record type, prompt handler, renderer, and active-tool filter.
+- OVR-02: The plan excludes arrays, file references, templates, per-agent overrides, new cache data, and new composition abstractions because the approved requirements do not need them.
+- OVR-03: Tests target public configuration and prompt behavior rather than helper implementation details or arbitrary prompt wording.
+
+### Phase PH-01 — RED Behavior Tests
+
+#### Goal
+
+- PH-01-G: Establish failing behavior contracts before production implementation.
+
+#### Work
+
+- PH-01-W1: Extend [`config.test.ts`](../../../../pi-package/extensions/mcp-wrapper/config.test.ts) for both transports: preserve nonblank multiline text, omit empty and whitespace-only text, and reject defined non-string values.
+- PH-01-W2: Extend [`metadata-cache.test.ts`](../../../../pi-package/extensions/mcp-wrapper/metadata-cache.test.ts) to prove that changing only `additionalInstructions` preserves the configuration hash while changing a connection field changes it.
+- PH-01-W3: Extend [`index.test.ts`](../../../../pi-package/extensions/mcp-wrapper/index.test.ts) for local-only instructions, server-provided-then-local ordering, no accepted tool, no active matching tool, deferred activation, and later startup state clearing.
+- PH-01-W4: Extend [`mcp-wrapper-system-prompt.test.ts`](../../../../test/integration/mcp-wrapper-system-prompt.test.ts) to prove final-active filtering after system-prompt replacement and for a restrictive child-agent tool policy.
+- PH-01-W5: Run the changed test files and record assertion failures caused by missing `additionalInstructions` behavior; compilation, fixture, timeout, or dependency failures do not satisfy RED.
+
+#### Deliverables
+
+- PH-01-D: Compiling behavior tests that fail only at the new expected outcomes.
+
+#### Exit Criteria
+
+- PH-01-E1: Every added test reaches its designated assertion and fails because production behavior is absent.
+- PH-01-E2: Tests use existing fakes, isolated fixtures, and explicit configured instruction text.
+
+#### Risks
+
+- PH-01-R: Over-testing internal helpers would make refactoring costly; tests assert parsed output, hash identity, final prompt content, source order, and visibility only.
+
+### Phase PH-02 — GREEN Minimum Implementation
+
+#### Goal
+
+- PH-02-G: Make the PH-01 behavior tests pass with the smallest coherent production change.
+
+#### Work
+
+- PH-02-W1: Add the optional field, allowed keys, type validation, blank detection, and original-text preservation in [`config.ts`](../../../../pi-package/extensions/mcp-wrapper/config.ts).
+- PH-02-W2: Remove `additionalInstructions` from the connection identity projection in `computeMcpServerConfigHash` without changing cache parsing, serialization, or version.
+- PH-02-W3: Assemble combined instruction records from parsed server configurations, server-provided instructions, and accepted catalog tools in `buildActiveServerInstructions`.
+- PH-02-W4: Pass parsed MCP server configurations from `handleSessionStart` to the record builder; leave the prompt handler, renderer, and `AgentRuntimeComposition` unchanged.
+- PH-02-W5: Run focused tests after each cohesive change, then all `mcp-wrapper` tests.
+
+#### Deliverables
+
+- PH-02-D: Working configuration-to-prompt behavior with no new runtime or persistence subsystem.
+
+#### Exit Criteria
+
+- PH-02-E1: All PH-01 tests and existing `mcp-wrapper` tests pass.
+- PH-02-E2: A combined server renders one block, and a server without an accepted tool renders no local instructions.
+
+#### Risks
+
+- PH-02-R1: Adding the field to the config hash would cause unnecessary discovery; the hash test prevents this regression.
+- PH-02-R2: Iterating only server-provided records would omit local-only servers; the local-only prompt test prevents this regression.
+
+### Phase PH-03 — REFACTOR, Documentation, and Cleanup
+
+#### Goal
+
+- PH-03-G: Simplify the passing implementation and remove implementation residue without changing behavior.
+
+#### Work
+
+- PH-03-W1: Extract one small parser helper only when it removes duplicated transport validation while keeping the configuration contract explicit.
+- PH-03-W2: Remove temporary scaffolding, debug output, test-only production branches, duplicate record paths, dead helpers, stale comments, workarounds, linter suppressions, and code slop introduced during implementation.
+- PH-03-W3: Update [`docs/extensions/mcp-wrapper.md`](../../../extensions/mcp-wrapper.md) with the field, JSON `\n` notation, blank-value behavior, source order, final-active condition, and cache-hash behavior.
+- PH-03-W4: Run focused tests, `bun run typecheck`, and `bun run check` after refactoring and documentation changes.
+
+#### Deliverables
+
+- PH-03-D1: Readable production code with one instruction assembly path.
+- PH-03-D2: Updated extension documentation matching the tested contract.
+
+#### Exit Criteria
+
+- PH-03-E1: Focused tests, typecheck, and check pass.
+- PH-03-E2: No temporary implementation or debugging artifacts remain.
+
+#### Risks
+
+- PH-03-R: Premature helper extraction can obscure the two transport parsers; retain inline code when a helper does not materially reduce duplication.
+
+### Phase PH-04 — Independent Verification
+
+#### Goal
+
+- PH-04-G: Verify the completed change through repository-wide checks and real Pi runtime data.
+
+#### Work
+
+- PH-04-W1: Run `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify`. Do not invent build or coverage commands because the repository declares neither script.
+- PH-04-W2: From `pi-package`, validate single-extension and whole-package loading with the project-prescribed `pi --no-session -p -e` commands and extension isolation flags.
+- PH-04-W3: Use temporary configuration, state, and a temporary debug extension to capture `before_agent_start.systemPrompt` and `pi.getActiveTools()` for main-agent and child-agent paths.
+- PH-04-W4: Inspect runtime captures for local-only visibility with a matching final-active tool, combined source order, omission under a restrictive child policy, and one server block.
+- PH-04-W5: Remove all temporary verification files and state.
+
+#### Deliverables
+
+- PH-04-D: Command results and inspected runtime evidence for the final behavior.
+
+#### Exit Criteria
+
+- PH-04-E1: Repository-wide scripts and both Pi loading checks exit successfully.
+- PH-04-E2: Main-agent and child-agent runtime captures satisfy PH-04-W4.
+- PH-04-E3: Temporary verification artifacts are removed.
+
+#### Risks
+
+- PH-04-R: Global extensions or persistent state can contaminate runtime evidence; isolate extensions and use temporary working and state directories.
+
+## Test Strategy
+
+- TST-01: Parser unit tests own field type, blank detection, and original-text preservation.
+- TST-02: Metadata-cache unit tests own cache identity exclusion.
+- TST-03: Extension behavior tests own record assembly, lifecycle clearing, deferred activation, and prompt rendering.
+- TST-04: Integration tests own final active-tool filtering after all prompt and child-agent composition layers.
+- TST-05: Real Pi checks own package loading and actual prompt/tool availability; they do not replace isolated automated tests.
+
+## Dependencies and Resourcing
+
+- DEP-01: No new package, service, network dependency, migration, or persistent schema is required.
+- DEP-02: Implementation uses Bun scripts and the installed Pi CLI defined by repository guidance.
+
+## Project Definition of Done
+
+- DOD-01: Approved configuration, merge, visibility, whitespace, and cache behavior is implemented and documented.
+- DOD-02: Focused, repository-wide, loading, and real runtime checks pass.
+- DOD-03: No workaround, fallback, temporary branch, debug artifact, linter suppression, or unrelated refactor remains.
+
+## Assumptions
+
+- ASM-01: The repository's existing child-agent runtime path can produce the restrictive-tool runtime required by PH-04-W3. Verification occurs while constructing the temporary runtime check before accepting PH-04.
+
+## Open Questions
+
+- OQ-01: None.
+
+## Standards Deviations
+
+- DEV-01: None.
+
+## References
+
+- REF-01: [`mcp_wrapper_additional_instructions_problem.md`](mcp_wrapper_additional_instructions_problem.md) - approved problem and glossary.
+- REF-02: [`mcp_wrapper_additional_instructions_prd.md`](mcp_wrapper_additional_instructions_prd.md) - approved behavior requirements.
+- REF-03: [`mcp_wrapper_additional_instructions_solution.md`](mcp_wrapper_additional_instructions_solution.md) - approved technical solution.
+- REF-04: [`AGENTS.md`](../../../../AGENTS.md) - repository development, testing, and validation rules.

--- a/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_prd.md
+++ b/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_prd.md
@@ -1,0 +1,58 @@
+# Idea: Conditional Local Instructions for MCP Servers
+
+## Definitions
+
+- **MCP server:** A server configured in `mcp-wrapper` that provides one or more MCP tools.
+- **Pi tool:** The Pi representation of an MCP tool registered by `mcp-wrapper`.
+- **Active Pi tool:** A Pi tool present in `pi.getActiveTools()` for an agent runtime after all tool restrictions are applied.
+- **Agent runtime:** A separate Pi instance that determines its own active Pi tools and system prompt for a main agent or child agent.
+- **Server-provided MCP instructions:** Instructions returned by an MCP server during initialization.
+- **Local MCP instructions:** Instructions associated with a specific MCP server and defined by an agent suite administrator.
+
+## Context and Problem
+
+`mcp-wrapper` conditionally adds server-provided MCP instructions to an agent's system prompt. An agent suite administrator cannot define equivalent local MCP instructions whose visibility follows the final active Pi tools of each agent runtime.
+
+## Goal
+
+Allow an agent suite administrator to define local MCP instructions that each agent runtime receives exactly when at least one Pi tool from the corresponding MCP server is active.
+
+## Scenarios
+
+- An MCP server has an active Pi tool and non-empty local MCP instructions. The final system prompt contains both its server-provided MCP instructions and local MCP instructions.
+- An MCP server has no active Pi tools. The final system prompt omits its local MCP instructions.
+- An MCP server has absent or empty local MCP instructions. The value is treated as not configured.
+
+## Scope and Non-Scope
+
+In scope:
+
+- One local MCP instruction string for each configured MCP server.
+- Conditional visibility based on final active Pi tools in each agent runtime.
+- Coexistence of local and server-provided MCP instructions.
+
+Out of scope:
+
+- Replacing server-provided MCP instructions.
+- Changing active-tool reconciliation.
+- Defining multiple local instruction entries for one MCP server.
+
+## Requirements
+
+- Each `mcpServers.<server>` configuration accepts an optional `additionalInstructions` field containing a multiline string.
+- An agent runtime includes an MCP server's local MCP instructions in its final system prompt exactly when `pi.getActiveTools()` contains at least one Pi tool registered from that MCP server.
+- When local and server-provided MCP instructions exist for the same MCP server, the final system prompt includes both.
+- An absent or empty `additionalInstructions` string is treated as local MCP instructions not being configured.
+
+## Open Questions
+
+None.
+
+## Technical Supplement
+
+Excluded. Implementation design belongs to the technical solution.
+
+## References
+
+- `docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_problem.md`
+- `docs/extensions/mcp-wrapper.md`

--- a/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_problem.md
+++ b/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_problem.md
@@ -1,0 +1,91 @@
+# Problem Statement
+
+## Context
+
+`mcp-wrapper` registers MCP server tools as Pi tools. Each agent runtime determines its final active Pi tools after applying main-agent policy, child and depth policy, workflow restrictions, vision restrictions, and on-demand activation.
+
+## Problem Statement
+
+An agent suite administrator cannot define local instructions for a specific MCP server so that an agent receives those instructions only when at least one Pi tool from that MCP server is available to that agent.
+
+## Who is affected
+
+Developers and administrators who configure `mcp-wrapper` and agent system prompts in an agent suite.
+
+## Evidence
+
+- `pi-package/extensions/mcp-wrapper/config.ts` has no field for local MCP instructions and rejects unsupported fields.
+- `registerMcpInstructionPromptHandler` in `pi-package/extensions/mcp-wrapper/index.ts` adds only instructions returned by an MCP server during initialization.
+- The handler already checks `pi.getActiveTools()` and includes an MCP server's instructions only when at least one registered Pi tool from that server is active.
+- `AgentRuntimeComposition` in `pi-package/shared/agent-runtime-composition.ts` computes the final active Pi tools after applying all tool restrictions.
+- `test/integration/mcp-wrapper-system-prompt.test.ts` verifies that server-provided MCP instructions are filtered using final active Pi tools.
+
+## Impact
+
+An agent suite administrator must choose one of these inadequate alternatives:
+
+- Put MCP-specific instructions in the global system prompt, where agents without access to the corresponding tools also receive them.
+- Modify the MCP server to provide instructions specific to the agent suite.
+- Leave agents without local guidance for using an available MCP server.
+
+No quantitative data is available for the frequency or cost of this problem.
+
+## Reproduction Steps
+
+1. Configure an MCP server in `mcp-wrapper`.
+2. Add local instructions to that server's configuration.
+3. Observe that configuration parsing rejects the unsupported field.
+4. Put the instructions in the global system prompt instead.
+5. Observe that instruction visibility does not depend on whether the current agent can use a tool from that MCP server.
+
+## Current State
+
+Conditional prompt inclusion exists for instructions returned by an MCP server during initialization. No equivalent mechanism exists for local instructions defined by an agent suite administrator.
+
+## Desired Outcome
+
+Each agent runtime receives local instructions for an MCP server only when at least one Pi tool from that server remains active after all tool restrictions are applied to that runtime.
+
+## Success Metrics
+
+- When an MCP server has an active Pi tool, the agent's final system prompt contains that server's local instructions.
+- When an MCP server has no active Pi tool, the agent's final system prompt omits that server's local instructions.
+- Instruction visibility uses the final active Pi tools of the current agent runtime, not the registered tool catalog.
+
+## Scope
+
+- Local instructions associated with one MCP server.
+- Main agents, regular subagents, and other child agents.
+- Instruction visibility based on final tool availability in each agent runtime.
+
+## Out of Scope / Non-Goals
+
+- Changing the MCP protocol.
+- Changing instructions returned by MCP servers during initialization.
+- Redesigning tool restrictions or on-demand tool activation.
+- Selecting the configuration shape, merge order, or implementation architecture; later design phases own these decisions.
+
+## Constraints
+
+- `AgentRuntimeComposition` remains the owner of final active Pi tool reconciliation.
+- Each agent runtime determines tool activity independently.
+- Tool registration alone must not make local MCP instructions visible.
+
+## Assumptions
+
+There are no assumptions that affect the problem definition.
+
+## Open Questions
+
+None at the problem-definition level.
+
+# Domain Glossary
+
+- **MCP server:** A server configured in `mcp-wrapper` that provides one or more MCP tools.
+- **MCP tool:** A tool declared by an MCP server.
+- **Pi tool:** The Pi representation of an MCP tool registered by `mcp-wrapper`.
+- **Active Pi tool:** A Pi tool present in `pi.getActiveTools()` for an agent runtime after all tool restrictions are applied.
+- **Agent runtime:** A separate Pi instance that determines its own active Pi tools and system prompt for a main agent or child agent.
+- **Server-provided MCP instructions:** Instructions returned by an MCP server during initialization.
+- **Local MCP instructions:** Instructions associated with a specific MCP server and defined by an agent suite administrator.
+- **Active MCP server:** An MCP server with at least one active Pi tool in the current agent runtime.

--- a/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_solution.md
+++ b/docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_solution.md
@@ -1,0 +1,95 @@
+# Technical Solution: Conditional Local Instructions for MCP Servers
+
+## Problem Statement
+
+- TS-P1: `mcp-wrapper` cannot accept local MCP instructions in an MCP server configuration.
+- TS-P2: Local MCP instructions must appear in an agent runtime's final system prompt exactly when at least one Pi tool from that MCP server is present in the runtime's final `pi.getActiveTools()` result.
+- TS-P3: The solution must preserve server-provided MCP instructions and must not change active-tool reconciliation.
+
+## Proposed Solution
+
+### Configuration contract
+
+- TS-C1: Add `additionalInstructions?: string` to both variants of `McpServerConfig` in `pi-package/extensions/mcp-wrapper/config.ts`.
+- TS-C2: Add `additionalInstructions` to the allowed keys for `stdio` and `streamableHttp` server configurations.
+- TS-C3: Reject a defined non-string `additionalInstructions` value as an invalid MCP server configuration.
+- TS-C4: Use `additionalInstructions.trim()` only to determine whether the string contains text. Omit a value whose trimmed result is empty; otherwise preserve the original string without trimming it.
+- TS-C5: An absent or omitted `additionalInstructions` value preserves the behavior of configurations that predate this feature.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "docs": {
+      "type": "streamableHttp",
+      "url": "https://example.com/mcp",
+      "additionalInstructions": "Use this server for internal documentation."
+    }
+  }
+}
+```
+
+### Instruction record assembly
+
+- TS-A1: Keep one `ServerInstructionRecord` per MCP server. The record remains the single input to active-tool filtering and prompt rendering.
+- TS-A2: Replace `buildActiveServerInstructions` with a builder that receives server-provided MCP instructions, parsed MCP server configurations, and accepted `PiToolCatalogEntry` values.
+- TS-A3: Create a record only when the MCP server has at least one accepted Pi tool and at least one non-empty instruction source.
+- TS-A4: For one MCP server, compose the record text from server-provided MCP instructions followed by local MCP instructions, separated by exactly one blank line. A single available source is used without an added separator.
+- TS-A5: Preserve the relative order of records backed by server-provided MCP instructions. Append records that contain only local MCP instructions in MCP server configuration order.
+- TS-A6: A server without accepted Pi tools produces no instruction record, including when `additionalInstructions` contains text.
+
+### Prompt visibility and rendering
+
+- TS-R1: Keep `registerMcpInstructionPromptHandler` as the only MCP instruction prompt handler.
+- TS-R2: On every `before_agent_start` event, filter instruction records against the final names returned by `pi.getActiveTools()` for that agent runtime.
+- TS-R3: Include a server record when at least one name in its `registeredPiToolNames` exists in `pi.getActiveTools()`; otherwise omit the record.
+- TS-R4: Render the result through the existing `<mcp_instructions>` and `<server name="...">` structure. This keeps one server block when both instruction sources exist.
+- TS-R5: Pass the combined text through the existing `escapeMcpInstructionText` function before adding it to the final system prompt.
+- TS-R6: Do not add a new `AgentRuntimeComposition` contribution. `AgentRuntimeComposition` remains the owner of final active-tool reconciliation, while `mcp-wrapper` remains the owner of MCP instruction rendering.
+
+### Metadata cache
+
+- TS-M1: Do not store `additionalInstructions` in `CachedMcpServerMetadata`.
+- TS-M2: Exclude `additionalInstructions` from `computeMcpServerConfigHash` together with `onDemand`, because neither field changes MCP connection identity or discovered metadata.
+- TS-M3: Read local MCP instructions from the parsed configuration during each session start and associate them with the accepted Pi tool catalog built from cached or discovered metadata.
+- TS-M4: Changing only `additionalInstructions` must not trigger MCP metadata discovery. The new value takes effect on the next runtime reload or session start that reads the configuration.
+
+### Failure behavior
+
+- TS-F1: A non-string `additionalInstructions` value follows the existing invalid-configuration path: `mcp-wrapper` registers no MCP tools for that session and reports its configuration warning.
+- TS-F2: An empty or whitespace-only `additionalInstructions` value produces no local MCP instructions and does not affect server-provided MCP instructions.
+- TS-F3: MCP metadata failure behavior remains unchanged. A server without accepted tool metadata has no active Pi tool and therefore cannot expose local MCP instructions.
+
+### Verification
+
+- TS-V1: Add parser tests for non-empty strings, exact preservation of non-empty text, empty and whitespace-only omission, non-string rejection, and both MCP transport variants.
+- TS-V2: Add metadata-cache tests proving that changing only `additionalInstructions` does not change the server configuration hash.
+- TS-V3: Add behavior tests proving local-only rendering, server-provided-then-local ordering, omission without an active server tool, and omission for empty local instructions.
+- TS-V4: Extend system-prompt integration tests to prove that final active-tool restrictions control local MCP instruction visibility without changing server-provided instruction behavior.
+- TS-V5: Verify the main-agent and child-agent prompt paths using the repository's required real `pi` CLI runtime check with temporary configuration, state, and debug output.
+- TS-V6: Run `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify` after implementation.
+
+### Documentation
+
+- TS-D1: Update `docs/extensions/mcp-wrapper.md` with the new server parameter, configuration example, empty-value behavior, merge order, active-tool condition, and metadata-cache behavior.
+- TS-D2: Keep the Problem Statement, Light PRD, and this Technical Solution under `docs/specs/features/mcp-wrapper-additional-instructions/`.
+
+## Overengineering and Overspecification Considerations
+
+- TS-O1: The design reuses the existing instruction record, active-tool filter, XML-like prompt structure, and lifecycle handler instead of adding another prompt handler or composition layer.
+- TS-O2: The configuration accepts one string rather than arrays, file references, templates, or per-agent overrides because the approved requirements do not require those capabilities.
+- TS-O3: Local MCP instructions remain outside the metadata cache because they do not affect transport setup or MCP discovery.
+
+## Open Questions
+
+- TS-Q1: None.
+
+## References
+
+- TS-REF1: `docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_problem.md` - approved Problem Statement and Domain Glossary.
+- TS-REF2: `docs/specs/features/mcp-wrapper-additional-instructions/mcp_wrapper_additional_instructions_prd.md` - approved Light PRD.
+- TS-REF3: `pi-package/extensions/mcp-wrapper/config.ts` - MCP server configuration types and strict parser.
+- TS-REF4: `pi-package/extensions/mcp-wrapper/index.ts` - instruction assembly, active-tool filtering, and prompt rendering.
+- TS-REF5: `pi-package/extensions/mcp-wrapper/metadata-cache.ts` - MCP metadata cache identity and storage.
+- TS-REF6: `pi-package/shared/agent-runtime-composition.ts` - final active-tool reconciliation.

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
@@ -105,8 +105,10 @@ Keep specialized toolsets outside the model context until needed while allowing 
 - A successful `activate_toolset` result sent to the LLM must contain the complete list of tool names made available to the current agent.
 - The LLM result must not contain tool parameters or individual tool descriptions.
 - A repeated activation of an active toolset must identify it as already active and contain its complete currently available tool-name list.
-- Collapsed TUI rendering must show activation status, tool count, and a shortened tool-name list.
-- Expanded TUI rendering must show the complete tool-name list.
+- The TUI call line must name the requested toolset.
+- The TUI result must start with `Activated:` or `Already active:` followed by comma-separated tool names; only the status label is success-colored.
+- Collapsed TUI rendering must show at most two wrapped content lines, append an ellipsis when content is hidden, and report the exact number of hidden wrapped lines with the standard expansion hint.
+- Expanded TUI rendering must show every tool name without truncation or an expansion hint.
 - TUI rendering must not show tool parameters or individual tool descriptions.
 - Main-agent and subagent screens must use the same collapsed and expanded rendering behavior.
 

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
@@ -1,0 +1,160 @@
+# Idea: On-Demand Toolsets
+
+## Definitions
+
+- **tool**: An individual operation that an LLM can invoke.
+- **toolset**: A named collection of tools that becomes available as one unit.
+- **tool provider**: A source that supplies one or more tools.
+- **MCP server**: The tool-provider type supported by this feature.
+- **model provider**: The service receiving the LLM request, including active tool definitions.
+- **activation trigger**: Compact metadata describing when the LLM should activate a deferred toolset.
+- **deferred toolset**: A toolset excluded from model-provider tool definitions and represented by an activation trigger.
+- **active toolset**: A toolset whose tools are available to the LLM.
+
+## Context and Problem
+
+`mcp-wrapper` exposes every discovered MCP tool to the model provider. Users who configure multiple specialized MCP servers receive irrelevant tool definitions in the model context even when a task requires only one toolset.
+
+## Goal
+
+Keep specialized toolsets outside the model context until needed while allowing the LLM to discover and activate them during a pi session.
+
+## Scenarios
+
+- A new session starts with eager MCP toolsets available and deferred toolsets represented only by activation triggers.
+- The LLM identifies a relevant trigger and activates its toolset.
+- A resumed session restores activations represented in its active history branch.
+- Rewinding or branching before an activation returns that toolset to deferred state.
+- Invalid activation requests leave toolset state unchanged.
+- Invalid configuration produces a startup warning and disables the extension without preventing pi from starting.
+
+## Scope and Non-Scope
+
+### Scope
+
+- Marking individual MCP servers as deferred toolsets.
+- Exposing compact activation triggers through the system prompt.
+- Activating all tools belonging to one deferred toolset.
+- Persisting activation state within pi session history.
+
+### Non-Scope
+
+- Supporting tool providers other than MCP servers.
+- Grouping several MCP servers into one toolset.
+- Splitting one MCP server into several toolsets.
+- Optimizing MCP connection, discovery, or server resource usage as an independent goal.
+- Preserving historical tool availability after the user removes or renames its toolset in configuration.
+
+## Requirements
+
+### Configuration
+
+- Each MCP server can be configured either for immediate availability or as one deferred toolset.
+- A deferred toolset configuration requires `name` and `description`.
+- Configured `name` values must be unique.
+- `name` must contain at least one non-whitespace character and must not contain leading or trailing whitespace.
+- `description` must contain at least one non-whitespace character and must not contain leading or trailing whitespace.
+- A duplicate name or any other configuration error must produce a startup warning and disable `mcp-wrapper`.
+- Configuration errors must not prevent pi from starting.
+- MCP servers without deferred-toolset configuration must retain `mcp-wrapper` behavior defined for non-deferred servers.
+
+### Initial availability
+
+- Tools belonging to a deferred toolset must not be included in model-provider tool definitions before activation.
+- MCP instructions and other provider-derived prompt content belonging to a deferred toolset must not appear before activation.
+- Before activation, the system prompt can represent the toolset only through its configured activation trigger.
+- The system-prompt template must expose activation triggers through the `{{toolsets}}` variable.
+- Activation triggers must not be appended to the system prompt when its template does not contain `{{toolsets}}`.
+- Each deferred toolset must be represented as:
+  ```xml
+  <toolsets>
+  <toolset name="configured name" description="configured activation rules"/>
+  </toolsets>
+  ```
+- Multiple deferred toolsets must appear as multiple `<toolset>` elements inside one `<toolsets>` element.
+- `{{toolsets}}` must expand to an empty string when no deferred toolsets remain.
+
+### Unavailable MCP metadata
+
+- A deferred MCP server must participate in the toolset catalog only after its tool metadata has been loaded successfully.
+- A deferred MCP server without loaded tool metadata must not produce a `<toolset>` trigger.
+- `activate_toolset` must not accept the name of a deferred MCP server without loaded tool metadata.
+- Existing MCP startup diagnostics must warn the user about the metadata loading failure.
+- The toolset may become available after a successful `/mcp-refresh` or in a later session.
+
+### Activation tool
+
+- The LLM must have access to a tool named `activate_toolset` while at least one deferred toolset remains in the active history branch.
+- `activate_toolset` must become unavailable after no deferred toolsets remain.
+- The tool must have a required string parameter named `name`.
+- The tool parameter schema must enforce a minimum string length of one character independently of configuration validation.
+- `activate_toolset.name` must use exact, case-sensitive matching against the configured toolset name.
+- The tool description visible to the LLM must explain that it activates a needed toolset listed in `<toolsets>` so that the toolset’s tools become available.
+- Configuration-only whitespace restrictions must not be duplicated in the tool parameter schema.
+- A non-empty parameter that does not identify a deferred or active configured toolset must be handled as an unknown name.
+
+### Successful activation
+
+- A successful `activate_toolset` call must make every tool of the selected MCP server available to the LLM.
+- After activation, the MCP server must follow the same tool availability, MCP instruction visibility, call routing, result mapping, and presentation behavior as a non-deferred server.
+- The activated toolset must be removed from subsequent `<toolsets>` expansions.
+- Repeated activation of an active toolset must return success without changing its state.
+
+### Activation output
+
+- A successful `activate_toolset` result sent to the LLM must contain the complete list of tool names made available to the current agent.
+- The LLM result must not contain tool parameters or individual tool descriptions.
+- A repeated activation of an active toolset must identify it as already active and contain its complete currently available tool-name list.
+- Collapsed TUI rendering must show activation status, tool count, and a shortened tool-name list.
+- Expanded TUI rendering must show the complete tool-name list.
+- TUI rendering must not show tool parameters or individual tool descriptions.
+- Main-agent and subagent screens must use the same collapsed and expanded rendering behavior.
+
+### Activation failure
+
+- An unknown name or MCP activation failure must return an error from `activate_toolset`.
+- A failed activation must not make any tools from the selected toolset available.
+- A failed activation must leave the selected toolset deferred.
+- The trigger must remain in subsequent `<toolsets>` expansions.
+- A failed activation may be retried.
+
+### Session state
+
+- Activation state must belong to one pi session rather than all sessions using the same configuration.
+- Resuming the same session after restarting pi must restore activation state from the active history branch.
+- A new session must start with all configured deferred toolsets in deferred state.
+- A history branch containing a successful activation must treat that toolset as active.
+- Rewinding or branching to history before a successful activation must treat that toolset as deferred.
+- Removing or renaming an activated toolset in configuration must produce a warning when the session is resumed.
+- After such a configuration change, `mcp-wrapper` must continue using the valid current configuration.
+- Historical availability is not guaranteed for tools removed or renamed through configuration changes.
+
+### Agent tool restrictions
+
+- Activating a toolset must remove only its deferred restriction.
+- Activation must not grant a tool excluded by the current agent’s tool restrictions.
+- A tool from a deferred toolset must become available only when:
+  1. the toolset is active in the current pi session branch; and
+  2. the current agent’s tool restrictions allow the tool.
+- `<toolsets>` must include only deferred toolsets containing at least one tool allowed for the current agent.
+- Activating such a toolset must expose only its tools allowed for the current agent.
+- `activate_toolset` must be available only when:
+  1. the current agent’s tool restrictions allow `activate_toolset`; and
+  2. at least one deferred toolset contains a tool allowed for that agent.
+- Main agent and each subagent must maintain activation state independently in their separate pi sessions.
+- Activation in a main-agent session must not activate the same toolset in a subagent session, and vice versa.
+
+## Open Questions
+
+None.
+
+## Technical Supplement
+
+None.
+
+## References
+
+- [Problem Statement](./on-demand-toolsets_problem.md)
+- [`system-prompt` extension](../../../extensions/system-prompt.md)
+- [`mcp-wrapper` extension](../../../extensions/mcp-wrapper.md)
+- `pi-package/extensions/vision/index.ts`: independent tool parameter schema validation example.

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md
@@ -84,8 +84,8 @@ Keep specialized toolsets outside the model context until needed while allowing 
 
 ### Activation tool
 
-- The LLM must have access to a tool named `activate_toolset` while at least one deferred toolset remains in the active history branch.
-- `activate_toolset` must become unavailable after no deferred toolsets remain.
+- The LLM must have access to a tool named `activate_toolset` only when it is allowed for the current agent and at least one loaded, still-deferred toolset contains a tool allowed for that agent.
+- `activate_toolset` must become unavailable when no loaded, still-deferred toolset contains a tool allowed for the current agent, including after the final eligible activation.
 - The tool must have a required string parameter named `name`.
 - The tool parameter schema must enforce a minimum string length of one character independently of configuration validation.
 - `activate_toolset.name` must use exact, case-sensitive matching against the configured toolset name.
@@ -125,6 +125,7 @@ Keep specialized toolsets outside the model context until needed while allowing 
 - A new session must start with all configured deferred toolsets in deferred state.
 - A history branch containing a successful activation must treat that toolset as active.
 - Rewinding or branching to history before a successful activation must treat that toolset as deferred.
+- The runtime must restore state from the last valid activation snapshot in the active branch; malformed or unsupported snapshots must not change state.
 - Removing or renaming an activated toolset in configuration must produce a warning when the session is resumed.
 - After such a configuration change, `mcp-wrapper` must continue using the valid current configuration.
 - Historical availability is not guaranteed for tools removed or renamed through configuration changes.
@@ -143,6 +144,13 @@ Keep specialized toolsets outside the model context until needed while allowing 
   2. at least one deferred toolset contains a tool allowed for that agent.
 - Main agent and each subagent must maintain activation state independently in their separate pi sessions.
 - Activation in a main-agent session must not activate the same toolset in a subagent session, and vice versa.
+
+### Active-tool composition
+
+- `AgentRuntimeComposition` must be the sole production owner of final `pi.setActiveTools()` reconciliation.
+- The composition baseline defines stable relative order. Main-agent, child-policy, nested-depth, workflow-availability, vision-availability, and deferred-toolset layers may only remove names from upstream candidates.
+- A tool restored after a restriction is lifted must return at its baseline position. No layer may add or reorder an upstream-excluded tool.
+- Workflow and vision availability must be represented by their respective restrictive composition layers rather than independent final active-tool writes.
 
 ## Open Questions
 

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_problem.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_problem.md
@@ -30,14 +30,14 @@ No token measurements or provider-specific limits have been collected.
 
 ## Reproduction Steps
 
-1. Configure several MCP servers in `mcp-wrapper`.
+1. Configure several MCP servers in `mcp-wrapper` without `onDemand`.
 2. Start a pi session with `mcp-wrapper` enabled.
 3. Inspect active tools and the tool definitions sent to the model provider.
-4. Observe that tools from all successfully discovered servers are available even when the current task needs only one specialized toolset.
+4. Observe that tools from all successfully discovered eager servers are available even when the current task needs only one specialized toolset.
 
-## Current State
+## Prior State
 
-Every successfully discovered MCP tool is registered for normal use. The system has no user-visible distinction between immediately available toolsets and toolsets that should become available only when relevant.
+Before this feature, every successfully discovered MCP tool was registered for normal use. There was no user-visible distinction between immediately available toolsets and toolsets that should become available only when relevant.
 
 ## Desired Outcome
 

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_problem.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_problem.md
@@ -1,0 +1,92 @@
+# Problem Statement
+
+## Context
+
+`mcp-wrapper` exposes tools from configured MCP servers to an LLM session. Users may configure many specialized tool providers, while each task usually requires only a subset of their capabilities.
+
+## Problem Statement
+
+`mcp-wrapper` makes all discovered tools available to the model provider regardless of their relevance to the current task. Irrelevant tool definitions consume context and make the available-tool catalog harder for the LLM to navigate.
+
+## Who is affected
+
+Users who configure multiple specialized MCP servers whose tools are not expected to be used simultaneously.
+
+## Evidence
+
+- `pi-package/extensions/mcp-wrapper/index.ts`: `registerCatalogTools` registers every catalog entry produced from discovered MCP tools.
+- `pi-package/extensions/mcp-wrapper/index.ts`: `handleSessionStart` loads metadata and builds the catalog for configured servers.
+- `pi-package/extensions/system-prompt/index.ts`: `buildTemplateValues` provides active tool and skill content to system-prompt macros.
+- `docs/extensions/system-prompt.md`: `{{tools}}` expands active tool prompt text, while `{{skills}}` provides a compact catalog for progressive disclosure.
+- The reported user scenario states that loading all tools creates excessive context.
+
+No token measurements or provider-specific limits have been collected.
+
+## Impact
+
+- Irrelevant tool schemas consume model input.
+- A large tool catalog increases the amount of unrelated information the LLM must inspect.
+- Reduced signal-to-noise ratio may impair tool selection. This is a hypothesis; it requires comparison of representative sessions before and after the change.
+
+## Reproduction Steps
+
+1. Configure several MCP servers in `mcp-wrapper`.
+2. Start a pi session with `mcp-wrapper` enabled.
+3. Inspect active tools and the tool definitions sent to the model provider.
+4. Observe that tools from all successfully discovered servers are available even when the current task needs only one specialized toolset.
+
+## Current State
+
+Every successfully discovered MCP tool is registered for normal use. The system has no user-visible distinction between immediately available toolsets and toolsets that should become available only when relevant.
+
+## Desired Outcome
+
+Users can keep specialized toolsets outside the initial model context while preserving enough information for the LLM to identify and enable a relevant toolset during the session.
+
+## Success Metrics
+
+1. Toolsets designated for deferred availability contribute no tool definitions to the initial model-provider request.
+2. The initial system prompt retains a compact activation signal for each deferred toolset.
+3. A relevant deferred toolset can become available within the current session without restarting pi.
+4. Toolsets not designated for deferred availability retain their established behavior.
+
+## Scope
+
+- Context and model-provider tool-list growth caused by specialized MCP toolsets.
+- Discoverability of deferred toolsets.
+- Transition of a deferred toolset to normal availability within a session.
+
+## Out of Scope / Non-Goals
+
+- Reducing MCP connection or discovery startup cost as an independent goal.
+- Reducing resource usage of connected MCP servers.
+- Supporting tool providers other than MCP servers in the initial feature.
+- Measuring or optimizing provider-specific token limits.
+
+## Constraints
+
+- The current source of toolsets is `mcp-wrapper` and its configured MCP servers.
+- The system-prompt extension owns project template variables described in `docs/extensions/system-prompt.md`.
+- Existing non-deferred MCP usage must remain viable.
+- No baseline token or tool-count threshold is available.
+
+## Assumptions
+
+- Removing irrelevant tool definitions reduces initial context size. Verify by comparing serialized model-provider requests with identical configurations.
+- A compact trigger catalog gives the LLM enough information to select a deferred toolset. Verify through behavior tests and representative live pi scenarios.
+- Users can classify specialized toolsets when configuring them. Verify through configuration usability review.
+
+## Open Questions
+
+None at the problem-definition level.
+
+# Domain Glossary
+
+- **tool**: An individual operation that an LLM can invoke.
+- **toolset**: A named collection of tools that becomes available as one unit.
+- **tool provider**: A source that supplies one or more tools.
+- **MCP server**: The tool-provider type supported by the initial feature.
+- **model provider**: The service receiving the LLM request, including active tool definitions.
+- **activation trigger**: Compact metadata describing when an LLM should make a deferred toolset available.
+- **deferred toolset**: A toolset excluded from initial model context and model-provider tool definitions but represented by an activation trigger.
+- **active toolset**: A toolset whose tools are available to the LLM under normal session behavior.

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
@@ -21,7 +21,7 @@
 - **CMP-01:** `shared/toolsets/contracts.ts` defines toolset metadata, provider registration, activation results, and persisted state details.
 - **CMP-02:** `shared/toolsets/runtime.ts` owns provider registrations, activation state, the `activate_toolset` definition, history reconstruction, and the deferred tool filter.
 - **CMP-03:** `shared/toolsets/rendering.ts` renders activation calls and results using Pi’s default tool shell.
-- **CMP-04:** `shared/agent-runtime-composition.ts` owns the unfiltered session tool baseline, the resolved current-agent restriction, ordered named filters, and the final active tool set.
+- **CMP-04:** `shared/agent-runtime-composition.ts` owns the stable session baseline order, resolved current-agent restriction, ordered named restrictive layers, and the final active tool set. It is the sole production owner of final `pi.setActiveTools()` writes.
 - **CMP-05:** `mcp-wrapper` remains responsible for MCP configuration, metadata discovery, cache refresh, generated tool definitions, MCP instructions, calls, and results.
 - **CMP-06:** `system-prompt` remains the sole owner of template-variable parsing and replacement.
 
@@ -33,17 +33,13 @@
 
 ### Tool availability composition
 
-- **SOL-04:** `AgentRuntimeComposition` computes candidates in this order:
-  1. session baseline established by Pi and `enable-tools`;
-  2. the tool list resolved for the current main or child agent;
-  3. current nested-depth restrictions;
-  4. deferred-toolset filtering.
-- **APC-01:** Named filters accept a candidate list and may only remove names. The composition intersects filter output with filter input so a filter cannot grant tools.
+- **SOL-04:** `AgentRuntimeComposition` starts from a stable session baseline, uses the resolved main or child agent tool list when present, then applies restrictive layers for child policy, nested depth, workflow availability, vision availability, and deferred toolsets.
+- **APC-01:** Named filters accept a candidate list and may only remove names. The composition intersects filter output with filter input, preserving baseline relative order; a filter cannot grant, reorder, or append tools. A restored tool returns at its baseline position.
 - **APC-02:** The composition exposes operations to update the session baseline, set or clear the current-agent tool list, register or remove a named filter, and reconcile `pi.getActiveTools()`.
-- **SOL-05:** `main-agent-selection`, child policy application, and `enable-tools` update the composition rather than leaving competing final calls to `pi.setActiveTools()`.
+- **SOL-05:** `main-agent-selection`, child policy application, `enable-tools`, workflow availability, and vision availability update the composition rather than leaving competing final calls to `pi.setActiveTools()`.
 - **SOL-06:** The toolset filter runs after agent and depth restrictions. It records the pre-deferred tool names needed to determine which triggers are visible.
 - **SOL-07:** Activating a toolset removes only its deferred restriction. It never adds a name absent from the pre-deferred candidate list.
-- **SOL-08:** Reconciliation runs after session setup, agent selection changes, child policy application, MCP catalog replacement, and successful activation. The existing `before_agent_start` reconciliation remains a final safety check.
+- **SOL-08:** Reconciliation runs after session setup, agent selection changes, child policy application, workflow or vision availability changes, MCP catalog replacement, and successful activation. The existing `before_agent_start` reconciliation remains a final safety check.
 
 ### MCP configuration
 
@@ -70,7 +66,7 @@
 - **STP-03:** Add all registered definitions to the composition baseline before applying current-agent and toolset filters.
 - **STP-04:** Register an MCP toolset only when metadata contains its discovered tool list.
 - **FLR-02:** A deferred server without loaded metadata has no toolset record, trigger, or activation route. Existing MCP startup diagnostics report the metadata failure.
-- **STP-05:** A successful `/mcp-refresh` reloads runtime state through the established reload path. Newly available metadata creates the toolset during the replacement session.
+- **STP-05:** A successful `/mcp-refresh` reloads runtime state through the established reload path. Newly available metadata creates the toolset during the replacement session; removed or unavailable metadata removes its trigger and activation route.
 - **SOL-10:** Eager servers never enter the deferred registry and retain their existing generated definitions, MCP instructions, call routing, result mapping, and presentation.
 - **SOL-11:** Deferred MCP instructions remain absent because the existing instruction handler already emits instructions only for active generated tool names.
 
@@ -108,7 +104,8 @@
   ```
 - **SOL-12:** The composition keeps `activate_toolset` active only when:
   - the current agent’s resolved tool list contains `activate_toolset`; and
-  - at least one deferred toolset contains a tool present before deferred filtering.
+  - at least one loaded, still-deferred toolset contains a tool present before deferred filtering.
+  It disappears after the final eligible activation.
 - **FLR-04:** Empty `name` fails JSON Schema validation.
 - **FLR-05:** A non-empty unknown name returns a tool error without changing activation state.
 - **SOL-13:** Repeated activation of an active name succeeds without changing state.
@@ -188,7 +185,7 @@
 - **DLV-02:** Add `pi-package/shared/toolsets/runtime.ts` and its adjacent tests.
 - **DLV-03:** Add `pi-package/shared/toolsets/rendering.ts` and its adjacent tests.
 - **DLV-04:** Update `pi-package/shared/agent-runtime-composition.ts` and its tests.
-- **DLV-05:** Update `main-agent-selection`, `run-subagent`, and `enable-tools` to use per-session composition.
+- **DLV-05:** Update `main-agent-selection`, `run-subagent`, `enable-tools`, workflow, and vision to use per-session composition.
 - **DLV-06:** Update `mcp-wrapper` configuration, metadata hashing, lifecycle, catalog registration, and behavior tests.
 - **DLV-07:** Update `system-prompt` macro handling, bundled template, documentation, and tests.
 - **DLV-08:** Update `docs/extensions/mcp-wrapper.md`.

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
@@ -152,9 +152,9 @@
   ```
 - **APC-15:** Repeated activation returns `already active` status followed by the complete currently available tool-name list.
 - **APC-16:** LLM content contains no tool parameters or individual tool descriptions.
-- **SOL-18:** `renderCall` uses a compact, width-bounded toolset name inside Pi’s default tool shell.
-- **SOL-19:** Collapsed `renderResult` shows status, tool count, the first bounded tool-name lines, and the standard `ctrl+o` hidden-content hint.
-- **SOL-20:** Expanded `renderResult` uses Pi `Text` to show the complete tool-name list.
+- **SOL-18:** `renderCall` uses a compact, width-bounded call line that names the requested toolset inside Pi’s default tool shell.
+- **SOL-19:** `renderResult` starts with `Activated:` or `Already active:` followed by comma-separated tool names; only the status label is success-colored. Collapsed rendering shows at most two wrapped content lines, appends an ellipsis when content is hidden, and reports the exact hidden wrapped-line count with the standard expansion hint. It shows no tool parameters or individual tool descriptions.
+- **SOL-20:** Expanded `renderResult` shows every tool name without truncation or an expansion hint.
 - **SOL-21:** Both main and subagent screens use the same registered tool definition and renderer.
 
 ### Testing strategy

--- a/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
+++ b/docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md
@@ -1,0 +1,217 @@
+# Technical Solution: On-Demand Toolsets
+
+## Problem Statement
+
+- **PRB-01:** `mcp-wrapper` registers all discovered MCP tools as active, causing unrelated tool definitions to enter model-provider requests.
+- **PRB-02:** Deferred tools must remain discoverable through compact triggers without bypassing the tool restrictions of the current independent pi session.
+- **CNS-01:** Main, child, and recursively nested child agents run independent pi sessions with separate `ExtensionAPI`, history, tool policy, and activation state.
+
+## Proposed Solution
+
+### Architecture
+
+- **DEC-01:** Add a generic per-`ExtensionAPI` toolset runtime under `pi-package/shared/toolsets/`.
+- **DEC-02:** Do not create a separate extension entry point. The first registered tool provider initializes the runtime.
+- **DEC-03:** `mcp-wrapper` registers deferred MCP servers as toolsets after their metadata is loaded.
+- **DEC-04:** `system-prompt` obtains the visible trigger catalog from the shared runtime when expanding `{{toolsets}}`.
+- **DEC-05:** Extend `AgentRuntimeComposition` instead of introducing a competing owner of `pi.setActiveTools()`.
+
+### Components
+
+- **CMP-01:** `shared/toolsets/contracts.ts` defines toolset metadata, provider registration, activation results, and persisted state details.
+- **CMP-02:** `shared/toolsets/runtime.ts` owns provider registrations, activation state, the `activate_toolset` definition, history reconstruction, and the deferred tool filter.
+- **CMP-03:** `shared/toolsets/rendering.ts` renders activation calls and results using Pi’s default tool shell.
+- **CMP-04:** `shared/agent-runtime-composition.ts` owns the unfiltered session tool baseline, the resolved current-agent restriction, ordered named filters, and the final active tool set.
+- **CMP-05:** `mcp-wrapper` remains responsible for MCP configuration, metadata discovery, cache refresh, generated tool definitions, MCP instructions, calls, and results.
+- **CMP-06:** `system-prompt` remains the sole owner of template-variable parsing and replacement.
+
+### Per-session isolation
+
+- **SOL-01:** The toolset runtime uses the same per-`ExtensionAPI` WeakMap and event-bus holder pattern as `AgentRuntimeComposition`.
+- **SOL-02:** Each main, child, and nested-child pi session receives a separate runtime because each has its own `ExtensionAPI`.
+- **SOL-03:** Activation state is never inherited or synchronized between parent and child sessions.
+
+### Tool availability composition
+
+- **SOL-04:** `AgentRuntimeComposition` computes candidates in this order:
+  1. session baseline established by Pi and `enable-tools`;
+  2. the tool list resolved for the current main or child agent;
+  3. current nested-depth restrictions;
+  4. deferred-toolset filtering.
+- **APC-01:** Named filters accept a candidate list and may only remove names. The composition intersects filter output with filter input so a filter cannot grant tools.
+- **APC-02:** The composition exposes operations to update the session baseline, set or clear the current-agent tool list, register or remove a named filter, and reconcile `pi.getActiveTools()`.
+- **SOL-05:** `main-agent-selection`, child policy application, and `enable-tools` update the composition rather than leaving competing final calls to `pi.setActiveTools()`.
+- **SOL-06:** The toolset filter runs after agent and depth restrictions. It records the pre-deferred tool names needed to determine which triggers are visible.
+- **SOL-07:** Activating a toolset removes only its deferred restriction. It never adds a name absent from the pre-deferred candidate list.
+- **SOL-08:** Reconciliation runs after session setup, agent selection changes, child policy application, MCP catalog replacement, and successful activation. The existing `before_agent_start` reconciliation remains a final safety check.
+
+### MCP configuration
+
+- **CFG-01:** Both stdio and streamable HTTP server objects accept:
+  ```json
+  {
+    "onDemand": {
+      "name": "github",
+      "description": "Activate for GitHub repository operations."
+    }
+  }
+  ```
+- **CFG-02:** Absence of `onDemand` retains eager behavior.
+- **CFG-03:** `onDemand` accepts exactly `name` and `description`.
+- **CFG-04:** Both values must contain at least one non-whitespace character and must not contain leading or trailing whitespace.
+- **CFG-05:** `onDemand.name` values use exact, case-sensitive identity and must be unique across `mcpServers`.
+- **FLR-01:** Any configuration violation returns the existing invalid-config result. `handleSessionStart` displays a warning and leaves `mcp-wrapper` disabled without preventing pi startup.
+- **SOL-09:** `computeMcpServerConfigHash` hashes only transport and connection identity fields. Changing `onDemand.name` or `onDemand.description` does not invalidate cached MCP metadata.
+
+### MCP startup and registration
+
+- **STP-01:** Preserve startup cache loading, discovery of missing metadata, cache persistence, and background refresh.
+- **STP-02:** Build and register Pi tool definitions for eager and deferred servers whose metadata is available.
+- **STP-03:** Add all registered definitions to the composition baseline before applying current-agent and toolset filters.
+- **STP-04:** Register an MCP toolset only when metadata contains its discovered tool list.
+- **FLR-02:** A deferred server without loaded metadata has no toolset record, trigger, or activation route. Existing MCP startup diagnostics report the metadata failure.
+- **STP-05:** A successful `/mcp-refresh` reloads runtime state through the established reload path. Newly available metadata creates the toolset during the replacement session.
+- **SOL-10:** Eager servers never enter the deferred registry and retain their existing generated definitions, MCP instructions, call routing, result mapping, and presentation.
+- **SOL-11:** Deferred MCP instructions remain absent because the existing instruction handler already emits instructions only for active generated tool names.
+
+### Generic provider contract
+
+- **ENT-01:** A registered toolset contains:
+  - provider identifier;
+  - exact toolset name;
+  - activation description;
+  - loaded tool names;
+  - provider activation operation.
+- **APC-03:** Provider registration replaces that provider’s previous session-local catalog atomically.
+- **APC-04:** The activation operation returns the loaded tool names available for composition. The MCP implementation does not introduce an extra network connection and preserves standard MCP connection behavior.
+- **APC-05:** Runtime commits activation state only after provider activation and active-tool reconciliation succeed.
+- **FLR-03:** Provider or reconciliation failure rolls back the pending activation, returns an error, keeps the trigger visible, and permits retry.
+
+### Activation tool
+
+- **APC-06:** Register one package tool named `activate_toolset`.
+- **APC-07:** Use a required parameter equivalent to:
+  ```ts
+  Type.Object(
+    {
+      name: Type.String({
+        minLength: 1,
+        description: "Exact case-sensitive toolset name from <toolsets>.",
+      }),
+    },
+    { additionalProperties: false },
+  )
+  ```
+- **APC-08:** Use this LLM-visible description:
+  ```text
+  Activate a toolset listed in <toolsets> when its tools are needed.
+  ```
+- **SOL-12:** The composition keeps `activate_toolset` active only when:
+  - the current agent’s resolved tool list contains `activate_toolset`; and
+  - at least one deferred toolset contains a tool present before deferred filtering.
+- **FLR-04:** Empty `name` fails JSON Schema validation.
+- **FLR-05:** A non-empty unknown name returns a tool error without changing activation state.
+- **SOL-13:** Repeated activation of an active name succeeds without changing state.
+
+### Session-history state
+
+- **EVC-01:** Every successful activation stores a versioned full snapshot in `toolResult.details`:
+  ```ts
+  {
+    version: 1,
+    activeToolsets: ["github", "database"],
+  }
+  ```
+- **ALG-01:** On `session_start`, scan `ctx.sessionManager.getBranch()` for successful `activate_toolset` results with valid details and restore the last valid snapshot.
+- **ALG-02:** Branching or rewinding naturally selects the last snapshot present in the active branch.
+- **FLR-06:** Unknown versions or malformed details are ignored rather than interpreted.
+- **FLR-07:** Snapshot names absent from the loaded configuration produce a warning and are ignored. The valid current configuration remains active.
+- **SOL-14:** Activation snapshots remain session-local and are not written to global configuration or cache files.
+
+### `{{toolsets}}` macro
+
+- **APC-09:** Add `toolsets` to `SUPPORTED_TEMPLATE_VARIABLES`.
+- **APC-10:** `buildTemplateValues` obtains visible deferred toolsets from the runtime associated with the handler’s `ExtensionAPI`.
+- **APC-11:** Before rendering, `system-prompt` requests active-tool reconciliation and uses the reconciled active names for tool-dependent template values.
+- **APC-12:** No visible toolsets produce an empty string.
+- **APC-13:** Visible entries produce:
+  ```xml
+  <toolsets>
+  <toolset name="github" description="Activate for GitHub repository operations."/>
+  </toolsets>
+  ```
+- **SOL-15:** XML attribute values escape `&`, `<`, `>`, `"`, and `'`.
+- **SOL-16:** The bundled system template adds `{{toolsets}}` between the skills catalog and the active-tools section.
+- **SOL-17:** Custom templates receive no triggers unless they contain `{{toolsets}}`.
+
+### LLM result and TUI rendering
+
+- **APC-14:** First activation returns LLM content containing status followed by every tool name made available to the current agent:
+  ```text
+  Activated toolset "github".
+  Available tools:
+  - github_create_issue
+  - github_get_issue
+  ```
+- **APC-15:** Repeated activation returns `already active` status followed by the complete currently available tool-name list.
+- **APC-16:** LLM content contains no tool parameters or individual tool descriptions.
+- **SOL-18:** `renderCall` uses a compact, width-bounded toolset name inside Pi’s default tool shell.
+- **SOL-19:** Collapsed `renderResult` shows status, tool count, the first bounded tool-name lines, and the standard `ctrl+o` hidden-content hint.
+- **SOL-20:** Expanded `renderResult` uses Pi `Text` to show the complete tool-name list.
+- **SOL-21:** Both main and subagent screens use the same registered tool definition and renderer.
+
+### Testing strategy
+
+- **TSK-01:** Add failing configuration tests for `onDemand`, unsupported keys, whitespace-only values, surrounding whitespace, and duplicate case-sensitive names.
+- **TSK-02:** Add shared runtime tests for per-`ExtensionAPI` isolation, provider replacement, unknown names, idempotent activation, atomic rollback, and visibility of `activate_toolset`.
+- **TSK-03:** Add history tests for snapshot restoration, branch rewind, malformed details, unknown versions, and stale configured names.
+- **TSK-04:** Extend composition tests for ordered restrictive filters and prove that no filter can add tools.
+- **TSK-05:** Add main, child, nested-depth, and `enable-tools` composition tests proving that activation never overrides agent restrictions.
+- **TSK-06:** Add `mcp-wrapper` tests proving deferred definitions are registered but inactive, eager tools remain active, metadata failures create no trigger, MCP instructions appear only after activation, and cache hashing ignores `onDemand`.
+- **TSK-07:** Add `system-prompt` tests for supported `{{toolsets}}`, empty expansion, XML escaping, custom-template omission, and the bundled macro position.
+- **TSK-08:** Add rendering tests for compact and expanded lists, default-shell width limits, Unicode preservation, and omission of parameters and descriptions.
+- **TSK-09:** Prompt-content tests assert only contract text explicitly required by the PRD.
+- **TSK-10:** Implement tests and production changes using RED–GREEN–REFACTOR.
+
+### Validation
+
+- **CHK-01:** Run targeted Bun tests after each behavior slice.
+- **CHK-02:** Run `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify`.
+- **CHK-03:** Validate single-extension loading for `mcp-wrapper` and `system-prompt` with `pi --no-session -p -e`.
+- **CHK-04:** Validate whole-package loading with `pi --no-session -p -e .`.
+- **CHK-05:** Run a live pi check with temporary configuration, an isolated fake MCP server, and a temporary diagnostic extension. Inspect the emitted system prompt and `pi.getActiveTools()` before and after activation.
+- **CHK-06:** Verify the live check independently in a main-agent session and a child-agent session, then remove temporary state.
+
+### Documentation and implementation surface
+
+- **DLV-01:** Add `pi-package/shared/toolsets/contracts.ts`.
+- **DLV-02:** Add `pi-package/shared/toolsets/runtime.ts` and its adjacent tests.
+- **DLV-03:** Add `pi-package/shared/toolsets/rendering.ts` and its adjacent tests.
+- **DLV-04:** Update `pi-package/shared/agent-runtime-composition.ts` and its tests.
+- **DLV-05:** Update `main-agent-selection`, `run-subagent`, and `enable-tools` to use per-session composition.
+- **DLV-06:** Update `mcp-wrapper` configuration, metadata hashing, lifecycle, catalog registration, and behavior tests.
+- **DLV-07:** Update `system-prompt` macro handling, bundled template, documentation, and tests.
+- **DLV-08:** Update `docs/extensions/mcp-wrapper.md`.
+- **DLV-09:** Save this document as `docs/specs/features/on-demand-toolsets/on-demand-toolsets_solution.md`.
+
+## Overengineering and Overspecification Considerations
+
+- **TRD-01:** A shared runtime is required because the provider, system-prompt macro, activation tool, session history, and agent composition cross extension boundaries.
+- **TRD-02:** No standalone toolsets extension is introduced; this avoids another package lifecycle owner.
+- **TRD-03:** Startup discovery remains unchanged. Lazy MCP startup, deactivation, multi-server toolsets, toolset splitting, and non-MCP providers are not implemented.
+- **TRD-04:** The generic provider boundary permits later providers without implementing their behavior now.
+- **TRD-05:** Extending `AgentRuntimeComposition` avoids a second active-tool arbiter and preserves one per-session owner.
+
+## Open Questions
+
+None.
+
+## References
+
+- **REF-01:** `docs/specs/features/on-demand-toolsets/on-demand-toolsets_problem.md` — approved problem statement and glossary.
+- **REF-02:** `docs/specs/features/on-demand-toolsets/on-demand-toolsets_prd.md` — approved requirements.
+- **REF-03:** `docs/extensions/system-prompt.md` — system-prompt macro contract.
+- **REF-04:** `docs/extensions/mcp-wrapper.md` — MCP wrapper behavior and configuration.
+- **REF-05:** `pi-package/shared/agent-runtime-composition.ts` — per-`ExtensionAPI` composition and filtering.
+- **REF-06:** `pi-package/extensions/run-subagent/agent-policy.ts` — child policy and nested-depth behavior.
+- **REF-07:** Pi `docs/extensions.md`, “State Management” — branch-aware state reconstruction through `toolResult.details`.

--- a/docs/specs/issues/subagent-cascade-cancellation/technical-solution.md
+++ b/docs/specs/issues/subagent-cascade-cancellation/technical-solution.md
@@ -1,0 +1,35 @@
+# Technical Solution: Cascade subagent cancellation
+
+## Problem Statement
+- PRB-01: Pi aborts an active main-agent run by emitting `agent_end` with the final assistant message set to `stopReason: "aborted"`; it does not emit `session_shutdown`.
+- PRB-02: The `run-subagent` extension previously started transitive shutdown only from `session_shutdown`, leaving accepted background child processes active after main-agent cancellation.
+- PRB-03: A child can own further child invocations, so stopping only direct child processes would leave deeper descendants active.
+
+## Proposed Solution
+- SOL-01: A shared agent-end classifier reads the final assistant message, ignoring trailing tool-result messages. It classifies only `stopReason: "aborted"` as cancellation and classifies neither provider errors nor missing assistant messages as cancellation.
+- SOL-02: The root `run-subagent` runtime handles an aborted `agent_end` by admitting `recoverRootShutdown` through `RuntimeFailureRecoveryTracker` and awaiting the tracker drain.
+- SOL-03: Worker runtimes do not initiate root recovery from `agent_end`. The root supervisor owns every process and expands cancellation transitively through `ownerRuntimeLeaseId`.
+- SOL-04: Agent-run cancellation retains the root runtime, root writer, management runtime, and recovery admission for later user prompts. Only `session_shutdown` disposes those session-scoped resources.
+- SOL-05: `SubagentCoordinator.shutdown` remains the logical-state authority: it cancels waits and records active invocations as `terminal-aborted` with forced-abort feedback withheld.
+- SOL-06: `InvocationSupervisor.terminateLease` remains the process authority: it expands the complete runtime-lease closure and joins idempotent process teardown.
+- SOL-07: `cmux` and `completion-sound` use the shared final-assistant classifier for their completed-work decisions, preserving their existing behavior.
+- ACC-01: Given an active root child with nested descendants, when the main agent ends with final `stopReason: "aborted"`, every active invocation in the ownership closure becomes terminal-aborted and every corresponding process teardown settles.
+- ACC-02: Given final `stopReason: "stop"`, `"toolUse"`, or `"error"`, the lifecycle handler does not start root recovery.
+- ACC-03: After aborted-run recovery, a later `message_end` can still reconcile through the retained root runtime.
+- ACC-04: Concurrent aborted-run recovery and `session_shutdown` join the recovery tracker and process teardown without duplicate terminal feedback.
+
+## Overengineering and Overspecification Considerations
+- DEC-01: The solution reuses the coordinator, supervisor, persistence recovery, and process escalation already used by `session_shutdown`; it adds no second cancellation graph or process-control path.
+- DEC-02: The shared classifier removes duplicate final-assistant traversal from three extensions and contains no session or process policy.
+- LIM-01: Pi does not expose cancellation of an auto-retry delay as a distinct extension lifecycle event. This solution handles active agent-run cancellation represented by final `stopReason: "aborted"` and session termination represented by `session_shutdown`.
+
+## Open Questions
+
+None.
+
+## References
+- REF-01: `pi-package/extensions/run-subagent/index.ts` - root lifecycle wiring and recovery admission.
+- REF-02: `pi-package/extensions/run-subagent/coordinator.ts` - logical runtime-lease closure and forced-abort state.
+- REF-03: `pi-package/extensions/run-subagent/invocation-supervisor.ts` - transitive process teardown.
+- REF-04: `pi-package/shared/agent-end-state.ts` - final assistant outcome classifier.
+- REF-05: `docs/extensions/run-subagent.md` - user-facing extension behavior.

--- a/docs/specs/issues/subagent-query-error-diagnostics/technical-solution.md
+++ b/docs/specs/issues/subagent-query-error-diagnostics/technical-solution.md
@@ -1,0 +1,38 @@
+# Technical Solution: Subagent Query Error Diagnostics
+
+## Problem Statement
+
+- PRB-01: `executeSubagentQuery` replaces exceptions from `completeAuxiliaryLlm` with `The query failed, please try again later`.
+- PRB-02: `executeSubagentQuery` replaces `AssistantMessage.errorMessage` when `AssistantMessage.stopReason` is `error` with the same generic message.
+- PRB-03: The replacement prevents callers from identifying authentication, provider, transport, and request failures carried by the auxiliary completion boundary.
+
+## Proposed Solution
+
+### SOL-01: Preserve completion diagnostics
+
+- WHILE `completeAuxiliaryLlm` rejects and the query cancellation signal has not won, WHEN `executeSubagentQuery` handles the rejection, THE query SHALL return the thrown value converted by `errorMessage` as its issue.
+- WHILE an assistant response has `stopReason: "error"`, WHEN `errorMessage` is present, THE query SHALL return `AssistantMessage.errorMessage` as its issue.
+- WHILE an assistant response has `stopReason: "error"`, WHEN `errorMessage` is absent, THE query SHALL return `The query failed, please try again later` as its issue.
+- WHILE a query issue crosses the registered tool boundary, WHEN `SubagentToolError` is constructed, THE error message SHALL pass through `sanitizePublicSubagentErrorMessage` before reaching the failed-tool result.
+
+### SOL-02: Verification
+
+- ACC-01: A provider response with `stopReason: "error"` and `errorMessage: "provider failed"` produces the issue `provider failed` and records billed provider cost.
+- ACC-02: A completion rejection with `Error("request timed out")` produces the issue `request timed out` and records no provider cost.
+- ACC-03: Query cancellation continues to propagate Pi's cancellation reason instead of producing `query_failed`.
+
+## Overengineering and Overspecification Considerations
+
+- The change reuses `errorMessage` and the `SubagentToolError` sanitization boundary already used by the extension.
+- The change adds no retry policy, error taxonomy, wrapper, configuration, or persistence field.
+
+## Open Questions
+
+No unresolved design questions remain for this solution.
+
+## References
+
+- REF-01: `pi-package/extensions/run-subagent/subagent-query.ts` - auxiliary query execution and error mapping.
+- REF-02: `pi-package/extensions/run-subagent/error-message.ts` - conversion of thrown values to messages.
+- REF-03: `pi-package/extensions/run-subagent/contracts.ts` - failed-tool error sanitization boundary.
+- REF-04: `pi-package/extensions/run-subagent/subagent-query.test.ts` - provider response and rejection behavior tests.

--- a/pi-package/extensions/cmux/index.ts
+++ b/pi-package/extensions/cmux/index.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { env as processEnv } from "node:process";
 import type {
-	AgentEndEvent,
 	ExtensionAPI,
 	ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
@@ -14,6 +13,7 @@ import {
 	isReadToolResult,
 	isWriteToolResult,
 } from "@earendil-works/pi-coding-agent";
+import { isCompletedAgentRun } from "../../shared/agent-end-state";
 import {
 	getSuiteConfigLocation,
 	isFileNotFoundError,
@@ -73,11 +73,6 @@ interface CmuxSessionContext {
 	};
 }
 
-type AssistantAgentMessage = Extract<
-	AgentEndEvent["messages"][number],
-	{ readonly role: "assistant" }
->;
-
 /** Optional dependencies that isolate environment and clock side effects. */
 export interface CmuxDependencies {
 	readonly env?: NodeJS.ProcessEnv;
@@ -109,7 +104,7 @@ export default function cmux(
 	});
 
 	pi.on("agent_end", async (event) => {
-		if (isChildAgentProcess(runtimeEnv) || !isCompletedWorkEvent(event)) {
+		if (isChildAgentProcess(runtimeEnv) || !isCompletedAgentRun(event)) {
 			return;
 		}
 
@@ -122,30 +117,6 @@ export default function cmux(
 		const body = summarizeSuccess(runState, durationMs);
 		await sendNotification(pi, body);
 	});
-}
-
-/** Returns true only for agent endings that represent completed assistant work. */
-function isCompletedWorkEvent(event: AgentEndEvent): boolean {
-	const lastAssistantMessage = findLastAssistantMessage(event.messages);
-	return (
-		lastAssistantMessage !== undefined &&
-		lastAssistantMessage.stopReason !== "error" &&
-		lastAssistantMessage.stopReason !== "aborted"
-	);
-}
-
-/** Finds the latest assistant message because tool results can follow assistant turns. */
-function findLastAssistantMessage(
-	messages: AgentEndEvent["messages"],
-): AssistantAgentMessage | undefined {
-	for (let index = messages.length - 1; index >= 0; index--) {
-		const message = messages[index];
-		if (message?.role === "assistant") {
-			return message;
-		}
-	}
-
-	return undefined;
 }
 
 /** Creates an empty run state for one agent run start time. */

--- a/pi-package/extensions/completion-sound/index.ts
+++ b/pi-package/extensions/completion-sound/index.ts
@@ -2,10 +2,8 @@ import { type SpawnOptions, spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { platform as getPlatform } from "node:os";
 import { env as processEnv } from "node:process";
-import type {
-	AgentEndEvent,
-	ExtensionAPI,
-} from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isCompletedAgentRun } from "../../shared/agent-end-state";
 import {
 	getSuiteConfigLocation,
 	isFileNotFoundError,
@@ -77,11 +75,6 @@ interface CompletionSoundSessionContext {
 	};
 }
 
-type AssistantAgentMessage = Extract<
-	AgentEndEvent["messages"][number],
-	{ readonly role: "assistant" }
->;
-
 /** Optional dependencies that isolate environment and playback side effects. */
 export interface CompletionSoundDependencies {
 	readonly env?: NodeJS.ProcessEnv;
@@ -106,7 +99,7 @@ export default function completionSound(
 	});
 
 	pi.on("agent_end", async (event) => {
-		if (isChildAgentProcess(runtimeEnv) || !isCompletedWorkEvent(event)) {
+		if (isChildAgentProcess(runtimeEnv) || !isCompletedAgentRun(event)) {
 			return;
 		}
 
@@ -125,30 +118,6 @@ export default function completionSound(
 			return;
 		}
 	});
-}
-
-/** Returns true only for agent endings that represent completed assistant work. */
-function isCompletedWorkEvent(event: AgentEndEvent): boolean {
-	const lastAssistantMessage = findLastAssistantMessage(event.messages);
-	return (
-		lastAssistantMessage !== undefined &&
-		lastAssistantMessage.stopReason !== "error" &&
-		lastAssistantMessage.stopReason !== "aborted"
-	);
-}
-
-/** Finds the latest assistant message because tool results can follow assistant turns. */
-function findLastAssistantMessage(
-	messages: AgentEndEvent["messages"],
-): AssistantAgentMessage | undefined {
-	for (let index = messages.length - 1; index >= 0; index--) {
-		const message = messages[index];
-		if (message?.role === "assistant") {
-			return message;
-		}
-	}
-
-	return undefined;
 }
 
 /** Reads and validates config while missing config keeps platform-default playback enabled. */

--- a/pi-package/extensions/consult-advisor/index.ts
+++ b/pi-package/extensions/consult-advisor/index.ts
@@ -196,6 +196,7 @@ export default function consultAdvisor(
 		},
 	};
 	registerPackageTool(pi, definition);
+	getAgentRuntimeComposition(pi).publishBaselineToolNames([TOOL_NAME]);
 }
 
 /** Executes one advisor model call after strict config, prompt, and model validation. */

--- a/pi-package/extensions/convene-council/index.ts
+++ b/pi-package/extensions/convene-council/index.ts
@@ -101,4 +101,5 @@ export default function conveneCouncil(
 		},
 	};
 	registerPackageTool(pi, definition);
+	getAgentRuntimeComposition(pi).publishBaselineToolNames([TOOL_NAME]);
 }

--- a/pi-package/extensions/enable-tools/index.ts
+++ b/pi-package/extensions/enable-tools/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition";
 import { readExtensionConfigFile } from "../../shared/agent-suite-storage";
 
 /** Suite directory owned only by this extension. */
@@ -59,18 +60,13 @@ export default function enableSearchTools(pi: ExtensionAPI): void {
 			pi.getAllTools().map((tool) => tool.name),
 		);
 		const excludedToolNames = new Set(config.config.exclude);
-		const activeToolNames = new Set(pi.getActiveTools());
-
-		for (const toolName of config.config.include) {
-			if (
-				availableToolNames.has(toolName) &&
-				!excludedToolNames.has(toolName)
-			) {
-				activeToolNames.add(toolName);
-			}
-		}
-
-		pi.setActiveTools([...activeToolNames]);
+		const includedToolNames = config.config.include.filter(
+			(toolName) =>
+				availableToolNames.has(toolName) && !excludedToolNames.has(toolName),
+		);
+		// The composition owns the final active list, so enabling defaults cannot
+		// restore a tool removed by an agent or child policy.
+		getAgentRuntimeComposition(pi).addBaselineToolNames(includedToolNames);
 	});
 }
 

--- a/pi-package/extensions/main-agent-selection/index.test.ts
+++ b/pi-package/extensions/main-agent-selection/index.test.ts
@@ -120,7 +120,8 @@ function createExtensionApiFake(
 	const setModelCalls: Model<Api>[] = [];
 	const thinkingCalls: string[] = [];
 	const activeToolCalls: string[][] = [];
-	let currentActiveTools = [...(options.activeTools ?? [])];
+	const allToolNames = options.allTools ?? ["read", "bash", "edit", "write"];
+	let currentActiveTools = [...(options.activeTools ?? allToolNames)];
 	let currentThinkingLevel = "medium";
 	const setModelResults = [...(options.setModelResults ?? [])];
 	const flagValues = new Map<string, boolean | string>(
@@ -191,14 +192,12 @@ function createExtensionApiFake(
 			activeToolCalls.push(toolNames);
 		},
 		getAllTools() {
-			return (options.allTools ?? ["read", "bash", "edit", "write"]).map(
-				(name) => ({
-					name,
-					description: name,
-					parameters: {},
-					sourceInfo: { path: "fake" },
-				}),
-			);
+			return allToolNames.map((name) => ({
+				name,
+				description: name,
+				parameters: {},
+				sourceInfo: { path: "fake" },
+			}));
 		},
 		getActiveTools(): string[] {
 			return [...currentActiveTools];
@@ -1392,7 +1391,7 @@ describe("main-agent-selection", () => {
 				body: "Sage prompt",
 			});
 			const oldPi = createExtensionApiFake({
-				activeTools: ["read", "bash"],
+				activeTools: ["read", "bash", "write"],
 				allTools: ["read", "bash", "edit", "write"],
 			});
 			const oldCtx = createCommandContext(
@@ -1422,7 +1421,7 @@ describe("main-agent-selection", () => {
 			);
 
 			const resumedPi = createExtensionApiFake({
-				activeTools: ["read", "bash"],
+				activeTools: ["read", "bash", "write"],
 				allTools: ["read", "bash", "edit", "write"],
 			});
 			const resumedCtx = createCommandContext(
@@ -1523,7 +1522,7 @@ describe("main-agent-selection", () => {
 				body: "Sage prompt",
 			});
 			const oldPi = createExtensionApiFake({
-				activeTools: ["read", "bash"],
+				activeTools: ["read", "bash", "write"],
 				allTools: ["read", "bash", "edit", "write"],
 			});
 			const oldCtx = createCommandContext("/tmp/project", undefined, [model]);
@@ -1541,7 +1540,7 @@ describe("main-agent-selection", () => {
 			);
 
 			const newPi = createExtensionApiFake({
-				activeTools: ["read", "bash"],
+				activeTools: ["read", "bash", "write"],
 				allTools: ["read", "bash", "edit", "write"],
 			});
 			const newCtx = createCommandContext("/tmp/project", undefined, [model]);
@@ -1859,7 +1858,7 @@ describe("main-agent-selection", () => {
 				body: "Builder system prompt",
 				tools: ["write"],
 			});
-			const pi = createExtensionApiFake({ activeTools: ["read"] });
+			const pi = createExtensionApiFake({ activeTools: ["read", "write"] });
 			const ctx = createCommandContext("/tmp/project");
 			mainAgentSelection(pi);
 
@@ -1870,7 +1869,7 @@ describe("main-agent-selection", () => {
 				cwd: "/tmp/project",
 				activeAgentId: null,
 			});
-			expect(pi.activeToolCalls).toEqual([["write"], ["read"]]);
+			expect(pi.activeToolCalls).toEqual([["write"], ["read", "write"]]);
 			expect(ctx.statusCalls).toEqual([]);
 			expect(
 				await getBeforeAgentStartHandler(pi)(
@@ -2605,7 +2604,7 @@ describe("main-agent-selection", () => {
 				tools: ["bash"],
 			});
 			const pi = createExtensionApiFake({
-				activeTools: ["read"],
+				activeTools: ["read", "write"],
 				setModelResults: [true, false],
 			});
 			const ctx = createCommandContext("/tmp/project", undefined, [
@@ -2620,7 +2619,7 @@ describe("main-agent-selection", () => {
 			expect(ctx.notifications[0]?.message).toStartWith(
 				"[main-agent-selection]",
 			);
-			expect(pi.activeToolCalls).toEqual([["write"], ["read"]]);
+			expect(pi.activeToolCalls).toEqual([["write"], ["read", "write"]]);
 			expect(ctx.statusCalls).toEqual([]);
 			expect(
 				await getBeforeAgentStartHandler(pi)(
@@ -2785,14 +2784,19 @@ describe("main-agent-selection", () => {
 				description: "Plans work",
 				body: "Planner prompt",
 			});
-			const pi = createExtensionApiFake({ activeTools: ["read", "bash"] });
+			const pi = createExtensionApiFake({
+				activeTools: ["read", "bash", "write"],
+			});
 			const ctx = createCommandContext("/tmp/project");
 			mainAgentSelection(pi);
 
 			await getCommand(pi, "agent").handler("writer", ctx);
 			await getCommand(pi, "agent").handler("planner", ctx);
 
-			expect(pi.activeToolCalls).toEqual([["write"], ["read", "bash"]]);
+			expect(pi.activeToolCalls).toEqual([
+				["write"],
+				["read", "bash", "write"],
+			]);
 		});
 	});
 

--- a/pi-package/extensions/mcp-wrapper/config.test.ts
+++ b/pi-package/extensions/mcp-wrapper/config.test.ts
@@ -93,6 +93,86 @@ describe("mcp-wrapper config", () => {
 		});
 	});
 
+	test("accepts a strict onDemand toolset declaration", () => {
+		const result = parseMcpWrapperConfig({
+			mcpServers: {
+				files: {
+					command: "server",
+					onDemand: { name: "files", description: "Read files when needed" },
+				},
+			},
+		});
+
+		expect(result.kind).toBe("valid");
+		if (result.kind !== "valid") {
+			throw new Error(result.issue);
+		}
+		expect(result.config.mcpServers["files"]).toMatchObject({
+			onDemand: { name: "files", description: "Read files when needed" },
+		});
+	});
+
+	test("accepts exact case-sensitive on-demand names across transport types", () => {
+		// Purpose: exact names with different case must remain distinct across stdio and HTTP servers.
+		// Input and expected output: two valid declarations parse without normalization.
+		// Edge case: name identity differs only by case.
+		// Dependencies: strict root and transport parsing only.
+		const result = parseMcpWrapperConfig({
+			mcpServers: {
+				files: {
+					command: "server",
+					onDemand: { name: "Files", description: "Read files" },
+				},
+				docs: {
+					type: "streamableHttp",
+					url: "https://example.com/mcp",
+					onDemand: { name: "files", description: "Read documentation" },
+				},
+			},
+		});
+
+		expect(result.kind).toBe("valid");
+	});
+
+	test("rejects duplicate and malformed on-demand declarations", () => {
+		// Purpose: invalid declarations must enter the extension's existing invalid-config path.
+		// Input and expected output: duplicates, extra keys, empty values, and surrounding whitespace are rejected.
+		// Edge case: duplicate identity spans stdio and HTTP servers.
+		// Dependencies: strict server parsing and cross-server validation only.
+		const invalidOnDemandValues = [
+			{ name: "", description: "Read files" },
+			{ name: "files", description: "" },
+			{ name: " files", description: "Read files" },
+			{ name: "files ", description: "Read files" },
+			{ name: "files", description: " Read files" },
+			{ name: "files", description: "Read files " },
+			{ name: "files", description: "Read files", extra: true },
+		];
+		for (const onDemand of invalidOnDemandValues) {
+			expect(
+				parseMcpWrapperConfig({
+					mcpServers: { files: { command: "server", onDemand } },
+				}).kind,
+			).toBe("invalid");
+		}
+
+		expect(
+			parseMcpWrapperConfig({
+				mcpServers: {
+					files: {
+						command: "server",
+						onDemand: { name: "shared", description: "Read files" },
+					},
+					docs: {
+						type: "streamableHttp",
+						url: "https://example.com/mcp",
+						onDemand: { name: "shared", description: "Read docs" },
+					},
+				},
+			}).kind,
+		).toBe("invalid");
+	});
+
 	test("rejects unsupported config keys and invalid primitive values", () => {
 		expect(parseMcpWrapperConfig({ "mcp-servers": {} }).kind).toBe("invalid");
 		expect(

--- a/pi-package/extensions/mcp-wrapper/config.test.ts
+++ b/pi-package/extensions/mcp-wrapper/config.test.ts
@@ -27,7 +27,9 @@ describe("mcp-wrapper config", () => {
 	});
 
 	test("preserves nonblank additional instructions for both transports", () => {
-		const localText = "  First line\\n\\nSecond line  ";
+		const localText = `  First line
+
+Second line  `;
 		const result = parseMcpWrapperConfig({
 			mcpServers: {
 				files: { command: "server", additionalInstructions: localText },
@@ -56,6 +58,11 @@ describe("mcp-wrapper config", () => {
 			mcpServers: {
 				empty: { command: "server", additionalInstructions: "" },
 				whitespace: { command: "server", additionalInstructions: " \n\t" },
+				httpWhitespace: {
+					type: "streamableHttp",
+					url: "https://example.com/mcp",
+					additionalInstructions: " \n\t",
+				},
 			},
 		});
 
@@ -69,6 +76,9 @@ describe("mcp-wrapper config", () => {
 		expect(result.config.mcpServers["whitespace"]).not.toHaveProperty(
 			"additionalInstructions",
 		);
+		expect(result.config.mcpServers["httpWhitespace"]).not.toHaveProperty(
+			"additionalInstructions",
+		);
 	});
 
 	test("rejects non-string additional instructions", () => {
@@ -77,6 +87,17 @@ describe("mcp-wrapper config", () => {
 				parseMcpWrapperConfig({
 					mcpServers: {
 						files: { command: "server", additionalInstructions: value },
+					},
+				}).kind,
+			).toBe("invalid");
+			expect(
+				parseMcpWrapperConfig({
+					mcpServers: {
+						docs: {
+							type: "streamableHttp",
+							url: "https://example.com/mcp",
+							additionalInstructions: value,
+						},
 					},
 				}).kind,
 			).toBe("invalid");

--- a/pi-package/extensions/mcp-wrapper/config.test.ts
+++ b/pi-package/extensions/mcp-wrapper/config.test.ts
@@ -26,6 +26,63 @@ describe("mcp-wrapper config", () => {
 		});
 	});
 
+	test("preserves nonblank additional instructions for both transports", () => {
+		const localText = "  First line\\n\\nSecond line  ";
+		const result = parseMcpWrapperConfig({
+			mcpServers: {
+				files: { command: "server", additionalInstructions: localText },
+				docs: {
+					type: "streamableHttp",
+					url: "https://example.com/mcp",
+					additionalInstructions: localText,
+				},
+			},
+		});
+
+		expect(result.kind).toBe("valid");
+		if (result.kind !== "valid") {
+			throw new Error(result.issue);
+		}
+		expect(result.config.mcpServers["files"]).toMatchObject({
+			additionalInstructions: localText,
+		});
+		expect(result.config.mcpServers["docs"]).toMatchObject({
+			additionalInstructions: localText,
+		});
+	});
+
+	test("omits empty and whitespace-only additional instructions", () => {
+		const result = parseMcpWrapperConfig({
+			mcpServers: {
+				empty: { command: "server", additionalInstructions: "" },
+				whitespace: { command: "server", additionalInstructions: " \n\t" },
+			},
+		});
+
+		expect(result.kind).toBe("valid");
+		if (result.kind !== "valid") {
+			throw new Error(result.issue);
+		}
+		expect(result.config.mcpServers["empty"]).not.toHaveProperty(
+			"additionalInstructions",
+		);
+		expect(result.config.mcpServers["whitespace"]).not.toHaveProperty(
+			"additionalInstructions",
+		);
+	});
+
+	test("rejects non-string additional instructions", () => {
+		for (const value of [null, 1, false, {}, []]) {
+			expect(
+				parseMcpWrapperConfig({
+					mcpServers: {
+						files: { command: "server", additionalInstructions: value },
+					},
+				}).kind,
+			).toBe("invalid");
+		}
+	});
+
 	test("accepts an empty mcpServers object without registering server configs", () => {
 		const result = parseMcpWrapperConfig({
 			settings: { enabled: true },

--- a/pi-package/extensions/mcp-wrapper/config.ts
+++ b/pi-package/extensions/mcp-wrapper/config.ts
@@ -22,14 +22,32 @@ const TIMEOUT_KEYS = [
 	"callSeconds",
 	"maxTotalSeconds",
 ] as const;
-const STDIO_SERVER_KEYS = ["type", "command", "args", "env", "cwd"] as const;
-const STREAMABLE_HTTP_SERVER_KEYS = ["type", "url", "headers"] as const;
+const STDIO_SERVER_KEYS = [
+	"type",
+	"command",
+	"args",
+	"env",
+	"cwd",
+	"onDemand",
+] as const;
+const STREAMABLE_HTTP_SERVER_KEYS = [
+	"type",
+	"url",
+	"headers",
+	"onDemand",
+] as const;
+const ON_DEMAND_KEYS = ["name", "description"] as const;
 
 export interface McpWrapperTimeouts {
 	readonly startupSeconds: number;
 	readonly listToolsSeconds: number;
 	readonly callSeconds: number;
 	readonly maxTotalSeconds: number;
+}
+
+export interface McpOnDemandConfig {
+	readonly name: string;
+	readonly description: string;
 }
 
 export type McpServerConfig =
@@ -39,11 +57,13 @@ export type McpServerConfig =
 			readonly args: readonly string[];
 			readonly env: Readonly<Record<string, string>>;
 			readonly cwd?: string;
+			readonly onDemand?: McpOnDemandConfig;
 	  }
 	| {
 			readonly type: "streamableHttp";
 			readonly url: string;
 			readonly headers: Readonly<Record<string, string>>;
+			readonly onDemand?: McpOnDemandConfig;
 	  };
 
 export interface McpWrapperConfig {
@@ -218,6 +238,7 @@ function parseMcpServers(value: unknown):
 	}
 
 	const mcpServers: Record<string, McpServerConfig> = {};
+	const onDemandNames = new Set<string>();
 	for (const [serverKey, serverConfig] of Object.entries(value)) {
 		if (serverKey.trim().length === 0) {
 			return invalidConfig("mcpServers keys must be non-empty");
@@ -225,6 +246,13 @@ function parseMcpServers(value: unknown):
 		const serverResult = parseMcpServerConfig(serverConfig);
 		if (serverResult.kind === "invalid") {
 			return serverResult;
+		}
+		const onDemandName = serverResult.serverConfig.onDemand?.name;
+		if (onDemandName !== undefined && onDemandNames.has(onDemandName)) {
+			return invalidConfig(`duplicate onDemand.name: ${onDemandName}`);
+		}
+		if (onDemandName !== undefined) {
+			onDemandNames.add(onDemandName);
 		}
 		mcpServers[serverKey] = serverResult.serverConfig;
 	}
@@ -268,6 +296,10 @@ function parseStdioServerConfig(
 	const args = value["args"];
 	const env = value["env"];
 	const cwd = value["cwd"];
+	const onDemand = parseOnDemand(value["onDemand"]);
+	if (onDemand.kind === "invalid") {
+		return onDemand;
+	}
 
 	if (typeof command !== "string" || command.length === 0) {
 		return invalidConfig("stdio.command must be a non-empty string");
@@ -290,6 +322,7 @@ function parseStdioServerConfig(
 			args: args ?? [],
 			env: env ?? {},
 			...(cwd !== undefined ? { cwd } : {}),
+			...(onDemand.value !== undefined ? { onDemand: onDemand.value } : {}),
 		},
 	};
 }
@@ -309,6 +342,10 @@ function parseStreamableHttpServerConfig(
 
 	const url = value["url"];
 	const headers = value["headers"];
+	const onDemand = parseOnDemand(value["onDemand"]);
+	if (onDemand.kind === "invalid") {
+		return onDemand;
+	}
 
 	if (typeof url !== "string" || url.length === 0) {
 		return invalidConfig("streamableHttp.url must be a non-empty string");
@@ -325,8 +362,45 @@ function parseStreamableHttpServerConfig(
 			type: "streamableHttp",
 			url,
 			headers: headers ?? {},
+			...(onDemand.value !== undefined ? { onDemand: onDemand.value } : {}),
 		},
 	};
+}
+
+/** Parses the optional deferred-toolset identity without accepting legacy forms. */
+function parseOnDemand(
+	value: unknown,
+):
+	| { readonly kind: "valid"; readonly value: McpOnDemandConfig | undefined }
+	| InvalidConfigResult {
+	if (value === undefined) {
+		return { kind: "valid", value: undefined };
+	}
+	if (
+		!isRecord(value) ||
+		findUnsupportedKey(value, ON_DEMAND_KEYS) !== undefined
+	) {
+		return invalidConfig("onDemand must contain only name and description");
+	}
+	const name = value["name"];
+	const description = value["description"];
+	if (
+		typeof name !== "string" ||
+		name.trim().length === 0 ||
+		name !== name.trim()
+	) {
+		return invalidConfig("onDemand.name must be a trimmed non-empty string");
+	}
+	if (
+		typeof description !== "string" ||
+		description.trim().length === 0 ||
+		description !== description.trim()
+	) {
+		return invalidConfig(
+			"onDemand.description must be a trimmed non-empty string",
+		);
+	}
+	return { kind: "valid", value: { name, description } };
 }
 
 /** Builds a fail-closed parser result with a safe diagnostic. */

--- a/pi-package/extensions/mcp-wrapper/config.ts
+++ b/pi-package/extensions/mcp-wrapper/config.ts
@@ -29,12 +29,14 @@ const STDIO_SERVER_KEYS = [
 	"env",
 	"cwd",
 	"onDemand",
+	"additionalInstructions",
 ] as const;
 const STREAMABLE_HTTP_SERVER_KEYS = [
 	"type",
 	"url",
 	"headers",
 	"onDemand",
+	"additionalInstructions",
 ] as const;
 const ON_DEMAND_KEYS = ["name", "description"] as const;
 
@@ -58,12 +60,14 @@ export type McpServerConfig =
 			readonly env: Readonly<Record<string, string>>;
 			readonly cwd?: string;
 			readonly onDemand?: McpOnDemandConfig;
+			readonly additionalInstructions?: string;
 	  }
 	| {
 			readonly type: "streamableHttp";
 			readonly url: string;
 			readonly headers: Readonly<Record<string, string>>;
 			readonly onDemand?: McpOnDemandConfig;
+			readonly additionalInstructions?: string;
 	  };
 
 export interface McpWrapperConfig {
@@ -300,29 +304,30 @@ function parseStdioServerConfig(
 	if (onDemand.kind === "invalid") {
 		return onDemand;
 	}
+	const additionalInstructions = parseAdditionalInstructions(
+		value["additionalInstructions"],
+	);
+	if (additionalInstructions.kind === "invalid") {
+		return additionalInstructions;
+	}
 
-	if (typeof command !== "string" || command.length === 0) {
-		return invalidConfig("stdio.command must be a non-empty string");
-	}
-	if (args !== undefined && !isStringArray(args)) {
-		return invalidConfig("stdio.args must be an array of strings");
-	}
-	if (env !== undefined && !isStringRecord(env)) {
-		return invalidConfig("stdio.env must be an object with string values");
-	}
-	if (cwd !== undefined && typeof cwd !== "string") {
-		return invalidConfig("stdio.cwd must be a string");
+	const fields = parseStdioServerFields(command, args, env, cwd);
+	if (fields.kind === "invalid") {
+		return fields;
 	}
 
 	return {
 		kind: "valid",
 		serverConfig: {
 			type: "stdio",
-			command,
-			args: args ?? [],
-			env: env ?? {},
-			...(cwd !== undefined ? { cwd } : {}),
+			command: fields.command,
+			args: fields.args,
+			env: fields.env,
+			...(fields.cwd !== undefined ? { cwd: fields.cwd } : {}),
 			...(onDemand.value !== undefined ? { onDemand: onDemand.value } : {}),
+			...(additionalInstructions.value !== undefined
+				? { additionalInstructions: additionalInstructions.value }
+				: {}),
 		},
 	};
 }
@@ -346,6 +351,12 @@ function parseStreamableHttpServerConfig(
 	if (onDemand.kind === "invalid") {
 		return onDemand;
 	}
+	const additionalInstructions = parseAdditionalInstructions(
+		value["additionalInstructions"],
+	);
+	if (additionalInstructions.kind === "invalid") {
+		return additionalInstructions;
+	}
 
 	if (typeof url !== "string" || url.length === 0) {
 		return invalidConfig("streamableHttp.url must be a non-empty string");
@@ -363,7 +374,63 @@ function parseStreamableHttpServerConfig(
 			url,
 			headers: headers ?? {},
 			...(onDemand.value !== undefined ? { onDemand: onDemand.value } : {}),
+			...(additionalInstructions.value !== undefined
+				? { additionalInstructions: additionalInstructions.value }
+				: {}),
 		},
+	};
+}
+
+function parseStdioServerFields(
+	command: unknown,
+	args: unknown,
+	env: unknown,
+	cwd: unknown,
+):
+	| {
+			readonly kind: "valid";
+			readonly command: string;
+			readonly args: readonly string[];
+			readonly env: Readonly<Record<string, string>>;
+			readonly cwd: string | undefined;
+	  }
+	| InvalidConfigResult {
+	if (typeof command !== "string" || command.length === 0) {
+		return invalidConfig("stdio.command must be a non-empty string");
+	}
+	if (args !== undefined && !isStringArray(args)) {
+		return invalidConfig("stdio.args must be an array of strings");
+	}
+	if (env !== undefined && !isStringRecord(env)) {
+		return invalidConfig("stdio.env must be an object with string values");
+	}
+	if (cwd !== undefined && typeof cwd !== "string") {
+		return invalidConfig("stdio.cwd must be a string");
+	}
+	return {
+		kind: "valid",
+		command,
+		args: args ?? [],
+		env: env ?? {},
+		cwd,
+	};
+}
+
+/** Uses trimmed text only to detect presence while preserving nonblank input unchanged. */
+function parseAdditionalInstructions(
+	value: unknown,
+):
+	| { readonly kind: "valid"; readonly value: string | undefined }
+	| InvalidConfigResult {
+	if (value === undefined) {
+		return { kind: "valid", value: undefined };
+	}
+	if (typeof value !== "string") {
+		return invalidConfig("additionalInstructions must be a string");
+	}
+	return {
+		kind: "valid",
+		value: value.trim().length > 0 ? value : undefined,
 	};
 }
 

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -547,6 +547,82 @@ describe("mcp-wrapper extension", () => {
 		expect(await runBeforeAgentStart(pi)).toContain("Use deferred search.");
 	});
 
+	test("restores resumed activation after cacheless live discovery finalizes the catalog", async () => {
+		// Purpose: startup restoration must validate history against live metadata rather than the empty preload catalog.
+		// Input and expected output: a cacheless resumed branch names the discovered toolset, which starts active without a stale warning.
+		// Edge case: the preload catalog is empty even though live discovery returns the same configured deferred server.
+		// Dependencies: shared toolset history restoration, MCP startup discovery, composition, and instruction filtering.
+		const pi = createExtensionApiFake();
+		const notifications: NotificationRecord[] = [];
+		const sessionManager = {
+			getBranch: () => [
+				{
+					type: "message",
+					message: {
+						role: "toolResult",
+						toolName: "activate_toolset",
+						isError: false,
+						details: { version: 1, activeToolsets: ["search-suite"] },
+					},
+				},
+			],
+		} as unknown as SessionManager;
+		const manager = managerWithCleanup({
+			discoverServers: async () => ({
+				serverToolLists: [
+					{
+						serverKey: "deferred",
+						tools: [{ name: "search", inputSchema: { type: "object" } }],
+					},
+				],
+				serverInstructions: [
+					{ serverKey: "deferred", instructions: "Use deferred search." },
+				],
+				failures: [],
+			}),
+			callTool: async () => ({ content: [] }),
+		});
+		await mcpWrapper(pi, {
+			readConfig: async () => ({
+				kind: "valid",
+				config: {
+					enabled: true,
+					timeouts: {
+						startupSeconds: 30,
+						listToolsSeconds: 15,
+						callSeconds: 120,
+						maxTotalSeconds: 180,
+					},
+					widgetLineBudget: 5,
+					mcpServers: {
+						deferred: {
+							type: "stdio",
+							command: "deferred",
+							args: [],
+							env: {},
+							onDemand: {
+								name: "search-suite",
+								description: "Search when needed",
+							},
+						},
+					},
+				},
+			}),
+			loadCache: async () => null,
+			saveCache: async () => {},
+			createManager: () => manager,
+		});
+
+		await runSessionStart(pi, notifications, [], sessionManager);
+
+		expect(pi.getActiveTools()).toEqual(["deferred_search"]);
+		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([]);
+		expect(await runBeforeAgentStart(pi)).toContain("Use deferred search.");
+		expect(
+			notifications.some(({ message }) => message.includes("stale activated")),
+		).toBe(false);
+	});
+
 	test("omits deferred activation routes when metadata loading fails", async () => {
 		// Purpose: only successfully loaded deferred metadata may enter the toolset catalog.
 		// Input and expected output: discovery failure leaves no visible trigger or exact activation route.
@@ -806,9 +882,9 @@ describe("mcp-wrapper extension", () => {
 	});
 
 	test("registers cached tools before session start", async () => {
-		// Purpose: resumed history needs MCP tool renderers before Pi emits session_start.
-		// Input and expected output: a complete cache registers one tool during awaited extension loading and does not register it again at session start.
-		// Edge case: cached registration must not start live MCP discovery.
+		// Purpose: resumed history needs MCP tool renderers and its activation catalog before Pi emits session_start.
+		// Input and expected output: a complete cache registers one deferred tool once and restores its branch activation at session start.
+		// Edge case: cached startup restoration must not wait for background live discovery.
 		// Dependencies: this test uses injected config, cache storage, and an in-memory manager fake.
 		await prepareSuiteCacheDir();
 		const pi = createExtensionApiFake();
@@ -817,6 +893,10 @@ describe("mcp-wrapper extension", () => {
 			command: "node",
 			args: [],
 			env: {},
+			onDemand: {
+				name: "files-suite",
+				description: "Use cached files",
+			},
 		};
 		await saveMcpWrapperCache({
 			version: 1,
@@ -881,12 +961,27 @@ describe("mcp-wrapper extension", () => {
 			},
 		]);
 		expect(discoveryCalls).toBe(0);
-		expect(await resolvesWithin(runSessionStart(pi), 25)).toBe(true);
+		const sessionManager = {
+			getBranch: () => [
+				{
+					type: "message",
+					message: {
+						role: "toolResult",
+						toolName: "activate_toolset",
+						isError: false,
+						details: { version: 1, activeToolsets: ["files-suite"] },
+					},
+				},
+			],
+		} as unknown as SessionManager;
+		expect(
+			await resolvesWithin(runSessionStart(pi, [], [], sessionManager), 25),
+		).toBe(true);
 		expect(pi.tools.map((tool) => tool.name)).toEqual([
 			"activate_toolset",
 			FILES_READ_TOOL_NAME,
 		]);
-		pi.setActiveTools([FILES_READ_TOOL_NAME]);
+		expect(pi.getActiveTools()).toEqual([FILES_READ_TOOL_NAME]);
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
 			"Use cached file instructions.",
 		);

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -13,7 +13,9 @@ import {
 	createEventBus,
 	SessionManager,
 } from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition.ts";
 import { AGENT_SUITE_DIR_ENV } from "../../shared/agent-suite-storage.ts";
+import { getToolsetRuntime } from "../../shared/toolsets/runtime.ts";
 import { createToolPresentationRegistry } from "../run-subagent/tool-rendering.ts";
 import type { McpClientManager } from "./client-manager.ts";
 import type { McpServerConfig } from "./config.ts";
@@ -62,6 +64,7 @@ interface NotificationRecord {
 }
 
 interface ExtensionApiFake extends ExtensionAPI {
+	readonly activeToolHistory: string[][];
 	readonly commands: Array<
 		Omit<RegisteredCommand, "name" | "sourceInfo"> & { readonly name: string }
 	>;
@@ -99,9 +102,11 @@ function createExtensionApiFake(
 	> = [];
 	const handlers: RegisteredHandler[] = [];
 	const tools: ToolDefinition[] = [];
+	const activeToolHistory: string[][] = [];
 	let activeTools: readonly string[] = [];
 
 	return {
+		activeToolHistory,
 		commands,
 		handlers,
 		tools,
@@ -134,6 +139,7 @@ function createExtensionApiFake(
 		},
 		setActiveTools(toolNames: readonly string[]): void {
 			activeTools = [...toolNames];
+			activeToolHistory.push([...toolNames]);
 		},
 		getModel(): undefined {
 			return undefined;
@@ -162,33 +168,37 @@ async function runSessionStart(
 	statuses: Array<{ readonly key: string; readonly text: string }> = [],
 	sessionManager: SessionManager = SessionManager.inMemory(),
 ): Promise<void> {
-	const sessionStart = pi.handlers.find(
+	const sessionStarts = pi.handlers.filter(
 		(handler) => handler.eventName === "session_start",
 	);
-	expect(sessionStart).toBeDefined();
-	await sessionStart?.handler({ type: "session_start", reason: "startup" }, {
-		hasUI: true,
-		sessionManager,
-		ui: {
-			notify(message: string, type?: "info" | "warning" | "error"): void {
-				notifications.push({ message, type });
+	expect(sessionStarts.length).toBeGreaterThan(0);
+	for (const sessionStart of sessionStarts) {
+		await sessionStart.handler({ type: "session_start", reason: "startup" }, {
+			hasUI: true,
+			sessionManager,
+			ui: {
+				notify(message: string, type?: "info" | "warning" | "error"): void {
+					notifications.push({ message, type });
+				},
+				setStatus(key: string, text: string): void {
+					statuses.push({ key, text });
+				},
 			},
-			setStatus(key: string, text: string): void {
-				statuses.push({ key, text });
-			},
-		},
-	} as unknown as ExtensionContext);
+		} as unknown as ExtensionContext);
+	}
 }
 
 async function runSessionShutdown(pi: ExtensionApiFake): Promise<void> {
-	const sessionShutdown = pi.handlers.find(
+	const sessionShutdowns = pi.handlers.filter(
 		(handler) => handler.eventName === "session_shutdown",
 	);
-	expect(sessionShutdown).toBeDefined();
-	await sessionShutdown?.handler(
-		{ type: "session_shutdown" },
-		{} as ExtensionContext,
-	);
+	expect(sessionShutdowns.length).toBeGreaterThan(0);
+	for (const sessionShutdown of sessionShutdowns) {
+		await sessionShutdown.handler(
+			{ type: "session_shutdown" },
+			{} as ExtensionContext,
+		);
+	}
 }
 
 async function runCommand(
@@ -304,7 +314,8 @@ describe("mcp-wrapper extension", () => {
 
 		await runSessionStart(pi, notifications);
 
-		expect(pi.tools).toHaveLength(0);
+		expect(pi.tools.map((tool) => tool.name)).toEqual(["activate_toolset"]);
+		expect(pi.getActiveTools()).toEqual([]);
 		expect(notifications).toEqual([]);
 	});
 
@@ -321,7 +332,8 @@ describe("mcp-wrapper extension", () => {
 
 		await runSessionStart(pi, notifications);
 
-		expect(pi.tools).toHaveLength(0);
+		expect(pi.tools.map((tool) => tool.name)).toEqual(["activate_toolset"]);
+		expect(pi.getActiveTools()).toEqual([]);
 		expect(notifications).toEqual([
 			{ message: "[mcp-wrapper] config must be an object", type: "warning" },
 		]);
@@ -379,7 +391,9 @@ describe("mcp-wrapper extension", () => {
 
 		const notifications: NotificationRecord[] = [];
 		await runSessionStart(pi, notifications);
-		const tool = pi.tools[0];
+		const tool = pi.tools.find(
+			(candidate) => candidate.name === FILES_READ_TOOL_NAME,
+		);
 		expect(tool?.name).toBe(FILES_READ_TOOL_NAME);
 		expect(tool?.description).toBe('Tool from MCP server "files": Read a file');
 		expect(tool?.promptSnippet).toBe(
@@ -438,6 +452,260 @@ describe("mcp-wrapper extension", () => {
 		]);
 	});
 
+	test("publishes loaded eager and deferred MCP catalogs through composition", async () => {
+		// Purpose: loaded metadata must register every definition while only eager tools start active.
+		// Input and expected output: eager and deferred servers load; activation exposes the deferred tool and instructions.
+		// Edge case: activation uses the already loaded catalog without another discovery or connection step.
+		// Dependencies: shared toolset runtime, composition, MCP manager routing, and instruction filtering.
+		const pi = createExtensionApiFake();
+		let discoveryCalls = 0;
+		const manager = {
+			discoverServers: async () => {
+				discoveryCalls += 1;
+				return {
+					serverToolLists: [
+						{
+							serverKey: "eager",
+							tools: [{ name: "read", inputSchema: { type: "object" } }],
+						},
+						{
+							serverKey: "deferred",
+							tools: [{ name: "search", inputSchema: { type: "object" } }],
+						},
+					],
+					serverInstructions: [
+						{ serverKey: "eager", instructions: "Use eager files." },
+						{ serverKey: "deferred", instructions: "Use deferred search." },
+					],
+					failures: [],
+				};
+			},
+			callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+		};
+		await mcpWrapper(pi, {
+			readConfig: async () => ({
+				kind: "valid",
+				config: {
+					enabled: true,
+					timeouts: {
+						startupSeconds: 30,
+						listToolsSeconds: 15,
+						callSeconds: 120,
+						maxTotalSeconds: 180,
+					},
+					widgetLineBudget: 5,
+					mcpServers: {
+						eager: { type: "stdio", command: "eager", args: [], env: {} },
+						deferred: {
+							type: "stdio",
+							command: "deferred",
+							args: [],
+							env: {},
+							onDemand: {
+								name: "search-suite",
+								description: "Search when needed",
+							},
+						},
+					},
+				},
+			}),
+			loadCache: async () => null,
+			saveCache: async () => {},
+			createManager: () => managerWithCleanup(manager),
+		});
+
+		await runSessionStart(pi);
+		expect(pi.tools.map((tool) => tool.name)).toEqual([
+			"activate_toolset",
+			"eager_read",
+			"deferred_search",
+		]);
+		expect(pi.getActiveTools()).toEqual(["activate_toolset", "eager_read"]);
+		expect(await runBeforeAgentStart(pi)).toContain("Use eager files.");
+		expect(await runBeforeAgentStart(pi)).not.toContain("Use deferred search.");
+		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([
+			{
+				name: "search-suite",
+				description: "Search when needed",
+				toolNames: ["deferred_search"],
+			},
+		]);
+
+		const activation = pi.tools.find(
+			(tool) => tool.name === "activate_toolset",
+		);
+		await activation?.execute(
+			"activate-1",
+			{ name: "search-suite" },
+			undefined,
+			undefined,
+			{} as ExtensionContext,
+		);
+
+		expect(discoveryCalls).toBe(1);
+		expect(pi.getActiveTools()).toEqual(["eager_read", "deferred_search"]);
+		expect(await runBeforeAgentStart(pi)).toContain("Use deferred search.");
+	});
+
+	test("omits deferred activation routes when metadata loading fails", async () => {
+		// Purpose: only successfully loaded deferred metadata may enter the toolset catalog.
+		// Input and expected output: discovery failure leaves no visible trigger or exact activation route.
+		// Edge case: the generic activation definition remains registered but inactive.
+		// Dependencies: existing MCP startup diagnostics and shared toolset runtime visibility.
+		const pi = createExtensionApiFake();
+		const notifications: NotificationRecord[] = [];
+		await mcpWrapper(pi, {
+			readConfig: async () => ({
+				kind: "valid",
+				config: {
+					enabled: true,
+					timeouts: {
+						startupSeconds: 30,
+						listToolsSeconds: 15,
+						callSeconds: 120,
+						maxTotalSeconds: 180,
+					},
+					widgetLineBudget: 5,
+					mcpServers: {
+						missing: {
+							type: "stdio",
+							command: "missing",
+							args: [],
+							env: {},
+							onDemand: {
+								name: "missing-suite",
+								description: "Use missing metadata",
+							},
+						},
+					},
+				},
+			}),
+			loadCache: async () => null,
+			saveCache: async () => {},
+			createManager: () =>
+				managerWithCleanup({
+					discoverServers: async () => ({
+						serverToolLists: [],
+						serverInstructions: [],
+						failures: [{ serverKey: "missing", issue: "unavailable" }],
+					}),
+					callTool: async () => ({ content: [] }),
+				}),
+		});
+
+		await runSessionStart(pi, notifications);
+
+		expect(pi.getActiveTools()).toEqual([]);
+		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([]);
+		expect(getToolsetRuntime(pi).activate("missing-suite")).rejects.toThrow(
+			"unknown toolset: missing-suite",
+		);
+		expect(
+			notifications.some(({ message }) =>
+				message.includes("missing (unavailable)"),
+			),
+		).toBe(true);
+	});
+
+	test("replaces a refreshed deferred catalog without transient stale or eager routes", async () => {
+		// Purpose: catalog shrink and replacement must publish one observable composition state.
+		// Input and expected output: old deferred metadata is replaced by new metadata while the old definition stays registered but inactive.
+		// Edge case: the new deferred definition must never appear active before its provider restriction is installed.
+		// Dependencies: repeated session startup models the established refresh-and-reload catalog boundary.
+		const pi = createExtensionApiFake();
+		const configs = [
+			{
+				serverKey: "old",
+				toolsetName: "old-suite",
+				toolName: "read",
+			},
+			{
+				serverKey: "new",
+				toolsetName: "new-suite",
+				toolName: "search",
+			},
+		] as const;
+		let configIndex = 0;
+		const createConfig = (index: number) => {
+			const item = configs[index] ?? configs[1];
+			return {
+				kind: "valid" as const,
+				config: {
+					enabled: true,
+					timeouts: {
+						startupSeconds: 30,
+						listToolsSeconds: 15,
+						callSeconds: 120,
+						maxTotalSeconds: 180,
+					},
+					widgetLineBudget: 5,
+					mcpServers: {
+						[item.serverKey]: {
+							type: "stdio" as const,
+							command: item.serverKey,
+							args: [],
+							env: {},
+							onDemand: {
+								name: item.toolsetName,
+								description: `Use ${item.toolsetName}`,
+							},
+						},
+					},
+				},
+			};
+		};
+		let managerIndex = 0;
+		const createManager = () => {
+			const item = configs[managerIndex] ?? configs[1];
+			managerIndex += 1;
+			return managerWithCleanup({
+				discoverServers: async () => ({
+					serverToolLists: [
+						{
+							serverKey: item.serverKey,
+							tools: [{ name: item.toolName, inputSchema: { type: "object" } }],
+						},
+					],
+					serverInstructions: [],
+					failures: [],
+				}),
+				callTool: async () => ({ content: [] }),
+			});
+		};
+		await mcpWrapper(pi, {
+			readConfig: async () => {
+				const result = createConfig(configIndex);
+				configIndex += 1;
+				return result;
+			},
+			loadCache: async () => null,
+			saveCache: async () => {},
+			createManager,
+		});
+
+		await runSessionStart(pi);
+		pi.activeToolHistory.length = 0;
+		await runSessionStart(pi);
+
+		expect(pi.tools.map((tool) => tool.name)).toEqual([
+			"activate_toolset",
+			"old_read",
+			"new_search",
+		]);
+		expect(pi.getActiveTools()).toEqual(["activate_toolset"]);
+		expect(
+			pi.activeToolHistory.some((names) => names.includes("new_search")),
+		).toBe(false);
+		expect(
+			getToolsetRuntime(pi)
+				.getVisibleToolsets()
+				.map(({ name }) => name),
+		).toEqual(["new-suite"]);
+		expect(getToolsetRuntime(pi).activate("old-suite")).rejects.toThrow(
+			"unknown toolset: old-suite",
+		);
+	});
+
 	test("shares dynamic presentation through one Pi runtime event bus", async () => {
 		// Purpose: normal MCP registration and Subagents presentation must meet through Pi's shared extension event bus.
 		// Input and expected output: one ExtensionAPI registers the dynamic tool, while the management consumer resolves exact renderers through the same runtime event bus.
@@ -489,7 +757,9 @@ describe("mcp-wrapper extension", () => {
 
 		// ACT: run the producer lifecycle, then let the management consumer resolve through the shared manager.
 		await runSessionStart(mcpPi, [], [], runtimeSessionManager);
-		const normalDefinition = mcpPi.tools[0];
+		const normalDefinition = mcpPi.tools.find(
+			(tool) => tool.name === FILES_READ_TOOL_NAME,
+		);
 		if (normalDefinition === undefined) {
 			throw new Error("MCP normal definition is missing");
 		}
@@ -600,6 +870,11 @@ describe("mcp-wrapper extension", () => {
 			})),
 		).toEqual([
 			{
+				name: "activate_toolset",
+				hasCallRenderer: true,
+				hasResultRenderer: true,
+			},
+			{
 				name: FILES_READ_TOOL_NAME,
 				hasCallRenderer: true,
 				hasResultRenderer: true,
@@ -607,7 +882,10 @@ describe("mcp-wrapper extension", () => {
 		]);
 		expect(discoveryCalls).toBe(0);
 		expect(await resolvesWithin(runSessionStart(pi), 25)).toBe(true);
-		expect(pi.tools.map((tool) => tool.name)).toEqual([FILES_READ_TOOL_NAME]);
+		expect(pi.tools.map((tool) => tool.name)).toEqual([
+			"activate_toolset",
+			FILES_READ_TOOL_NAME,
+		]);
 		pi.setActiveTools([FILES_READ_TOOL_NAME]);
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
 			"Use cached file instructions.",
@@ -1274,7 +1552,9 @@ describe("mcp-wrapper extension", () => {
 			100,
 		);
 
-		expect(pi.tools[0]?.name).toBe(FILES_READ_TOOL_NAME);
+		expect(pi.tools.some((tool) => tool.name === FILES_READ_TOOL_NAME)).toBe(
+			true,
+		);
 		expect(cleanupFinished).toBe(true);
 		expect(refreshCloseCalls).toBe(1);
 	});
@@ -1449,6 +1729,7 @@ describe("mcp-wrapper extension", () => {
 
 		expect(discoveredServerMaps[0]).toEqual({ missing: missingConfig });
 		expect(pi.tools.map((tool) => tool.name)).toEqual([
+			"activate_toolset",
 			"cached_read",
 			"missing_search",
 		]);
@@ -1504,8 +1785,11 @@ describe("mcp-wrapper extension", () => {
 
 		await runSessionStart(pi);
 
-		expect(pi.tools[0]?.description).toBe('Tool from MCP server "files".');
-		expect(pi.tools[0]?.promptSnippet).toBe('Tool from MCP server "files".');
+		const tool = pi.tools.find(
+			(candidate) => candidate.name === FILES_READ_TOOL_NAME,
+		);
+		expect(tool?.description).toBe('Tool from MCP server "files".');
+		expect(tool?.promptSnippet).toBe('Tool from MCP server "files".');
 	});
 
 	test("truncates long prompt snippets at a word boundary", async () => {
@@ -1552,10 +1836,13 @@ describe("mcp-wrapper extension", () => {
 
 		await runSessionStart(pi);
 
-		expect(pi.tools[0]?.description).toBe(
+		const tool = pi.tools.find(
+			(candidate) => candidate.name === FILES_READ_TOOL_NAME,
+		);
+		expect(tool?.description).toBe(
 			`Tool from MCP server "files": ${"alpha ".repeat(20).trim()}`,
 		);
-		expect(pi.tools[0]?.promptSnippet).toBe(
+		expect(tool?.promptSnippet).toBe(
 			'Tool from MCP server "files": alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha...',
 		);
 	});
@@ -1625,7 +1912,9 @@ describe("mcp-wrapper extension", () => {
 		});
 
 		await runSessionStart(pi);
-		pi.setActiveTools(["docs_server_search"]);
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", [
+			"docs_server_search",
+		]);
 
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe(`Base prompt
 
@@ -1679,6 +1968,7 @@ Use this server. Do not call &lt;private>.
 		});
 
 		await runSessionStart(pi);
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", []);
 
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
@@ -1782,7 +2072,8 @@ Use this server. Do not call &lt;private>.
 
 		await runSessionStart(pi, notifications, statuses);
 
-		expect(pi.tools).toHaveLength(0);
+		expect(pi.tools.map((tool) => tool.name)).toEqual(["activate_toolset"]);
+		expect(pi.getActiveTools()).toEqual([]);
 		expect(statuses).toEqual([
 			{ key: "mcp-bad-server", text: "bad/server: connection failed" },
 			{
@@ -1826,6 +2117,7 @@ Use this server. Do not call &lt;private>.
 
 		await runSessionStart(pi);
 
-		expect(pi.tools).toHaveLength(0);
+		expect(pi.tools.map((tool) => tool.name)).toEqual(["activate_toolset"]);
+		expect(pi.getActiveTools()).toEqual([]);
 	});
 });

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -501,6 +501,7 @@ describe("mcp-wrapper extension", () => {
 							command: "deferred",
 							args: [],
 							env: {},
+							additionalInstructions: "Use deferred search carefully.",
 							onDemand: {
 								name: "search-suite",
 								description: "Search when needed",
@@ -522,7 +523,9 @@ describe("mcp-wrapper extension", () => {
 		]);
 		expect(pi.getActiveTools()).toEqual(["activate_toolset", "eager_read"]);
 		expect(await runBeforeAgentStart(pi)).toContain("Use eager files.");
-		expect(await runBeforeAgentStart(pi)).not.toContain("Use deferred search.");
+		expect(await runBeforeAgentStart(pi)).not.toContain(
+			"Use deferred search carefully.",
+		);
 		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([
 			{
 				name: "search-suite",
@@ -544,7 +547,9 @@ describe("mcp-wrapper extension", () => {
 
 		expect(discoveryCalls).toBe(1);
 		expect(pi.getActiveTools()).toEqual(["eager_read", "deferred_search"]);
-		expect(await runBeforeAgentStart(pi)).toContain("Use deferred search.");
+		expect(await runBeforeAgentStart(pi)).toContain(
+			"Use deferred search carefully.",
+		);
 	});
 
 	test("restores resumed activation after cacheless live discovery finalizes the catalog", async () => {
@@ -600,6 +605,7 @@ describe("mcp-wrapper extension", () => {
 							command: "deferred",
 							args: [],
 							env: {},
+							additionalInstructions: "Use deferred search carefully.",
 							onDemand: {
 								name: "search-suite",
 								description: "Search when needed",
@@ -617,7 +623,9 @@ describe("mcp-wrapper extension", () => {
 
 		expect(pi.getActiveTools()).toEqual(["deferred_search"]);
 		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([]);
-		expect(await runBeforeAgentStart(pi)).toContain("Use deferred search.");
+		expect(await runBeforeAgentStart(pi)).toContain(
+			"Use deferred search carefully.",
+		);
 		expect(
 			notifications.some(({ message }) => message.includes("stale activated")),
 		).toBe(false);
@@ -1997,9 +2005,16 @@ describe("mcp-wrapper extension", () => {
 							command: "node",
 							args: [],
 							env: {},
+							additionalInstructions: "Local docs guidance.",
 						},
 						files: { type: "stdio", command: "node", args: [], env: {} },
-						empty: { type: "stdio", command: "node", args: [], env: {} },
+						empty: {
+							type: "stdio",
+							command: "node",
+							args: [],
+							env: {},
+							additionalInstructions: "No accepted tool guidance.",
+						},
 					},
 				},
 			}),
@@ -2016,8 +2031,56 @@ describe("mcp-wrapper extension", () => {
 <mcp_instructions>
   <server name="docs&amp;server">
 Use this server. Do not call &lt;private>.
+
+Local docs guidance.
   </server>
 </mcp_instructions>`);
+	});
+
+	test("renders local MCP instructions for an eligible server without protocol instructions", async () => {
+		const pi = createExtensionApiFake();
+		const manager = {
+			discoverServers: async () => ({
+				serverToolLists: [
+					{ serverKey: "files", tools: [{ name: "read", inputSchema: {} }] },
+				],
+				serverInstructions: [],
+				failures: [],
+			}),
+			callTool: async () => ({ content: [] }),
+		} satisfies Pick<McpClientManager, "discoverServers" | "callTool">;
+
+		mcpWrapper(pi, {
+			readConfig: async () => ({
+				kind: "valid",
+				config: {
+					enabled: true,
+					timeouts: {
+						startupSeconds: 30,
+						listToolsSeconds: 15,
+						callSeconds: 120,
+						maxTotalSeconds: 180,
+					},
+					widgetLineBudget: 5,
+					mcpServers: {
+						files: {
+							type: "stdio",
+							command: "node",
+							args: [],
+							env: {},
+							additionalInstructions: "Use local file guidance.",
+						},
+					},
+				},
+			}),
+			createManager: () => managerWithCleanup(manager),
+		});
+
+		await runSessionStart(pi);
+		pi.setActiveTools([FILES_READ_TOOL_NAME]);
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
+			"Use local file guidance.",
+		);
 	});
 
 	test("omits MCP initialize instructions when no registered MCP tool is active", async () => {
@@ -2106,6 +2169,7 @@ Use this server. Do not call &lt;private>.
 									command: "node",
 									args: [],
 									env: {},
+									additionalInstructions: "Files local guidance.",
 								},
 							}
 						: {},

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -2042,7 +2042,8 @@ Local docs guidance.
 		const manager = {
 			discoverServers: async () => ({
 				serverToolLists: [
-					{ serverKey: "files", tools: [{ name: "read", inputSchema: {} }] },
+					{ serverKey: "alpha", tools: [{ name: "read", inputSchema: {} }] },
+					{ serverKey: "beta", tools: [{ name: "search", inputSchema: {} }] },
 				],
 				serverInstructions: [],
 				failures: [],
@@ -2063,12 +2064,19 @@ Local docs guidance.
 					},
 					widgetLineBudget: 5,
 					mcpServers: {
-						files: {
+						alpha: {
 							type: "stdio",
 							command: "node",
 							args: [],
 							env: {},
-							additionalInstructions: "Use local file guidance.",
+							additionalInstructions: "Alpha local guidance.",
+						},
+						beta: {
+							type: "stdio",
+							command: "node",
+							args: [],
+							env: {},
+							additionalInstructions: "Beta local guidance.",
 						},
 					},
 				},
@@ -2077,10 +2085,17 @@ Local docs guidance.
 		});
 
 		await runSessionStart(pi);
-		pi.setActiveTools([FILES_READ_TOOL_NAME]);
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
-			"Use local file guidance.",
-		);
+		pi.setActiveTools(["alpha_read", "beta_search"]);
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe(`Base prompt
+
+<mcp_instructions>
+  <server name="alpha">
+Alpha local guidance.
+  </server>
+  <server name="beta">
+Beta local guidance.
+  </server>
+</mcp_instructions>`);
 	});
 
 	test("omits MCP initialize instructions when no registered MCP tool is active", async () => {

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -475,6 +475,7 @@ async function handleSessionStart(
 		manager,
 		serverInstructionRecords: buildActiveServerInstructions(
 			startup.serverInstructions,
+			configResult.config.mcpServers,
 			catalog.tools,
 		),
 	};
@@ -597,16 +598,45 @@ function createDefaultMcpClientManager(
 /** Links server instructions to accepted Pi tool names for active-tool prompt filtering. */
 function buildActiveServerInstructions(
 	serverInstructions: readonly ServerInstructions[],
+	serverConfigs: Readonly<Record<string, McpServerConfig>>,
 	tools: readonly PiToolCatalogEntry[],
 ): readonly ServerInstructionRecord[] {
 	const toolNamesByServer = groupCatalogToolNamesByServer(tools);
+	const records = new Map<string, ServerInstructionRecord>();
 
-	return serverInstructions.flatMap((instructions) => {
+	for (const instructions of serverInstructions) {
 		const registeredPiToolNames = toolNamesByServer.get(instructions.serverKey);
-		return registeredPiToolNames === undefined
-			? []
-			: [{ ...instructions, registeredPiToolNames }];
-	});
+		if (registeredPiToolNames === undefined) {
+			continue;
+		}
+		const localText =
+			serverConfigs[instructions.serverKey]?.additionalInstructions;
+		records.set(instructions.serverKey, {
+			...instructions,
+			instructions: localText
+				? `${instructions.instructions}\n\n${localText}`
+				: instructions.instructions,
+			registeredPiToolNames,
+		});
+	}
+
+	const result = [...records.values()];
+	for (const [serverKey, config] of Object.entries(serverConfigs)) {
+		const registeredPiToolNames = toolNamesByServer.get(serverKey);
+		if (
+			registeredPiToolNames === undefined ||
+			config.additionalInstructions === undefined ||
+			records.has(serverKey)
+		) {
+			continue;
+		}
+		result.push({
+			serverKey,
+			instructions: config.additionalInstructions,
+			registeredPiToolNames,
+		});
+	}
+	return result;
 }
 
 function groupCatalogToolNamesByServer(

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -4,10 +4,16 @@ import type {
 	ExtensionContext,
 	ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition.ts";
 import {
 	registerPackageTool,
 	registerPackageToolPresentation,
 } from "../../shared/tool-presentation/registry.ts";
+import type { Toolset } from "../../shared/toolsets/contracts.ts";
+import {
+	getToolsetRuntime,
+	type ToolsetRuntime,
+} from "../../shared/toolsets/runtime.ts";
 import { McpClientManager, type ServerInstructions } from "./client-manager.ts";
 import {
 	type McpServerConfig,
@@ -33,6 +39,8 @@ import {
 } from "./tool-catalog.ts";
 
 const ISSUE_PREFIX = "[mcp-wrapper]";
+const MCP_TOOLSET_PROVIDER_ID = "mcp-wrapper";
+const MCP_BASELINE_OWNER = "mcp-wrapper";
 const STATUS_KEY_PREFIX = "mcp-";
 const PROMPT_SNIPPET_MAX_LENGTH = 100;
 const WORD_BOUNDARY_MIN_RATIO = 0.6;
@@ -66,12 +74,14 @@ export default async function mcpWrapper(
 	const createManager =
 		dependencies.createManager ?? createDefaultMcpClientManager;
 	const registeredToolDefinitions = new Map<string, ToolDefinition>();
+	const toolsetRuntime = getToolsetRuntime(pi);
 	const state: McpRuntimeState = {
 		activeManager: undefined,
 		lifecycleVersion: 0,
 		metadataWriteGeneration: 0,
 		preloadedStateConsumed: false,
 		serverInstructionRecords: [],
+		catalogToolNames: [],
 	};
 	const queueCacheSave = createQueuedCacheSave(saveCache);
 
@@ -90,6 +100,8 @@ export default async function mcpWrapper(
 		loadCache,
 		getActiveManager: () => state.activeManager,
 		registeredToolDefinitions,
+		toolsetRuntime,
+		state,
 	});
 	registerMcpSessionLifecycleHandlers({
 		pi,
@@ -100,6 +112,7 @@ export default async function mcpWrapper(
 		createManager,
 		queueCacheSave,
 		registeredToolDefinitions,
+		toolsetRuntime,
 	});
 	registerMcpInstructionPromptHandler(pi, () => state.serverInstructionRecords);
 
@@ -157,6 +170,8 @@ interface HandleSessionStartOptions {
 	readonly saveCache: (cache: McpWrapperMetadataCache) => Promise<void>;
 	readonly getMetadataWriteGeneration: () => number;
 	readonly registeredToolDefinitions: Map<string, ToolDefinition>;
+	readonly toolsetRuntime: ToolsetRuntime;
+	readonly state: McpRuntimeState;
 }
 
 interface HandleSessionStartResult {
@@ -175,6 +190,7 @@ interface McpRuntimeState {
 	metadataWriteGeneration: number;
 	preloadedStateConsumed: boolean;
 	serverInstructionRecords: readonly ServerInstructionRecord[];
+	catalogToolNames: readonly string[];
 }
 
 /** Binds session events after cached tool definitions have started loading. */
@@ -187,6 +203,7 @@ function registerMcpSessionLifecycleHandlers(options: {
 	readonly createManager: McpManagerFactory;
 	readonly queueCacheSave: QueuedCacheSave;
 	readonly registeredToolDefinitions: Map<string, ToolDefinition>;
+	readonly toolsetRuntime: ToolsetRuntime;
 }): void {
 	options.pi.on("session_start", async (_event, ctx) => {
 		const preloadedState = await options.preloadedStatePromise;
@@ -219,6 +236,8 @@ function registerMcpSessionLifecycleHandlers(options: {
 			saveCache: options.queueCacheSave,
 			getMetadataWriteGeneration: () => options.state.metadataWriteGeneration,
 			registeredToolDefinitions: options.registeredToolDefinitions,
+			toolsetRuntime: options.toolsetRuntime,
+			state: options.state,
 		});
 		if (sessionVersion !== options.state.lifecycleVersion) {
 			return;
@@ -234,6 +253,58 @@ function registerMcpSessionLifecycleHandlers(options: {
 		options.state.activeManager = undefined;
 		await manager?.closeAll();
 	});
+}
+
+function buildMcpToolsets(
+	servers: ValidMcpWrapperConfig["mcpServers"],
+	serverToolLists: readonly McpServerToolList[],
+	catalogTools: readonly PiToolCatalogEntry[],
+): readonly Toolset[] {
+	const loadedServerKeys = new Set(
+		serverToolLists.map((serverToolList) => serverToolList.serverKey),
+	);
+	const toolNamesByServer = new Map<string, string[]>();
+	for (const entry of catalogTools) {
+		const names = toolNamesByServer.get(entry.route.serverKey) ?? [];
+		names.push(entry.definition.name);
+		toolNamesByServer.set(entry.route.serverKey, names);
+	}
+
+	return Object.entries(servers).flatMap(([serverKey, server]) => {
+		if (server.onDemand === undefined || !loadedServerKeys.has(serverKey)) {
+			return [];
+		}
+		const toolNames = toolNamesByServer.get(serverKey) ?? [];
+		return [
+			{
+				providerId: MCP_TOOLSET_PROVIDER_ID,
+				name: server.onDemand.name,
+				description: server.onDemand.description,
+				toolNames,
+				// MCP metadata and definitions are already loaded; normal tool execution owns connection readiness.
+				activate: async () => toolNames,
+			},
+		];
+	});
+}
+
+function replaceRuntimeCatalog(
+	options: Pick<HandleSessionStartOptions, "pi" | "toolsetRuntime" | "state">,
+	toolsets: readonly Toolset[],
+	toolNames: readonly string[] = [],
+): void {
+	const previousToolNames = options.state.catalogToolNames;
+	const composition = getAgentRuntimeComposition(options.pi);
+	composition.stageBaselineToolNames(MCP_BASELINE_OWNER, toolNames);
+	try {
+		options.toolsetRuntime.replaceProvider(MCP_TOOLSET_PROVIDER_ID, toolsets);
+		options.state.catalogToolNames = [...toolNames];
+	} catch (error) {
+		// Baseline and activation routes are one catalog publication boundary.
+		composition.stageBaselineToolNames(MCP_BASELINE_OWNER, previousToolNames);
+		composition.reconcileActiveTools();
+		throw error;
+	}
 }
 
 interface HandleManualRefreshOptions {
@@ -283,6 +354,8 @@ async function preloadCachedTools(options: {
 	readonly loadCache: () => Promise<McpWrapperMetadataCache | null>;
 	readonly getActiveManager: () => McpManagerLike | undefined;
 	readonly registeredToolDefinitions: Map<string, ToolDefinition>;
+	readonly toolsetRuntime: ToolsetRuntime;
+	readonly state: McpRuntimeState;
 }): Promise<PreloadedMcpState> {
 	const configResult = await options.readConfig();
 	if (
@@ -309,14 +382,28 @@ async function preloadCachedTools(options: {
 
 	// Pi renders resumed messages before session_start, so cached definitions must
 	// exist now even though their execution manager becomes active during startup.
+	const catalogTools = buildPiToolCatalog(cachedToolLists).tools;
 	registerCatalogTools({
 		pi: options.pi,
-		tools: buildPiToolCatalog(cachedToolLists).tools,
+		tools: catalogTools,
 		getActiveManager: options.getActiveManager,
 		registeredToolDefinitions: options.registeredToolDefinitions,
 		servers: configResult.config.mcpServers,
 		widgetLineBudget: configResult.config.widgetLineBudget,
 	});
+	const catalogToolNames = catalogTools.map((entry) => entry.definition.name);
+	getAgentRuntimeComposition(options.pi).publishBaselineToolNames(
+		catalogToolNames,
+	);
+	options.toolsetRuntime.replaceProvider(
+		MCP_TOOLSET_PROVIDER_ID,
+		buildMcpToolsets(
+			configResult.config.mcpServers,
+			cachedToolLists,
+			catalogTools,
+		),
+	);
+	options.state.catalogToolNames = catalogToolNames;
 
 	return { configResult, cache };
 }
@@ -327,13 +414,16 @@ async function handleSessionStart(
 ): Promise<HandleSessionStartResult> {
 	const configResult = await options.readConfig();
 	if (configResult.kind === "invalid") {
+		replaceRuntimeCatalog(options, []);
 		options.ctx.ui.notify(`${ISSUE_PREFIX} ${configResult.issue}`, "warning");
 		return { manager: undefined, serverInstructionRecords: [] };
 	}
 	if (!configResult.config.enabled) {
+		replaceRuntimeCatalog(options, []);
 		return { manager: undefined, serverInstructionRecords: [] };
 	}
 	if (Object.keys(configResult.config.mcpServers).length === 0) {
+		replaceRuntimeCatalog(options, []);
 		return { manager: undefined, serverInstructionRecords: [] };
 	}
 
@@ -410,6 +500,11 @@ function registerStartupCatalog({
 		servers: config.mcpServers,
 		widgetLineBudget: config.widgetLineBudget,
 	});
+	replaceRuntimeCatalog(
+		options,
+		buildMcpToolsets(config.mcpServers, startup.serverToolLists, catalog.tools),
+		catalog.tools.map((entry) => entry.definition.name),
+	);
 	reportStartupDiagnostics(options.ctx, {
 		connectedServers: startup.discoveredServerKeys,
 		cachedServers: startup.cachedServerKeys,

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -152,6 +152,7 @@ function registerMcpInstructionPromptHandler(
 }
 
 interface SessionStartContextLike {
+	readonly hasUI: boolean;
 	readonly sessionManager: ExtensionContext["sessionManager"];
 	readonly ui: {
 		notify(message: string, type?: "info" | "warning" | "error"): void;
@@ -242,6 +243,11 @@ function registerMcpSessionLifecycleHandlers(options: {
 		if (sessionVersion !== options.state.lifecycleVersion) {
 			return;
 		}
+		// Startup history is interpreted only after metadata publication establishes the finalized catalog.
+		options.toolsetRuntime.restoreFromBranch(
+			ctx.sessionManager.getBranch(),
+			ctx,
+		);
 		options.state.activeManager = result.manager;
 		options.state.serverInstructionRecords = result.serverInstructionRecords;
 	});
@@ -263,12 +269,7 @@ function buildMcpToolsets(
 	const loadedServerKeys = new Set(
 		serverToolLists.map((serverToolList) => serverToolList.serverKey),
 	);
-	const toolNamesByServer = new Map<string, string[]>();
-	for (const entry of catalogTools) {
-		const names = toolNamesByServer.get(entry.route.serverKey) ?? [];
-		names.push(entry.definition.name);
-		toolNamesByServer.set(entry.route.serverKey, names);
-	}
+	const toolNamesByServer = groupCatalogToolNamesByServer(catalogTools);
 
 	return Object.entries(servers).flatMap(([serverKey, server]) => {
 		if (server.onDemand === undefined || !loadedServerKeys.has(serverKey)) {
@@ -598,12 +599,7 @@ function buildActiveServerInstructions(
 	serverInstructions: readonly ServerInstructions[],
 	tools: readonly PiToolCatalogEntry[],
 ): readonly ServerInstructionRecord[] {
-	const toolNamesByServer = new Map<string, string[]>();
-	for (const entry of tools) {
-		const toolNames = toolNamesByServer.get(entry.route.serverKey) ?? [];
-		toolNames.push(entry.definition.name);
-		toolNamesByServer.set(entry.route.serverKey, toolNames);
-	}
+	const toolNamesByServer = groupCatalogToolNamesByServer(tools);
 
 	return serverInstructions.flatMap((instructions) => {
 		const registeredPiToolNames = toolNamesByServer.get(instructions.serverKey);
@@ -611,6 +607,18 @@ function buildActiveServerInstructions(
 			? []
 			: [{ ...instructions, registeredPiToolNames }];
 	});
+}
+
+function groupCatalogToolNamesByServer(
+	catalogTools: readonly PiToolCatalogEntry[],
+): Map<string, string[]> {
+	const toolNamesByServer = new Map<string, string[]>();
+	for (const entry of catalogTools) {
+		const names = toolNamesByServer.get(entry.route.serverKey) ?? [];
+		names.push(entry.definition.name);
+		toolNamesByServer.set(entry.route.serverKey, names);
+	}
+	return toolNamesByServer;
 }
 
 type McpDiscoveryResult = Awaited<

--- a/pi-package/extensions/mcp-wrapper/metadata-cache.test.ts
+++ b/pi-package/extensions/mcp-wrapper/metadata-cache.test.ts
@@ -105,6 +105,12 @@ describe("mcp-wrapper metadata cache", () => {
 		expect(computeMcpServerConfigHash(config)).toBe(
 			computeMcpServerConfigHash({
 				...config,
+				additionalInstructions: "Use this server for files.",
+			}),
+		);
+		expect(computeMcpServerConfigHash(config)).toBe(
+			computeMcpServerConfigHash({
+				...config,
 				onDemand: { name: "files", description: "Read files" },
 			}),
 		);

--- a/pi-package/extensions/mcp-wrapper/metadata-cache.test.ts
+++ b/pi-package/extensions/mcp-wrapper/metadata-cache.test.ts
@@ -102,5 +102,22 @@ describe("mcp-wrapper metadata cache", () => {
 		expect(computeMcpServerConfigHash(config)).not.toBe(
 			computeMcpServerConfigHash({ ...config, args: ["other.js"] }),
 		);
+		expect(computeMcpServerConfigHash(config)).toBe(
+			computeMcpServerConfigHash({
+				...config,
+				onDemand: { name: "files", description: "Read files" },
+			}),
+		);
+		expect(
+			computeMcpServerConfigHash({
+				...config,
+				onDemand: { name: "files", description: "Read files" },
+			}),
+		).toBe(
+			computeMcpServerConfigHash({
+				...config,
+				onDemand: { name: "renamed", description: "Changed trigger" },
+			}),
+		);
 	});
 });

--- a/pi-package/extensions/mcp-wrapper/metadata-cache.ts
+++ b/pi-package/extensions/mcp-wrapper/metadata-cache.ts
@@ -67,7 +67,11 @@ export async function saveMcpWrapperCache(
 
 /** Builds a stable hash from fields that define one MCP server's discovered tools. */
 export function computeMcpServerConfigHash(config: McpServerConfig): string {
-	const { onDemand: _onDemand, ...connectionConfig } = config;
+	const {
+		onDemand: _onDemand,
+		additionalInstructions: _additionalInstructions,
+		...connectionConfig
+	} = config;
 	return createHash("sha256")
 		.update(stableStringify(connectionConfig))
 		.digest("hex");

--- a/pi-package/extensions/mcp-wrapper/metadata-cache.ts
+++ b/pi-package/extensions/mcp-wrapper/metadata-cache.ts
@@ -67,7 +67,10 @@ export async function saveMcpWrapperCache(
 
 /** Builds a stable hash from fields that define one MCP server's discovered tools. */
 export function computeMcpServerConfigHash(config: McpServerConfig): string {
-	return createHash("sha256").update(stableStringify(config)).digest("hex");
+	const { onDemand: _onDemand, ...connectionConfig } = config;
+	return createHash("sha256")
+		.update(stableStringify(connectionConfig))
+		.digest("hex");
 }
 
 /** Converts cached server entries to the discovery shape used by the tool catalog. */

--- a/pi-package/extensions/run-subagent/agent-policy.test.ts
+++ b/pi-package/extensions/run-subagent/agent-policy.test.ts
@@ -229,21 +229,26 @@ describe("effective callable-agent policy", () => {
 		// Edge case: active tools are cleared before the invalid policy escapes.
 		// Dependencies: child tool-pattern environment parsing and public ExtensionAPI tool selection.
 		const previous = process.env[SUBAGENT_TOOL_PATTERNS_ENV];
-		const activeTools: string[][] = [];
+		let activeTools = ["subagent_start"];
 		process.env[SUBAGENT_TOOL_PATTERNS_ENV] = JSON.stringify(["run_subagent"]);
 		try {
 			let message = "";
 			try {
 				applyChildToolPolicy({
+					events: { emit() {}, on: () => () => {} },
+					on() {},
 					getAllTools: () => [{ name: "subagent_start" }],
-					setActiveTools: (names: string[]) => activeTools.push(names),
+					getActiveTools: () => activeTools,
+					setActiveTools: (names: string[]) => {
+						activeTools = [...names];
+					},
 				} as unknown as ExtensionAPI);
 			} catch (error) {
 				message = error instanceof Error ? error.message : String(error);
 			}
 			expect({ message, activeTools }).toEqual({
 				message: "tool pattern run_subagent did not match any available tool",
-				activeTools: [[]],
+				activeTools: [],
 			});
 		} finally {
 			if (previous === undefined) {

--- a/pi-package/extensions/run-subagent/agent-policy.ts
+++ b/pi-package/extensions/run-subagent/agent-policy.ts
@@ -160,7 +160,7 @@ export function publishPromptContribution(
 				extensionDescription,
 			}),
 	});
-	composition.setSubagentsActiveToolFilter((toolNames) =>
+	composition.setRestrictiveToolFilter("subagent-depth", (toolNames) =>
 		filterSubagentTools(
 			toolNames,
 			composition.getMainAgentContribution()?.agent,
@@ -360,7 +360,7 @@ function filterSubagentTools(
 export function applyChildToolPolicy(pi: ExtensionAPI): void {
 	const policy = readSubagentToolPatterns();
 	if ("issue" in policy) {
-		pi.setActiveTools([]);
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("child-policy", []);
 		throw new Error(policy.issue);
 	}
 	if (policy.patterns === undefined) {
@@ -371,10 +371,13 @@ export function applyChildToolPolicy(pi: ExtensionAPI): void {
 		pi.getAllTools().map((tool) => tool.name),
 	);
 	if ("issue" in result) {
-		pi.setActiveTools([]);
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("child-policy", []);
 		throw new Error(result.issue);
 	}
-	pi.setActiveTools([...result.tools]);
+	getAgentRuntimeComposition(pi).setRestrictiveToolNames(
+		"child-policy",
+		result.tools,
+	);
 }
 
 /** Loads only definitions that can act as callable subagents. */

--- a/pi-package/extensions/run-subagent/index.test.ts
+++ b/pi-package/extensions/run-subagent/index.test.ts
@@ -1645,6 +1645,95 @@ describe("subagents entry", () => {
 		});
 	});
 
+	test("recovers active root subagents when the main agent run is aborted", async () => {
+		// Purpose: aborting the main Pi agent must stop every active subagent owned by its root runtime.
+		// Input and expected output: only agent_end with a final aborted assistant message invokes root recovery for the active lease.
+		// Edge case: stop and error leave the child running, while abort retains root reconciliation for the open Pi session.
+		// Dependencies: registered lifecycle handlers, reconstructed root state, and root recovery tracking.
+		const rootSession = {
+			key: { ownerPiSessionId: "owner-pi", ownerLocalSessionId: 1 },
+			childPiSessionId: "aborted-root-child",
+			childSessionDir: suiteDir,
+			childSessionFile: join(suiteDir, "aborted-root-child.jsonl"),
+			agentId: "SubAgentCoder",
+			taskName: "Cancelled root work",
+			creationOrder: 1,
+			invocationId: "aborted-root-invocation",
+			runtimeLeaseId: "aborted-root-lease",
+			invocationMetadata: TEST_INVOCATION_METADATA,
+			state: "active" as const,
+		} satisfies LogicalSession;
+		const entries = [
+			{
+				type: "custom",
+				id: "aborted-root-accepted",
+				parentId: null,
+				timestamp: new Date(0).toISOString(),
+				customType: SUBAGENT_JOURNAL_CUSTOM_TYPE,
+				data: {
+					kind: "session-accepted",
+					session: rootSession,
+				} satisfies JournalRecord,
+			},
+		];
+		const pi = createPiFake();
+		const ctx = createContext(suiteDir, entries);
+		const observedLeaseIds: string[][] = [];
+		let reconcileCalls = 0;
+		const runtimeFailure = await import("./runtime-failure");
+		const recoverySpy = spyOn(
+			runtimeFailure,
+			"recoverRootShutdown",
+		).mockImplementation(async (options) => {
+			if (!(options.store instanceof SessionStore)) {
+				throw new Error("root recovery store is not SessionStore");
+			}
+			const store = options.store;
+			const reconcileActive = store.reconcileActive.bind(store);
+			spyOn(store, "reconcileActive").mockImplementation(async (writer) => {
+				reconcileCalls += 1;
+				return reconcileActive(writer);
+			});
+			observedLeaseIds.push([
+				...(await options.coordinator.shutdown(options.owner)),
+			]);
+		});
+		try {
+			await subagents(pi);
+			await pi.emit("session_start", { type: "session_start" }, ctx);
+
+			for (const stopReason of ["stop", "error"] as const) {
+				await pi.emit(
+					"agent_end",
+					{
+						type: "agent_end",
+						messages: [{ role: "assistant", stopReason }],
+					},
+					ctx,
+				);
+			}
+			expect(observedLeaseIds).toEqual([]);
+
+			await pi.emit(
+				"agent_end",
+				{
+					type: "agent_end",
+					messages: [{ role: "assistant", stopReason: "aborted" }],
+				},
+				ctx,
+			);
+			await pi.emit("message_end", { type: "message_end" }, ctx);
+
+			expect({ observedLeaseIds, reconcileCalls }).toEqual({
+				observedLeaseIds: [[rootSession.runtimeLeaseId]],
+				reconcileCalls: 1,
+			});
+		} finally {
+			recoverySpy.mockRestore();
+			await pi.emit("session_shutdown", { type: "session_shutdown" }, ctx);
+		}
+	});
+
 	test("cancels registered root waits before rejection and later history delivery", async () => {
 		// Purpose: Pi abort must remove root wait admission before the registered tool rejects or later feedback is routed.
 		// Input and expected output: two aborted calls settle promptly with their Pi reasons; the second is admissible and child feedback reaches history once.

--- a/pi-package/extensions/run-subagent/index.ts
+++ b/pi-package/extensions/run-subagent/index.ts
@@ -1,11 +1,13 @@
 import { join } from "node:path";
 import { completeSimple as defaultCompleteSimple } from "@earendil-works/pi-ai/compat";
 import type {
+	AgentEndEvent,
 	AgentToolResult,
 	ExtensionAPI,
 	ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
+import { isAbortedAgentRun } from "../../shared/agent-end-state";
 import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition";
 import { getSuiteExtensionDir } from "../../shared/agent-suite-storage";
 import type { AuxiliaryLlmCompletion } from "../../shared/auxiliary-llm";
@@ -268,6 +270,7 @@ function registerLifecycleHandlers(
 		return state.initialization;
 	});
 	pi.on("message_end", (_event, ctx) => reconcileRuntime(state, ctx));
+	pi.on("agent_end", (event) => handleAgentEnd(state, event));
 	pi.on("session_shutdown", (_event, ctx) => handleSessionShutdown(state, ctx));
 	pi.on("tool_result", (event) => {
 		if (!SUBAGENT_TOOL_NAME_SET.has(event.toolName) || !event.isError) {
@@ -345,6 +348,29 @@ async function reconcileRuntime(
 	) {
 		await state.rootRuntime.store.reconcileActive(state.rootRuntime.writer);
 	}
+}
+
+/** Stops root-owned background work when Pi aborts the active main-agent run. */
+async function handleAgentEnd(
+	state: RuntimeState,
+	event: AgentEndEvent,
+): Promise<void> {
+	const rootRuntime = state.rootRuntime;
+	if (
+		state.workerBridge !== undefined ||
+		rootRuntime === undefined ||
+		!isAbortedAgentRun(event)
+	) {
+		return;
+	}
+	rootRuntime.recoveries.start(() =>
+		recoverRootShutdown({
+			coordinator: rootRuntime.coordinator,
+			store: rootRuntime.store,
+			owner: rootRuntime.owner,
+		}),
+	);
+	await rootRuntime.recoveries.drain();
 }
 
 /** Stops direct-owner work before releasing its sole session writer. */

--- a/pi-package/extensions/run-subagent/index.ts
+++ b/pi-package/extensions/run-subagent/index.ts
@@ -225,6 +225,9 @@ export default async function subagents(
 			dependencies.completeSimple ?? defaultCompleteSimple,
 		),
 	};
+	getAgentRuntimeComposition(pi).publishBaselineToolNames([
+		...SUBAGENT_TOOL_NAME_SET,
+	]);
 	registerLifecycleHandlers(pi, state);
 	configReady = readConfig();
 	// Pi awaits the factory promise before copying definitions into its first agent snapshot.

--- a/pi-package/extensions/run-subagent/subagent-query.test.ts
+++ b/pi-package/extensions/run-subagent/subagent-query.test.ts
@@ -225,9 +225,9 @@ describe("executeSubagentQuery", () => {
 		expect(costs).toEqual([{ source: "subagent-query", cost: 0.25 }]);
 	});
 
-	test("uses configured model and records billed provider errors", async () => {
-		// Purpose: query overrides must select the caller registry model while accounting for every billed assistant response.
-		// Input and expected output: configured model/off thinking and a billed provider error produce query_failed without reasoning or retry.
+	test("uses configured model and preserves billed provider errors", async () => {
+		// Purpose: query overrides must select the caller registry model while preserving its provider diagnostic and accounting for billed responses.
+		// Input and expected output: configured model/off thinking and a billed provider error return the provider message without reasoning or retry.
 		// Edge case: the failed response still creates one helper cost entry.
 		// Dependencies: deterministic model registry, completion, and append-entry fakes.
 		const calls: CompletionCall[] = [];
@@ -254,14 +254,33 @@ describe("executeSubagentQuery", () => {
 			currentThinkingLevel: "high",
 		});
 
-		expect(result).toEqual({
-			kind: "issue",
-			issue: "The query failed, please try again later",
-		});
+		expect(result).toEqual({ kind: "issue", issue: "provider failed" });
 		expect(calls).toHaveLength(1);
 		expect(calls[0]?.model).toBe(CONFIGURED_MODEL);
 		expect(calls[0]?.options).not.toHaveProperty("reasoning");
 		expect(costs).toEqual([{ source: "subagent-query", cost: 0.5 }]);
+	});
+
+	test("preserves thrown completion diagnostics", async () => {
+		// Purpose: completion exceptions must expose their actionable diagnostic instead of replacing it with a generic retry message.
+		// Input and expected output: one thrown timeout error returns its message as the query issue.
+		// Edge case: a thrown completion has no assistant response and therefore records no helper cost.
+		// Dependencies: deterministic completion and append-entry fakes.
+		const costs: unknown[] = [];
+		const result = await executeSubagentQuery({
+			completeSimple: async () => {
+				throw new Error("request timed out");
+			},
+			ctx: createContext(),
+			pi: createPi((_type, data) => costs.push(data)),
+			branchEntries: savedBranch(),
+			question: "Question",
+			systemPrompt: "System",
+			currentThinkingLevel: "medium",
+		});
+
+		expect(result).toEqual({ kind: "issue", issue: "request timed out" });
+		expect(costs).toEqual([]);
 	});
 
 	test("applies alias default thinking when query model has no explicit thinking", async () => {

--- a/pi-package/extensions/run-subagent/subagent-query.ts
+++ b/pi-package/extensions/run-subagent/subagent-query.ts
@@ -20,6 +20,7 @@ import { readKnowledgeBlock } from "../../shared/knowledge-runtime";
 import { isReasoningLevel } from "../../shared/reasoning-levels";
 import { readCancellationError } from "./cancellation-reason";
 import type { SubagentQueryModelConfig } from "./entry-config";
+import { errorMessage } from "./error-message";
 
 const QUESTION_TAG = "question";
 
@@ -97,14 +98,11 @@ export async function executeSubagentQuery({
 			context,
 			options,
 		);
-	} catch {
+	} catch (error) {
 		if (signal?.aborted) {
 			throw readCancellationError(signal);
 		}
-		return {
-			kind: "issue",
-			issue: "The query failed, please try again later",
-		};
+		return { kind: "issue", issue: errorMessage(error) };
 	}
 
 	recordHelperApiCost(pi, "subagent-query", response);
@@ -117,7 +115,8 @@ export async function executeSubagentQuery({
 	if (response.stopReason === "error") {
 		return {
 			kind: "issue",
-			issue: "The query failed, please try again later",
+			issue:
+				response.errorMessage ?? "The query failed, please try again later",
 		};
 	}
 	const answer = getAuxiliaryLlmResponseText(response);

--- a/pi-package/extensions/system-prompt/index.test.ts
+++ b/pi-package/extensions/system-prompt/index.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import type {
-	BuildSystemPromptOptions,
-	ExtensionAPI,
+import {
+	type BuildSystemPromptOptions,
+	createEventBus,
+	type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
+import { getToolsetRuntime } from "../../shared/toolsets/runtime";
 import systemPrompt from "./index";
 
 const AGENT_DIR_ENV = "PI_CODING_AGENT_DIR";
@@ -38,15 +40,26 @@ interface ContextFake {
 }
 
 /** Creates an ExtensionAPI fake that records lifecycle handlers registered by system-prompt. */
-function createExtensionApiFake(): ExtensionApiFake {
+function createExtensionApiFake(
+	initialActiveTools: readonly string[] = [],
+): ExtensionApiFake {
 	const handlers: RegisteredHandler[] = [];
+	let activeTools = [...initialActiveTools];
 
 	return {
 		handlers,
+		events: createEventBus(),
 		on(eventName: string, handler: unknown): void {
 			handlers.push({ eventName, handler });
 		},
-	} as ExtensionApiFake;
+		registerTool(): void {},
+		getActiveTools(): readonly string[] {
+			return activeTools;
+		},
+		setActiveTools(toolNames: readonly string[]): void {
+			activeTools = [...toolNames];
+		},
+	} as unknown as ExtensionApiFake;
 }
 
 /** Creates the session context fake needed to observe startup warnings. */
@@ -257,7 +270,7 @@ describe("system-prompt", () => {
 				].join("\n"),
 			);
 			await writeSuiteConfig(suiteDir, { templateFile });
-			const pi = createExtensionApiFake();
+			const pi = createExtensionApiFake(["read", "bash", "hidden"]);
 			const context = createContextFake();
 
 			systemPrompt(pi);
@@ -353,6 +366,154 @@ describe("system-prompt", () => {
 					context.ctx,
 				),
 			).not.toContain("{{");
+		});
+	});
+
+	test("renders eligible deferred toolsets in runtime order with escaped attributes", async () => {
+		// Purpose: {{toolsets}} must expose only runtime-eligible deferred toolsets in its required XML form.
+		// Input and expected output: two eligible toolsets include Unicode and every XML-sensitive attribute character.
+		// Edge case: runtime order and literal Unicode survive while XML delimiters are escaped.
+		// Dependencies: shared runtime/composition and isolated system-prompt lifecycle fakes.
+		await withIsolatedAgentDir(async ({ suiteDir }) => {
+			const templateFile = join(suiteDir, "template.md");
+			await writeFile(templateFile, "{{toolsets}}");
+			await writeSuiteConfig(suiteDir, { templateFile });
+			const pi = createExtensionApiFake(["alpha_tool", "beta_tool"]);
+			systemPrompt(pi);
+			const runtime = getToolsetRuntime(pi);
+			runtime.replaceProvider("mcp", [
+				{
+					providerId: "mcp",
+					name: `alpha & <β> "'`,
+					description: `first > & < "' 工具`,
+					toolNames: ["alpha_tool"],
+					activate: async () => ["alpha_tool"],
+				},
+				{
+					providerId: "mcp",
+					name: "second",
+					description: "second suite",
+					toolNames: ["beta_tool"],
+					activate: async () => ["beta_tool"],
+				},
+			]);
+			const context = createContextFake();
+
+			await getRegisteredHandler(pi, "session_start")(
+				{ type: "session_start", reason: "startup" },
+				context.ctx,
+			);
+
+			expect(
+				await runBeforeAgentStartHandlers(
+					pi,
+					createBeforeAgentStartEvent(),
+					context.ctx,
+				),
+			).toBe(
+				'<toolsets>\n<toolset name="alpha &amp; &lt;β&gt; &quot;&apos;" description="first &gt; &amp; &lt; &quot;&apos; 工具"/>\n<toolset name="second" description="second suite"/>\n</toolsets>',
+			);
+		});
+	});
+
+	test("removes the trigger after activation and restores it after history rewind", async () => {
+		// Purpose: prompt discovery must follow the runtime's active branch state.
+		// Input and expected output: one eligible toolset activates, then an empty history branch restores it.
+		// Edge case: activate_toolset is removed with the final trigger and restored on rewind.
+		// Dependencies: shared runtime history handler, composition, and isolated system-prompt lifecycle fakes.
+		await withIsolatedAgentDir(async ({ suiteDir }) => {
+			const templateFile = join(suiteDir, "template.md");
+			await writeFile(templateFile, "{{toolsets}}");
+			await writeSuiteConfig(suiteDir, { templateFile });
+			const pi = createExtensionApiFake(["files_read"]);
+			systemPrompt(pi);
+			const runtime = getToolsetRuntime(pi);
+			runtime.replaceProvider("mcp", [
+				{
+					providerId: "mcp",
+					name: "files",
+					description: "Read files",
+					toolNames: ["files_read"],
+					activate: async () => ["files_read"],
+				},
+			]);
+			const context = createContextFake();
+			await getRegisteredHandler(pi, "session_start")(
+				{ type: "session_start", reason: "startup" },
+				context.ctx,
+			);
+
+			await runBeforeAgentStartHandlers(
+				pi,
+				createBeforeAgentStartEvent(),
+				context.ctx,
+			);
+			expect(pi.getActiveTools()).toContain("activate_toolset");
+			await runtime.activate("files");
+			expect(
+				await runBeforeAgentStartHandlers(
+					pi,
+					createBeforeAgentStartEvent(),
+					context.ctx,
+				),
+			).toBe("");
+			expect(pi.getActiveTools()).not.toContain("activate_toolset");
+
+			await getRegisteredHandler(pi, "session_tree")(
+				{ type: "session_tree" },
+				{
+					hasUI: false,
+					sessionManager: { getBranch: () => [] },
+				},
+			);
+			expect(
+				await runBeforeAgentStartHandlers(
+					pi,
+					createBeforeAgentStartEvent(),
+					context.ctx,
+				),
+			).toBe(
+				'<toolsets>\n<toolset name="files" description="Read files"/>\n</toolsets>',
+			);
+			expect(pi.getActiveTools()).toContain("activate_toolset");
+		});
+	});
+
+	test("places bundled toolsets between skills and active tools", async () => {
+		// Purpose: the bundled template must expose the deferred catalog at the approved structural location.
+		// Input and expected output: the bundled template renders one eligible toolset beside populated skills and active tools.
+		// Edge case: placement is asserted by required section boundaries rather than mutable prompt prose.
+		// Dependencies: bundled template loading plus the shared runtime/composition lifecycle.
+		await withIsolatedAgentDir(async () => {
+			const pi = createExtensionApiFake(["files_read"]);
+			systemPrompt(pi);
+			getToolsetRuntime(pi).replaceProvider("mcp", [
+				{
+					providerId: "mcp",
+					name: "files",
+					description: "Read files",
+					toolNames: ["files_read"],
+					activate: async () => ["files_read"],
+				},
+			]);
+			const context = createContextFake();
+			await getRegisteredHandler(pi, "session_start")(
+				{ type: "session_start", reason: "startup" },
+				context.ctx,
+			);
+
+			const prompt = await runBeforeAgentStartHandlers(
+				pi,
+				createBeforeAgentStartEvent(),
+				context.ctx,
+			);
+			expect(prompt.indexOf("</skills>")).toBeGreaterThanOrEqual(0);
+			expect(prompt.indexOf("<toolsets>")).toBeGreaterThan(
+				prompt.indexOf("</skills>"),
+			);
+			expect(prompt.indexOf("<tools>")).toBeGreaterThan(
+				prompt.indexOf("<toolsets>"),
+			);
 		});
 	});
 

--- a/pi-package/extensions/system-prompt/index.ts
+++ b/pi-package/extensions/system-prompt/index.ts
@@ -6,11 +6,14 @@ import {
 	type ExtensionAPI,
 	formatSkillsForPrompt,
 } from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition";
 import { writeRuntimeDiagnostic } from "../../shared/agent-runtime-diagnostics";
 import {
 	getSuiteConfigLocation,
 	isFileNotFoundError,
 } from "../../shared/agent-suite-storage";
+import type { VisibleToolset } from "../../shared/toolsets/contracts";
+import { getToolsetRuntime } from "../../shared/toolsets/runtime";
 import { AVAILABLE_SUBAGENTS_PROMPT_OPENING_TAG } from "../run-subagent/contracts";
 
 const EXTENSION_DIR = "system-prompt";
@@ -26,6 +29,7 @@ const SUPPORTED_TEMPLATE_VARIABLES = [
 	"appendSystemPrompt",
 	"contextFiles",
 	"skills",
+	"toolsets",
 ] as const;
 const DEFAULT_SELECTED_TOOLS = ["read", "bash", "edit", "write"] as const;
 const TEMPLATE_VARIABLE_PATTERN = /{{\s*([^{}]+?)\s*}}/g;
@@ -90,9 +94,19 @@ export default function systemPrompt(pi: ExtensionAPI): void {
 		}
 
 		const typedEvent = event as BeforeAgentStartEventLike;
+		const composition = getAgentRuntimeComposition(pi);
+		composition.reconcileActiveTools();
+		const options = {
+			...typedEvent.systemPromptOptions,
+			selectedTools: [...pi.getActiveTools()],
+		};
+		const toolsets = hasTemplateVariable(templateState.template, "toolsets")
+			? getToolsetRuntime(pi).getVisibleToolsets()
+			: [];
 		const systemPrompt = renderTemplate(
 			templateState.template,
-			typedEvent.systemPromptOptions,
+			options,
+			toolsets,
 		);
 		writeRuntimeDiagnostic("system-prompt.before-agent-start.applied", {
 			incomingPromptLength: incomingPrompt.length,
@@ -221,8 +235,9 @@ async function readTemplate(
 function renderTemplate(
 	template: string,
 	options: BuildSystemPromptOptions,
+	toolsets: readonly VisibleToolset[],
 ): string {
-	const values = buildTemplateValues(options);
+	const values = buildTemplateValues(options, toolsets);
 
 	return template.replace(
 		TEMPLATE_VARIABLE_PATTERN,
@@ -236,6 +251,7 @@ function renderTemplate(
 /** Builds the dynamic values allowed to cross from pi runtime state into the Markdown template. */
 function buildTemplateValues(
 	options: BuildSystemPromptOptions,
+	toolsets: readonly VisibleToolset[],
 ): Record<TemplateVariable, string> {
 	return {
 		date: getLocalDate(),
@@ -245,6 +261,7 @@ function buildTemplateValues(
 		appendSystemPrompt: options.appendSystemPrompt ?? "",
 		contextFiles: formatContextFiles(options),
 		skills: formatSkills(options),
+		toolsets: formatToolsets(toolsets),
 	};
 }
 
@@ -297,6 +314,42 @@ function formatSkills(options: BuildSystemPromptOptions): string {
 	}
 
 	return formatSkillsForPrompt(options.skills ?? []);
+}
+
+/** Formats the visible deferred catalog without exposing tool schemas or provider details. */
+function formatToolsets(toolsets: readonly VisibleToolset[]): string {
+	if (toolsets.length === 0) {
+		return "";
+	}
+
+	return [
+		"<toolsets>",
+		...toolsets.map(
+			({ name, description }) =>
+				`<toolset name="${escapeXmlAttribute(name)}" description="${escapeXmlAttribute(description)}"/>`,
+		),
+		"</toolsets>",
+	].join("\n");
+}
+
+/** Escapes XML-sensitive attribute characters while preserving all other Unicode text. */
+function escapeXmlAttribute(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&apos;");
+}
+
+/** Returns whether a template explicitly requests one supported dynamic value. */
+function hasTemplateVariable(
+	template: string,
+	expectedName: TemplateVariable,
+): boolean {
+	return [...template.matchAll(TEMPLATE_VARIABLE_PATTERN)].some(
+		(match) => match[1]?.trim() === expectedName,
+	);
 }
 
 /** Returns the local date string in the same YYYY-MM-DD shape used by pi's base prompt. */

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -20,16 +20,27 @@ Current working directory: {{cwd}}
 <user_communication>
     <style>
        <rules>
+        - Write in requested language
+        - Lead with answer, decision, or most important finding
         - Be concise, direct, specific, and engineering-focused
-        - Lead with answer or decision
-        - State each fact once
-        - Match detail to task
+        - Match detail to task and state each fact once
         - Challenge incorrect assumptions directly
-        - Prefer concrete domain terminology over rhetorical language
-        - Compress whenever meaning is preserved
+        - Use one term for one concept and one meaning. Do not vary terminology for style
+        - Preserve established technical names, identifiers, commands, API names, product names, and domain terminology when changing them could alter meaning
+        - Prefer common and simple words unless specialized terminology is necessary for precision
+        - Prefer short sentences with one primary statement each
+        - Use explicit actor-action-object structures and direct instructions when they improve clarity
+        - Put necessary conditions before dependent actions or conclusions
+        - Make important logical relations explicit: condition, cause, result, purpose, contrast, sequence, and exception
+        - Avoid ambiguous references. Repeat noun or term when necessary
+        - Avoid unnecessarily complex grammar, nested clauses, long dependency chains, and multiple negations
+        - Use exact quantities, units, dates, ranges, limits, and tolerances when precision matters
+        - Compress only when meaning and relevant distinctions are preserved
+        - When clarity conflicts with natural style, prefer clarity
+        - When brevity conflicts with precision, prefer precision
+        - Do not restate user's question unless needed for clarity
         - Avoid praise, motivational language, rhetorical filler, decorative headings, analogies, emoji, and excessive punctuation
         - Avoid vague or performative phrases such as "the real tension", "worth stating plainly", "here's the honest truth", "load-bearing", or similar rhetoric
-        - Do not restate user's question unless needed for clarity
         </rules>
 
         <reference_points>
@@ -47,12 +58,12 @@ Current working directory: {{cwd}}
         </reference_points>
 
         <scope_and_verification>
-        - Do only what was requested.
-        - Do not expand task into unrelated cleanup, refactoring, documentation, or speculative future work.
-        - Do not claim something works, is fixed, or is complete without evidence.
-        - Distinguish facts from assumptions when uncertainty matters.
-        - If verification is possible and materially affects correctness, verify before concluding.
-        - When task is complete, state result concisely.
+        - Do only what was requested
+        - Do not expand task into unrelated cleanup, refactoring, documentation, or speculative future work
+        - Do not claim something works, is fixed, or is complete without evidence
+        - Distinguish facts from assumptions when uncertainty matters
+        - If verification is possible and materially affects correctness, verify before concluding
+        - When task is complete, state result concisely
         </scope_and_verification>
 
         <style_example>
@@ -63,15 +74,15 @@ Current working directory: {{cwd}}
     </style>
 
     <brevity>
-    - Minimum needed detail SHOULD be given by default.
+    - Minimum needed detail SHOULD be given by default
     - Responses MUST be vertically compact
     - MUST NOT insert blank lines between adjacent bullets
     - One blank line only between distinct sections
     - More than one consecutive blank line is FORBIDDEN
     - MUST NOT format every sentence as separate paragraph
     - Group related sentences into one paragraph when they answer same point
-    - If response exceeds 50 lines, it SHOULD start with short summary.
-    - If response exceeds 50 lines, full text SHOULD be offered on request.
+    - If response exceeds 50 lines, it SHOULD start with short summary
+    - If response exceeds 50 lines, full text SHOULD be offered on request
     </brevity>
 
     <questions>

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -21,38 +21,38 @@ Current working directory: {{cwd}}
     <style>
        <rules>
         - Be concise, direct, specific, and engineering-focused
-        - Lead with the answer or decision
+        - Lead with answer or decision
         - State each fact once
-        - Match detail to the task
+        - Match detail to task
         - Challenge incorrect assumptions directly
         - Prefer concrete domain terminology over rhetorical language
         - Compress whenever meaning is preserved
         - Avoid praise, motivational language, rhetorical filler, decorative headings, analogies, emoji, and excessive punctuation
         - Avoid vague or performative phrases such as "the real tension", "worth stating plainly", "here's the honest truth", "load-bearing", or similar rhetoric
-        - Do not restate the user's question unless needed for clarity
+        - Do not restate user's question unless needed for clarity
         </rules>
 
         <reference_points>
         For 2+ findings, decisions, options, risks, questions, or actions, assign stable short IDs:
-        - `D1`, `D2` — decisions
-        - `O1`, `O2` — options
-        - `F1`, `F2` — findings
-        - `R1`, `R2` — risks
-        - `Q1`, `Q2` — questions
-        - `A1`, `A2` — actions
+        - `D1`, `D2: decisions
+        - `O1`, `O2`: options
+        - `F1`, `F2`: findings
+        - `R1`, `R2`: risks
+        - `Q1`, `Q2`: questions
+        - `A1`, `A2`: actions
 
-        Preserve IDs throughout the conversation.
+        Preserve IDs throughout conversation.
 
         Do not use reference points for simple answers.
         </reference_points>
 
         <scope_and_verification>
         - Do only what was requested.
-        - Do not expand the task into unrelated cleanup, refactoring, documentation, or speculative future work.
+        - Do not expand task into unrelated cleanup, refactoring, documentation, or speculative future work.
         - Do not claim something works, is fixed, or is complete without evidence.
         - Distinguish facts from assumptions when uncertainty matters.
         - If verification is possible and materially affects correctness, verify before concluding.
-        - When the task is complete, state the result concisely.
+        - When task is complete, state result concisely.
         </scope_and_verification>
 
         <style_example>

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -18,54 +18,98 @@ Current working directory: {{cwd}}
 </goal_guard>
 
 <user_communication>
-<brevity>
-- Minimum needed detail SHOULD be given by default.
-- Responses MUST be vertically compact
-- MUST NOT insert blank lines between adjacent bullets
-- One blank line only between distinct sections
-- More than one consecutive blank line is FORBIDDEN
-- MUST NOT format every sentence as separate paragraph
-- Group related sentences into one paragraph when they answer same point
-- If response exceeds 50 lines, it SHOULD start with short summary.
-- If response exceeds 50 lines, full text SHOULD be offered on request.
-</brevity>
+    <style>
+       <rules>
+        - Be concise, direct, specific, and engineering-focused
+        - Lead with the answer or decision
+        - State each fact once
+        - Match detail to the task
+        - Challenge incorrect assumptions directly
+        - Prefer concrete domain terminology over rhetorical language
+        - Compress whenever meaning is preserved
+        - Avoid praise, motivational language, rhetorical filler, decorative headings, analogies, emoji, and excessive punctuation
+        - Avoid vague or performative phrases such as "the real tension", "worth stating plainly", "here's the honest truth", "load-bearing", or similar rhetoric
+        - Do not restate the user's question unless needed for clarity
+        </rules>
 
-<questions>
-Rules:
-- Use only for approval, clarification, choice, blocker, or long-term code-health trade-off for scope, speed, or coordination
-- Action, alternative, or permission offer MUST use it
-- First try to find factual answer
-- User MUST decide design trade-off, debt acceptance, structural change, scope growth, and workaround versus refactor
-- User MUST decide before duplicate logic to avoid refactor, single-use interface widening, one-off adapter or wrapper, constraint-bypass config, special case instead of model fix, cross-boundary internal leak, or knowingly harder future change for scope
-- Do not continue work before user approval on critical question
-- Status or result and Decision Question MUST NOT share one section
-- If result needs approval, send result first, then separate Decision Question
-- Never use Decision Question for status or final report
-- Use plain paths, not Markdown links
-- Use globally unique IDs such as `Q1`, `Q2`, `O1-1`, `O2-1`
-- Put every unresolved question needing user input in Decision Question template under unique `Qn`
-- MUST use template exactly:
-```md
-# {Role}
-## Reason
-{Why needed now}
-## Questions/Choices
-### Q1: {Question}
-**Details:** {Context}
-**Options:**
-1. O1-1: {Option, pros, cons, recommendation}
-2. O1-2: {Option, pros, cons, recommendation}
-### Q2...
-```
+        <reference_points>
+        For 2+ findings, decisions, options, risks, questions, or actions, assign stable short IDs:
+        - `D1`, `D2` — decisions
+        - `O1`, `O2` — options
+        - `F1`, `F2` — findings
+        - `R1`, `R2` — risks
+        - `Q1`, `Q2` — questions
+        - `A1`, `A2` — actions
 
-Status or Result:
-- Use concise Markdown for findings, completion, or explanation
-- Ask no courtesy question without decision need
+        Preserve IDs throughout the conversation.
 
-Closing Prompt:
-- MAY end final message with one short plain courtesy question
-- Not Decision Question and no IDs, options, recommendations, or specific action offers
-</questions>
+        Do not use reference points for simple answers.
+        </reference_points>
+
+        <scope_and_verification>
+        - Do only what was requested.
+        - Do not expand the task into unrelated cleanup, refactoring, documentation, or speculative future work.
+        - Do not claim something works, is fixed, or is complete without evidence.
+        - Distinguish facts from assumptions when uncertainty matters.
+        - If verification is possible and materially affects correctness, verify before concluding.
+        - When the task is complete, state the result concisely.
+        </scope_and_verification>
+
+        <style_example>
+        Bad: "Great question. The real architectural tension here is whether introducing Redis gives us enough leverage to justify the additional operational complexity. Since SQLite already provides persistence and there is only one writer, Redis may not be necessary at this stage. I would probably avoid adding it unless cross-host coordination becomes a requirement."
+
+        Good: "Do not add Redis here. SQLite already provides persistence, there is one writer, and cross-host coordination is not required. Redis would add operational complexity without solving a current problem."
+        </style_example>
+    </style>
+
+    <brevity>
+    - Minimum needed detail SHOULD be given by default.
+    - Responses MUST be vertically compact
+    - MUST NOT insert blank lines between adjacent bullets
+    - One blank line only between distinct sections
+    - More than one consecutive blank line is FORBIDDEN
+    - MUST NOT format every sentence as separate paragraph
+    - Group related sentences into one paragraph when they answer same point
+    - If response exceeds 50 lines, it SHOULD start with short summary.
+    - If response exceeds 50 lines, full text SHOULD be offered on request.
+    </brevity>
+
+    <questions>
+    Rules:
+    - Use only for approval, clarification, choice, blocker, or long-term code-health trade-off for scope, speed, or coordination
+    - Action, alternative, or permission offer MUST use it
+    - First try to find factual answer
+    - User MUST decide design trade-off, debt acceptance, structural change, scope growth, and workaround versus refactor
+    - User MUST decide before duplicate logic to avoid refactor, single-use interface widening, one-off adapter or wrapper, constraint-bypass config, special case instead of model fix, cross-boundary internal leak, or knowingly harder future change for scope
+    - Do not continue work before user approval on critical question
+    - Status or result and Decision Question MUST NOT share one section
+    - If result needs approval, send result first, then separate Decision Question
+    - Never use Decision Question for status or final report
+    - Use plain paths, not Markdown links
+    - Use globally unique IDs such as `Q1`, `Q2`, `O1-1`, `O2-1`
+    - Put every unresolved question needing user input in Decision Question template under unique `Qn`
+    - MUST use template exactly:
+    ```md
+    # {Role}
+    ## Reason
+    {Why needed now}
+    ## Questions/Choices
+    ### Q1: {Question}
+    **Details:** {Context}
+    **Options:**
+    1. O1-1: {Option, pros, cons, recommendation}
+    2. O1-2: {Option, pros, cons, recommendation}
+    ### Q2...
+    ```
+
+    Status or Result:
+    - Use concise Markdown for findings, completion, or explanation
+    - Ask no courtesy question without decision need
+
+    Closing Prompt:
+    - MAY end final message with one short plain courtesy question
+    - Not Decision Question and no IDs, options, recommendations, or specific action offers
+    </questions>
 </user_communication>
 
 {{appendSystemPrompt}}

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -83,6 +83,8 @@ Closing Prompt:
 </available_skills>
 </skills>
 
+{{toolsets}}
+
 <tools>
 <available>
 {{tools}}

--- a/pi-package/extensions/vision/index.test.ts
+++ b/pi-package/extensions/vision/index.test.ts
@@ -6,6 +6,7 @@ import type {
 	ExtensionAPI,
 	ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition";
 import vision, { isMultimodal } from "./index";
 
 type Handler = (...args: never[]) => unknown;
@@ -119,6 +120,27 @@ describe("vision extension", () => {
 		expect(pi.getActiveTools()).toEqual(["read", "describe_image"]);
 		const select = pi.handlers.get("model_select")?.[0];
 		select?.({ model: { input: ["text", "image"] } } as never, {} as never);
+		expect(pi.getActiveTools()).toEqual(["read"]);
+	});
+
+	/**
+	 * Proves text-only model availability remains subordinate to upstream restrictions.
+	 * Input and expected output: configured vision is eligible, while an upstream layer permits only read.
+	 * Edge case: the later model lifecycle event must not restore the restricted vision tool.
+	 * Dependencies: shared active-tool composition and vision model synchronization.
+	 */
+	test("keeps the text-only model tool behind upstream restrictions", async () => {
+		const pi = createPi();
+		vision(pi, { readConfigFile: async () => configuredFile() });
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("upstream", [
+			"read",
+		]);
+
+		await pi.handlers.get("session_start")?.[0]?.(
+			{} as never,
+			context({ input: ["text"] }) as never,
+		);
+
 		expect(pi.getActiveTools()).toEqual(["read"]);
 	});
 

--- a/pi-package/extensions/vision/index.ts
+++ b/pi-package/extensions/vision/index.ts
@@ -4,6 +4,7 @@ import type {
 	ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { getAgentRuntimeComposition } from "../../shared/agent-runtime-composition";
 import { readSuiteConfigFile } from "../../shared/agent-suite-storage";
 import type { AuxiliaryLlmCompletion } from "../../shared/auxiliary-llm";
 import { registerPackageTool } from "../../shared/tool-presentation/registry";
@@ -66,6 +67,7 @@ export default function vision(
 		pi,
 		createToolDefinition(pi, () => config, completeSimple),
 	);
+	getAgentRuntimeComposition(pi).publishBaselineToolNames([TOOL_NAME]);
 }
 
 function createToolSynchronizer(
@@ -74,15 +76,13 @@ function createToolSynchronizer(
 ) {
 	return (model: { readonly input?: readonly string[] } | undefined): void => {
 		const config = getConfig();
-		const active = pi.getActiveTools().filter((name) => name !== TOOL_NAME);
-		if (
-			config.enabled &&
-			config.model?.id !== undefined &&
-			!isMultimodal(model)
-		) {
-			active.push(TOOL_NAME);
-		}
-		pi.setActiveTools(active);
+		const available =
+			config.enabled && config.model?.id !== undefined && !isMultimodal(model);
+		getAgentRuntimeComposition(pi).setRestrictiveToolFilter(
+			"vision-availability",
+			(candidates) =>
+				candidates.filter((name) => name !== TOOL_NAME || available),
+		);
 	};
 }
 

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -355,12 +355,14 @@ async function createFakePi(): Promise<FakePi> {
 function setMainWorkflowPolicy(
 	fake: FakePi,
 	workflows: readonly string[] | undefined,
+	tools?: readonly string[],
 ): void {
 	if (fake.api === undefined) {
 		throw new Error("extension API missing");
 	}
 	getAgentRuntimeComposition(fake.api).setMainAgentContribution({
 		prompt: "main",
+		...(tools === undefined ? {} : { tools }),
 		agent: {
 			id: "Main",
 			...(workflows === undefined ? {} : { workflows }),
@@ -624,8 +626,8 @@ describe("workflow extension lifecycle", () => {
 		});
 		expect(fake.activeTools).toEqual([
 			"read",
-			"workflow_create",
 			"workflow_transition",
+			"workflow_create",
 		]);
 		expect(
 			await transition.execute("transition", { stageId: "done" }),
@@ -1316,7 +1318,7 @@ describe("workflow extension lifecycle", () => {
 	test("keeps active context after suppressing the sole activation tool", async () => {
 		await createSuite(validYaml());
 		const fake = await createFakePi();
-		fake.activeTools = ["read", "workflow_activate"];
+		setMainWorkflowPolicy(fake, ["delivery"], ["read", "workflow_activate"]);
 		await runLifecycle(fake, "session_start");
 		const activate = requireTool(fake, "workflow_activate");
 
@@ -1520,7 +1522,7 @@ describe("workflow extension lifecycle", () => {
 	test("leaves active names unchanged while the subsystem is usable", async () => {
 		await createSuite(validYaml());
 		const fake = await createFakePi();
-		fake.activeTools = ["read"];
+		setMainWorkflowPolicy(fake, ["delivery"], ["read"]);
 		await runLifecycle(fake, "session_start");
 		expect(fake.activeTools).toEqual(["read"]);
 	});
@@ -1530,32 +1532,41 @@ describe("workflow extension lifecycle", () => {
 		await createSuite();
 		const fake = await createFakePi();
 		fake.activeTools = ["read", "workflow_activate", "workflow_transition"];
+		if (fake.api === undefined) {
+			throw new Error("extension API missing");
+		}
+		const composition = getAgentRuntimeComposition(fake.api);
+		composition.setMainAgentContribution({
+			prompt: "main",
+			tools: ["read", "workflow_activate", "workflow_transition"],
+		});
 		await runLifecycle(fake, "session_start");
 		expect(fake.activeTools).toEqual(["read"]);
 
-		fake.activeTools = ["read", "workflow_transition"];
 		await runLifecycle(fake, "session_tree");
 		expect(fake.activeTools).toEqual(["read"]);
 
+		composition.setRestrictiveToolNames("upstream", ["read"]);
+		composition.addBaselineToolNames(["workflow_transition"]);
+
 		await runLifecycle(fake, "session_tree", [activatedEntry()]);
-		expect(fake.activeTools).toEqual(["read", "workflow_transition"]);
+		expect(fake.activeTools).toEqual(["read"]);
 		await runLifecycle(fake, "session_tree", [activatedEntry()]);
-		expect(fake.activeTools).toEqual(["read", "workflow_transition"]);
+		expect(fake.activeTools).toEqual(["read"]);
 	});
 
 	/** Proves a main-agent policy reset replaces stale suppression ownership. */
 	test("reconciles inactive state after main-agent contribution changes", async () => {
 		await createSuite();
 		const fake = await createFakePi();
-		fake.activeTools = ["read", "workflow_activate", "workflow_transition"];
+		setMainWorkflowPolicy(fake, undefined, [
+			"read",
+			"workflow_activate",
+			"workflow_transition",
+		]);
 		await runLifecycle(fake, "session_start");
 
-		fake.activeTools = ["read", "workflow_transition"];
-		for (const listener of fake.listeners.get(
-			MAIN_AGENT_CONTRIBUTION_CHANGE_EVENT,
-		) ?? []) {
-			listener();
-		}
+		setMainWorkflowPolicy(fake, undefined, ["read", "workflow_transition"]);
 		expect(fake.activeTools).toEqual(["read"]);
 		await runLifecycle(fake, "session_tree", [activatedEntry()]);
 		expect(fake.activeTools).toEqual(["read", "workflow_transition"]);
@@ -1565,17 +1576,12 @@ describe("workflow extension lifecycle", () => {
 	test("clears stale suppression after a usable main-agent policy change", async () => {
 		await createSuite();
 		const fake = await createFakePi();
-		fake.activeTools = ["read", "workflow_transition"];
+		setMainWorkflowPolicy(fake, undefined, ["read", "workflow_transition"]);
 		await runLifecycle(fake, "session_start");
 		await runLifecycle(fake, "session_tree", [activatedEntry()]);
 		expect(fake.activeTools).toEqual(["read", "workflow_transition"]);
 
-		fake.activeTools = ["read"];
-		for (const listener of fake.listeners.get(
-			MAIN_AGENT_CONTRIBUTION_CHANGE_EVENT,
-		) ?? []) {
-			listener();
-		}
+		setMainWorkflowPolicy(fake, undefined, ["read"]);
 		expect(fake.activeTools).toEqual(["read"]);
 		await runLifecycle(fake, "session_tree");
 		await runLifecycle(fake, "session_tree", [activatedEntry()]);
@@ -1696,7 +1702,11 @@ describe("workflow extension lifecycle", () => {
 	test("deactivates cleanly and rejects malformed saved entries", async () => {
 		await createSuite();
 		const fake = await createFakePi();
-		fake.activeTools = ["read", "workflow_activate", "workflow_transition"];
+		setMainWorkflowPolicy(fake, undefined, [
+			"read",
+			"workflow_activate",
+			"workflow_transition",
+		]);
 		await runLifecycle(fake, "session_start");
 		expect(fake.activeTools).toEqual(["read"]);
 		await expect(

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -635,6 +635,9 @@ function registerWorkflowRuntime(
 			refreshTools("lifecycle");
 		},
 	});
+	getAgentRuntimeComposition(pi).publishBaselineToolNames([
+		...WORKFLOW_TOOL_NAMES,
+	]);
 	pi.on("context", (event) => {
 		const activeNames = pi.getActiveTools();
 		const availability = resolveAvailability();
@@ -1163,36 +1166,27 @@ function reconcileTools(
 		selfSuppressedNames.clear();
 	}
 
-	// The extension records only names it removes for current system availability.
-	const removedNames = activeNames
-		.filter(isWorkflowToolName)
-		.filter((name) => !availableToolNames.has(name));
-	for (const name of removedNames) {
-		selfSuppressedNames.add(name);
+	// Suppression ownership remains separate from final list ownership because context projection uses it.
+	for (const name of activeNames.filter(isWorkflowToolName)) {
+		if (!availableToolNames.has(name)) {
+			selfSuppressedNames.add(name);
+		}
+	}
+	if (trigger === "lifecycle") {
+		for (const name of selfSuppressedNames) {
+			if (isWorkflowToolName(name) && availableToolNames.has(name)) {
+				selfSuppressedNames.delete(name);
+			}
+		}
 	}
 
-	// Ordinary lifecycle changes may restore only names previously removed by this extension.
-	const restoredNames =
-		trigger === "lifecycle"
-			? [...selfSuppressedNames]
-					.filter(isWorkflowToolName)
-					.filter(
-						(name) =>
-							availableToolNames.has(name) && !activeNames.includes(name),
-					)
-			: [];
-	for (const name of restoredNames) {
-		selfSuppressedNames.delete(name);
-	}
-
-	const removedNameSet: ReadonlySet<string> = new Set(removedNames);
-	const nextNames = [
-		...activeNames.filter((name) => !removedNameSet.has(name)),
-		...restoredNames,
-	];
-	if (removedNames.length > 0 || restoredNames.length > 0) {
-		pi.setActiveTools(nextNames);
-	}
+	getAgentRuntimeComposition(pi).setRestrictiveToolFilter(
+		"workflow-availability",
+		(candidates) =>
+			candidates.filter(
+				(name) => !isWorkflowToolName(name) || availableToolNames.has(name),
+			),
+	);
 }
 
 /** Narrows arbitrary Pi tool names to the workflow-owned finite set. */

--- a/pi-package/shared/agent-end-state.test.ts
+++ b/pi-package/shared/agent-end-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
+import { isAbortedAgentRun, isCompletedAgentRun } from "./agent-end-state";
+
+function agentEnd(messages: readonly Record<string, unknown>[]): AgentEndEvent {
+	return { type: "agent_end", messages } as unknown as AgentEndEvent;
+}
+
+describe("agent end state", () => {
+	test("classifies the final assistant outcome", () => {
+		// Purpose: lifecycle consumers must share one definition of cancellation and completed work.
+		// Input and expected output: aborted is cancellation, stop is completion, and error is neither.
+		// Edge case: provider errors must not be treated as user cancellation.
+		// Dependencies: pure AgentEndEvent classification only.
+		expect({
+			aborted: {
+				cancelled: isAbortedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "aborted" }]),
+				),
+				completed: isCompletedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "aborted" }]),
+				),
+			},
+			stop: {
+				cancelled: isAbortedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "stop" }]),
+				),
+				completed: isCompletedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "stop" }]),
+				),
+			},
+			error: {
+				cancelled: isAbortedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "error" }]),
+				),
+				completed: isCompletedAgentRun(
+					agentEnd([{ role: "assistant", stopReason: "error" }]),
+				),
+			},
+		}).toEqual({
+			aborted: { cancelled: true, completed: false },
+			stop: { cancelled: false, completed: true },
+			error: { cancelled: false, completed: false },
+		});
+	});
+
+	test("uses the latest assistant message despite surrounding messages", () => {
+		// Purpose: an earlier cancelled turn must not override a newer successful assistant outcome.
+		// Input and expected output: aborted assistant, tool result, successful assistant, and trailing tool result classify as completed.
+		// Edge case: non-assistant messages can follow either assistant outcome.
+		// Dependencies: pure AgentEndEvent classification only.
+		const event = agentEnd([
+			{ role: "assistant", stopReason: "aborted" },
+			{ role: "toolResult" },
+			{ role: "assistant", stopReason: "toolUse" },
+			{ role: "toolResult" },
+		]);
+
+		expect({
+			cancelled: isAbortedAgentRun(event),
+			completed: isCompletedAgentRun(event),
+		}).toEqual({ cancelled: false, completed: true });
+	});
+
+	test("does not classify an event without an assistant message", () => {
+		// Purpose: malformed or empty lifecycle events must not fabricate an outcome.
+		// Input and expected output: empty and tool-only message lists are neither cancelled nor completed.
+		// Edge case: a tool result may be the only message in a synthetic event.
+		// Dependencies: pure AgentEndEvent classification only.
+		for (const event of [agentEnd([]), agentEnd([{ role: "toolResult" }])]) {
+			expect({
+				cancelled: isAbortedAgentRun(event),
+				completed: isCompletedAgentRun(event),
+			}).toEqual({ cancelled: false, completed: false });
+		}
+	});
+});

--- a/pi-package/shared/agent-end-state.ts
+++ b/pi-package/shared/agent-end-state.ts
@@ -1,0 +1,34 @@
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
+
+type AssistantAgentMessage = Extract<
+	AgentEndEvent["messages"][number],
+	{ readonly role: "assistant" }
+>;
+
+/** Returns whether the final assistant outcome represents a cancelled agent run. */
+export function isAbortedAgentRun(event: AgentEndEvent): boolean {
+	return findLastAssistantMessage(event)?.stopReason === "aborted";
+}
+
+/** Returns whether the final assistant outcome represents completed work. */
+export function isCompletedAgentRun(event: AgentEndEvent): boolean {
+	const stopReason = findLastAssistantMessage(event)?.stopReason;
+	return (
+		stopReason !== undefined &&
+		stopReason !== "error" &&
+		stopReason !== "aborted"
+	);
+}
+
+/** Finds the latest assistant message because tool results can follow assistant turns. */
+function findLastAssistantMessage(
+	event: AgentEndEvent,
+): AssistantAgentMessage | undefined {
+	for (let index = event.messages.length - 1; index >= 0; index--) {
+		const message = event.messages[index];
+		if (message?.role === "assistant") {
+			return message;
+		}
+	}
+	return undefined;
+}

--- a/pi-package/shared/agent-runtime-composition.test.ts
+++ b/pi-package/shared/agent-runtime-composition.test.ts
@@ -12,6 +12,7 @@ interface Handler {
 
 function createPi(
 	active: readonly string[],
+	registered: readonly string[] = active,
 ): ExtensionAPI & { readonly handlers: Handler[] } {
 	let activeTools = [...active];
 	const handlers: Handler[] = [];
@@ -23,6 +24,9 @@ function createPi(
 		},
 		getActiveTools(): readonly string[] {
 			return activeTools;
+		},
+		getAllTools() {
+			return registered.map((name) => ({ name }));
 		},
 		setActiveTools(names: readonly string[]): void {
 			activeTools = [...names];
@@ -122,6 +126,36 @@ describe("agent runtime composition", () => {
 		composition.addBaselineToolNames(["grep"]);
 
 		expect(pi.getActiveTools()).toEqual(["read", "grep"]);
+	});
+
+	/**
+	 * Proves every main-agent tool policy is a remove-only filter of the stable baseline.
+	 * Input and expected output: a reordered allowlist with registered baseline-external write preserves [read, edit]; clearing a narrower policy restores read under the child restriction.
+	 * Edge case: write is registered but absent from the baseline, so the policy cannot grant it.
+	 * Dependencies: main-agent contribution updates and named restrictive layers both trigger composition reconciliation.
+	 */
+	test("treats main-agent tools as a baseline-ordered remove-only filter", () => {
+		const pi = createPi(
+			["read", "grep", "edit"],
+			["read", "grep", "edit", "write"],
+		);
+		const composition = getAgentRuntimeComposition(pi);
+		composition.setRestrictiveToolNames("child", ["read", "edit"]);
+		composition.setMainAgentContribution({
+			prompt: "Main-agent prompt",
+			tools: ["edit", "write", "read"],
+		});
+
+		expect(pi.getActiveTools()).toEqual(["read", "edit"]);
+
+		composition.setMainAgentContribution({
+			prompt: "Main-agent prompt",
+			tools: ["edit"],
+		});
+		expect(pi.getActiveTools()).toEqual(["edit"]);
+
+		composition.clearMainAgentContribution();
+		expect(pi.getActiveTools()).toEqual(["read", "edit"]);
 	});
 
 	test("restores eligible tools at their stable baseline positions", () => {

--- a/pi-package/shared/agent-runtime-composition.test.ts
+++ b/pi-package/shared/agent-runtime-composition.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createEventBus,
+	type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "./agent-runtime-composition.ts";
+
+interface Handler {
+	readonly name: string;
+	readonly run: (event: unknown, ctx: unknown) => Promise<unknown> | unknown;
+}
+
+function createPi(
+	active: readonly string[],
+): ExtensionAPI & { readonly handlers: Handler[] } {
+	let activeTools = [...active];
+	const handlers: Handler[] = [];
+	return {
+		handlers,
+		events: createEventBus(),
+		on(name: string, run: Handler["run"]): void {
+			handlers.push({ name, run });
+		},
+		getActiveTools(): readonly string[] {
+			return activeTools;
+		},
+		setActiveTools(names: readonly string[]): void {
+			activeTools = [...names];
+		},
+	} as unknown as ExtensionAPI & { readonly handlers: Handler[] };
+}
+
+describe("agent runtime composition", () => {
+	/**
+	 * Proves extension-loading publication records order without invoking active-tool actions.
+	 * Input and expected output: a deferred tool stays inactive until runtime reconciliation, then appears after read.
+	 * Edge case: publication occurs before the composition has captured a Pi active-tool baseline.
+	 * Dependencies: lazy baseline initialization and stable registration ordering.
+	 */
+	test("defers published baseline tools until runtime reconciliation", () => {
+		const pi = createPi(["read"]);
+		const composition = getAgentRuntimeComposition(pi);
+
+		composition.publishBaselineToolNames(["describe_image"]);
+		expect(pi.getActiveTools()).toEqual(["read"]);
+
+		composition.reconcileActiveTools();
+		expect(pi.getActiveTools()).toEqual(["read", "describe_image"]);
+	});
+
+	test("publishes restrictive filters without invoking extension-loading actions", () => {
+		let runtimeReady = false;
+		let activeTools = ["read", "deferred_tool"];
+		const pi = {
+			events: createEventBus(),
+			on() {},
+			getActiveTools() {
+				if (!runtimeReady) {
+					throw new Error("Extension runtime not initialized");
+				}
+				return [...activeTools];
+			},
+			setActiveTools(names: readonly string[]) {
+				if (!runtimeReady) {
+					throw new Error("Extension runtime not initialized");
+				}
+				activeTools = [...names];
+			},
+		} as unknown as ExtensionAPI;
+		const composition = getAgentRuntimeComposition(pi);
+
+		expect(() =>
+			composition.publishRestrictiveToolFilter("deferred", (candidates) =>
+				candidates.filter((name) => name !== "deferred_tool"),
+			),
+		).not.toThrow();
+		runtimeReady = true;
+		composition.reconcileActiveTools();
+		expect(activeTools).toEqual(["read"]);
+	});
+
+	test("atomically replaces one owner's baseline tools", () => {
+		// Purpose: dynamic providers must replace stale registered definitions without removing unrelated baseline tools.
+		// Input and expected output: a provider changes old_tool to new_tool while read remains active.
+		// Edge case: a restrictive filter is evaluated only against the replacement catalog.
+		// Dependencies: lazy baseline capture and final composition reconciliation.
+		const pi = createPi(["read", "old_tool"]);
+		const composition = getAgentRuntimeComposition(pi);
+		composition.replaceBaselineToolNames("provider", ["old_tool"]);
+		composition.setRestrictiveToolFilter("provider-policy", (candidates) =>
+			candidates.filter((name) => name !== "old_tool"),
+		);
+
+		composition.replaceBaselineToolNames("provider", ["new_tool"]);
+
+		expect(pi.getActiveTools()).toEqual(["read", "new_tool"]);
+	});
+
+	test("keeps added baseline tools subject to restrictive allowlists", () => {
+		const pi = createPi(["read"]);
+		const composition = getAgentRuntimeComposition(pi);
+		composition.setRestrictiveToolNames("child", ["read"]);
+		composition.addBaselineToolNames(["grep"]);
+
+		expect(pi.getActiveTools()).toEqual(["read"]);
+	});
+
+	/**
+	 * Proves named dynamic restrictions are re-evaluated by the sole active-tool owner.
+	 * Input and expected output: a depth filter removes a subagent tool and cannot grant an unknown name.
+	 * Edge case: a later baseline addition remains filtered instead of restoring the restricted tool.
+	 * Dependencies: stable baseline publication and named restrictive composition layers.
+	 */
+	test("keeps named restrictive filters enforced across later reconciliation", () => {
+		const pi = createPi(["read", "subagent_start"]);
+		const composition = getAgentRuntimeComposition(pi);
+		composition.setRestrictiveToolFilter("subagent-depth", (candidates) => [
+			...candidates.filter((name) => name !== "subagent_start"),
+			"forbidden_tool",
+		]);
+
+		composition.addBaselineToolNames(["grep"]);
+
+		expect(pi.getActiveTools()).toEqual(["read", "grep"]);
+	});
+
+	test("restores eligible tools at their stable baseline positions", () => {
+		const pi = createPi(["read", "workflow_transition", "workflow_create"]);
+		const composition = getAgentRuntimeComposition(pi);
+		composition.setRestrictiveToolNames("workflow", [
+			"read",
+			"workflow_create",
+		]);
+		expect(pi.getActiveTools()).toEqual(["read", "workflow_create"]);
+
+		composition.setRestrictiveToolNames("workflow", [
+			"read",
+			"workflow_transition",
+			"workflow_create",
+		]);
+
+		expect(pi.getActiveTools()).toEqual([
+			"read",
+			"workflow_transition",
+			"workflow_create",
+		]);
+	});
+});

--- a/pi-package/shared/agent-runtime-composition.ts
+++ b/pi-package/shared/agent-runtime-composition.ts
@@ -30,10 +30,7 @@ interface BeforeAgentStartEventLike {
 	readonly systemPrompt?: string;
 }
 
-type ActiveToolFilter = (
-	toolNames: readonly string[],
-	ctx: unknown,
-) => Promise<readonly string[]> | readonly string[];
+type ActiveToolFilter = (toolNames: readonly string[]) => readonly string[];
 
 /** Runtime composition owner for agent-related prompt and active-tool contributions. */
 export interface AgentRuntimeComposition {
@@ -43,7 +40,27 @@ export interface AgentRuntimeComposition {
 	clearMainAgentContribution(): void;
 	getMainAgentContribution(): MainAgentContribution | undefined;
 	setSubagentsContribution(contribution: PromptContribution | undefined): void;
-	setSubagentsActiveToolFilter(filter: ActiveToolFilter | undefined): void;
+	/** Records tools registered during extension loading without invoking Pi action methods. */
+	publishBaselineToolNames(toolNames: readonly string[]): void;
+	/** Adds registered baseline tools without allowing policy filters to be bypassed. */
+	addBaselineToolNames(toolNames: readonly string[]): void;
+	/** Replaces one owner's registered baseline-tool contribution. */
+	replaceBaselineToolNames(owner: string, toolNames: readonly string[]): void;
+	/** Stages one owner's baseline replacement for a coupled reconciliation. */
+	stageBaselineToolNames(owner: string, toolNames: readonly string[]): void;
+	/** Applies one named restrictive allowlist to the final active-tool pipeline. */
+	setRestrictiveToolNames(
+		name: string,
+		toolNames: readonly string[] | undefined,
+	): void;
+	/** Applies one named restrictive filter to every active-tool reconciliation. */
+	setRestrictiveToolFilter(
+		name: string,
+		filter: ActiveToolFilter | undefined,
+	): void;
+	/** Records an extension-loading filter without calling unavailable Pi action methods. */
+	publishRestrictiveToolFilter(name: string, filter: ActiveToolFilter): void;
+	reconcileActiveTools(): void;
 	setConsultAdvisorContribution(
 		contribution: PromptContribution | undefined,
 	): void;
@@ -143,10 +160,16 @@ export function markAgentRuntimeCompositionStale(pi: ExtensionAPI): void {
 class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 	private mainAgentContribution: MainAgentContribution | undefined;
 	private subagentsContribution: PromptContribution | undefined;
-	private subagentsActiveToolFilter: ActiveToolFilter | undefined;
 	private consultAdvisorContribution: PromptContribution | undefined;
 	private conveneCouncilContribution: PromptContribution | undefined;
 	private baselineActiveTools: string[] | undefined;
+	private readonly pendingBaselineToolNames: string[] = [];
+	private readonly baselineToolNamesByOwner = new Map<
+		string,
+		readonly string[]
+	>();
+	private readonly restrictiveToolNames = new Map<string, readonly string[]>();
+	private readonly restrictiveToolFilters = new Map<string, ActiveToolFilter>();
 
 	public constructor(private readonly pi: ExtensionAPI) {
 		writeRuntimeDiagnostic("runtime-composition.before-agent-start.registered");
@@ -213,9 +236,7 @@ class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 	public setMainAgentContribution(
 		contribution: MainAgentContribution | undefined,
 	): void {
-		if (this.baselineActiveTools === undefined) {
-			this.baselineActiveTools = this.pi.getActiveTools();
-		}
+		this.ensureBaselineActiveTools();
 
 		writeRuntimeDiagnostic("runtime-composition.main-agent.set", {
 			mainAgentId: contribution?.agent?.id ?? null,
@@ -225,11 +246,7 @@ class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 			activeToolsBeforeSet: this.pi.getActiveTools(),
 		});
 		this.mainAgentContribution = contribution;
-		this.pi.setActiveTools(
-			contribution?.tools !== undefined
-				? [...contribution.tools]
-				: this.baselineActiveTools,
-		);
+		this.reconcileActiveTools();
 		writeRuntimeDiagnostic("runtime-composition.main-agent.tools-applied", {
 			mainAgentId: contribution?.agent?.id ?? null,
 			activeToolsAfterSet: this.pi.getActiveTools(),
@@ -258,10 +275,130 @@ class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 		this.subagentsContribution = contribution;
 	}
 
-	public setSubagentsActiveToolFilter(
+	public publishBaselineToolNames(toolNames: readonly string[]): void {
+		for (const name of toolNames) {
+			if (
+				!this.pendingBaselineToolNames.includes(name) &&
+				!this.baselineActiveTools?.includes(name)
+			) {
+				this.pendingBaselineToolNames.push(name);
+			}
+		}
+	}
+
+	public addBaselineToolNames(toolNames: readonly string[]): void {
+		const baseline = this.ensureBaselineActiveTools();
+		for (const name of toolNames) {
+			if (!baseline.includes(name)) {
+				baseline.push(name);
+			}
+		}
+		this.reconcileActiveTools();
+	}
+
+	public replaceBaselineToolNames(
+		owner: string,
+		toolNames: readonly string[],
+	): void {
+		const baseline = this.ensureBaselineActiveTools();
+		const previousBaseline = [...baseline];
+		const previousContribution = this.baselineToolNamesByOwner.get(owner);
+		this.stageBaselineToolNames(owner, toolNames);
+		try {
+			this.reconcileActiveTools();
+		} catch (error) {
+			// Baseline ownership and Pi's active list must describe the same catalog.
+			baseline.splice(0, baseline.length, ...previousBaseline);
+			if (previousContribution === undefined) {
+				this.baselineToolNamesByOwner.delete(owner);
+			} else {
+				this.baselineToolNamesByOwner.set(owner, previousContribution);
+			}
+			this.reconcileActiveTools();
+			throw error;
+		}
+	}
+
+	public stageBaselineToolNames(
+		owner: string,
+		toolNames: readonly string[],
+	): void {
+		const baseline = this.ensureBaselineActiveTools();
+		const previousContribution = this.baselineToolNamesByOwner.get(owner);
+		const nextContribution = [...new Set(toolNames)];
+		const namesOwnedElsewhere = new Set(
+			[...this.baselineToolNamesByOwner.entries()]
+				.filter(([candidateOwner]) => candidateOwner !== owner)
+				.flatMap(([, names]) => names),
+		);
+		const removedNames = new Set(
+			(previousContribution ?? []).filter(
+				(name) =>
+					!nextContribution.includes(name) && !namesOwnedElsewhere.has(name),
+			),
+		);
+
+		baseline.splice(
+			0,
+			baseline.length,
+			...baseline.filter((name) => !removedNames.has(name)),
+		);
+		for (const name of nextContribution) {
+			if (!baseline.includes(name)) {
+				baseline.push(name);
+			}
+		}
+		this.baselineToolNamesByOwner.set(owner, nextContribution);
+	}
+
+	public setRestrictiveToolNames(
+		name: string,
+		toolNames: readonly string[] | undefined,
+	): void {
+		if (toolNames === undefined) {
+			this.restrictiveToolNames.delete(name);
+		} else {
+			this.restrictiveToolNames.set(name, [...toolNames]);
+		}
+		this.reconcileActiveTools();
+	}
+
+	public setRestrictiveToolFilter(
+		name: string,
 		filter: ActiveToolFilter | undefined,
 	): void {
-		this.subagentsActiveToolFilter = filter;
+		if (filter === undefined) {
+			this.restrictiveToolFilters.delete(name);
+		} else {
+			this.restrictiveToolFilters.set(name, filter);
+		}
+		this.reconcileActiveTools();
+	}
+
+	/** Records a restriction during extension loading and reconciles it only after Pi actions become available. */
+	public publishRestrictiveToolFilter(
+		name: string,
+		filter: ActiveToolFilter,
+	): void {
+		this.restrictiveToolFilters.set(name, filter);
+		if (this.baselineActiveTools !== undefined) {
+			this.reconcileActiveTools();
+		}
+	}
+
+	public reconcileActiveTools(): void {
+		const baseline = this.ensureBaselineActiveTools();
+		const source = this.mainAgentContribution?.tools ?? baseline;
+		const resolved = [...source];
+		for (const allowedNames of this.restrictiveToolNames.values()) {
+			intersectToolNames(resolved, allowedNames);
+		}
+		for (const filter of this.restrictiveToolFilters.values()) {
+			intersectToolNames(resolved, filter(resolved));
+		}
+		if (!areStringArraysEqual(this.pi.getActiveTools(), resolved)) {
+			this.pi.setActiveTools(resolved);
+		}
 	}
 
 	public setConsultAdvisorContribution(
@@ -276,20 +413,25 @@ class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 		this.conveneCouncilContribution = contribution;
 	}
 
-	/** Applies dynamic tool filters after selected-agent restoration and before prompt composition. */
-	private async resolveActiveToolNames(
-		ctx: unknown,
-	): Promise<readonly string[]> {
-		const currentToolNames = this.pi.getActiveTools();
-		const filteredToolNames =
-			this.subagentsActiveToolFilter === undefined
-				? currentToolNames
-				: await this.subagentsActiveToolFilter(currentToolNames, ctx);
-		if (!areStringArraysEqual(currentToolNames, filteredToolNames)) {
-			this.pi.setActiveTools([...filteredToolNames]);
+	/** Captures Pi state lazily because action methods are unavailable during extension loading. */
+	private ensureBaselineActiveTools(): string[] {
+		if (this.baselineActiveTools === undefined) {
+			this.baselineActiveTools = [...this.pi.getActiveTools()];
 		}
+		const baseline = this.baselineActiveTools;
+		for (const name of this.pendingBaselineToolNames) {
+			if (!baseline.includes(name)) {
+				baseline.push(name);
+			}
+		}
+		this.pendingBaselineToolNames.length = 0;
+		return baseline;
+	}
 
-		return filteredToolNames;
+	/** Resolves every named restriction before composing tool-dependent prompts. */
+	private resolveActiveToolNames(_ctx: unknown): readonly string[] {
+		this.reconcileActiveTools();
+		return this.pi.getActiveTools();
 	}
 }
 
@@ -314,6 +456,19 @@ async function resolvePromptContribution(
 }
 
 /** Compares ordered tool-name lists to avoid redundant active-tool writes. */
+function intersectToolNames(
+	candidates: string[],
+	requestedNames: readonly string[],
+): void {
+	const requested = new Set(requestedNames);
+	for (let index = candidates.length - 1; index >= 0; index -= 1) {
+		const candidate = candidates[index];
+		if (candidate !== undefined && !requested.has(candidate)) {
+			candidates.splice(index, 1);
+		}
+	}
+}
+
 function areStringArraysEqual(
 	left: readonly string[],
 	right: readonly string[],

--- a/pi-package/shared/agent-runtime-composition.ts
+++ b/pi-package/shared/agent-runtime-composition.ts
@@ -388,8 +388,10 @@ class AgentRuntimeCompositionImpl implements AgentRuntimeComposition {
 
 	public reconcileActiveTools(): void {
 		const baseline = this.ensureBaselineActiveTools();
-		const source = this.mainAgentContribution?.tools ?? baseline;
-		const resolved = [...source];
+		const resolved = [...baseline];
+		if (this.mainAgentContribution?.tools !== undefined) {
+			intersectToolNames(resolved, this.mainAgentContribution.tools);
+		}
 		for (const allowedNames of this.restrictiveToolNames.values()) {
 			intersectToolNames(resolved, allowedNames);
 		}

--- a/pi-package/shared/toolsets/contracts.ts
+++ b/pi-package/shared/toolsets/contracts.ts
@@ -1,0 +1,37 @@
+export interface Toolset {
+	readonly providerId: string;
+	readonly name: string;
+	readonly description: string;
+	readonly toolNames: readonly string[];
+	/** Confirms provider readiness and returns the registered names available for composition. */
+	readonly activate: () => Promise<readonly string[]>;
+}
+
+export interface VisibleToolset {
+	readonly name: string;
+	readonly description: string;
+	readonly toolNames: readonly string[];
+}
+
+export interface ToolsetActivation {
+	readonly name: string;
+	readonly toolNames: readonly string[];
+	readonly alreadyActive: boolean;
+}
+
+/** Full branch-local state; replay replaces activation state instead of merging events. */
+export interface ToolsetActivationSnapshotV1 {
+	readonly version: 1;
+	readonly activeToolsets: readonly string[];
+}
+
+export interface ToolsetActivationPresentation {
+	readonly name: string;
+	readonly status: "activated" | "already_active";
+	readonly toolNames: readonly string[];
+}
+
+/** Keeps replay state and typed presentation data together without parsing LLM text. */
+export interface ToolsetActivationDetails extends ToolsetActivationSnapshotV1 {
+	readonly activation: ToolsetActivationPresentation;
+}

--- a/pi-package/shared/toolsets/contracts.ts
+++ b/pi-package/shared/toolsets/contracts.ts
@@ -19,12 +19,6 @@ export interface ToolsetActivation {
 	readonly alreadyActive: boolean;
 }
 
-/** Full branch-local state; replay replaces activation state instead of merging events. */
-export interface ToolsetActivationSnapshotV1 {
-	readonly version: 1;
-	readonly activeToolsets: readonly string[];
-}
-
 export interface ToolsetActivationPresentation {
 	readonly name: string;
 	readonly status: "activated" | "already_active";
@@ -32,6 +26,8 @@ export interface ToolsetActivationPresentation {
 }
 
 /** Keeps replay state and typed presentation data together without parsing LLM text. */
-export interface ToolsetActivationDetails extends ToolsetActivationSnapshotV1 {
+export interface ToolsetActivationDetails {
+	readonly version: 1;
+	readonly activeToolsets: readonly string[];
 	readonly activation: ToolsetActivationPresentation;
 }

--- a/pi-package/shared/toolsets/rendering.test.ts
+++ b/pi-package/shared/toolsets/rendering.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { initTheme, type Theme } from "@earendil-works/pi-coding-agent";
+import { Box, visibleWidth } from "@earendil-works/pi-tui";
+import type { ToolsetActivationDetails } from "./contracts.ts";
+import {
+	renderActivateToolsetCall,
+	renderActivateToolsetResult,
+} from "./rendering.ts";
+
+initTheme(undefined, false);
+
+const theme = {
+	bold: (text: string) => text,
+	fg: (_color: string, text: string) => text,
+} as unknown as Theme;
+
+const toolNames = [
+	"files_read",
+	"files_write",
+	"files_search",
+	"files_list",
+	"files_move",
+	"files_remove",
+];
+
+function result(status: "activated" | "already_active" = "activated") {
+	const details: ToolsetActivationDetails = {
+		version: 1,
+		activeToolsets: ["files"],
+		activation: { name: "files", status, toolNames },
+	};
+	return {
+		content: [{ type: "text", text: "LLM content must not drive rendering" }],
+		details,
+	};
+}
+
+describe("activate_toolset rendering", () => {
+	test("renders a compact width-bounded call with the exact requested name", () => {
+		const component = renderActivateToolsetCall(
+			{ name: "проектные-файлы-с-длинным-именем" },
+			theme,
+		);
+		const lines = component.render(24);
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("activate_toolset");
+		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
+	});
+
+	test("shows status, count, a bounded preview, and expansion hint when collapsed", () => {
+		const component = renderActivateToolsetResult(
+			result(),
+			{ expanded: false },
+			theme,
+		);
+		const lines = component.render(36);
+		const text = lines.join("\n");
+
+		expect(text).toContain('Activated "files"');
+		expect(text).toContain("6 tools");
+		expect(text).toContain("files_read");
+		expect(text).not.toContain("files_remove");
+		expect(text).toContain("to expand");
+		expect(lines.length).toBeLessThanOrEqual(4);
+	});
+
+	test("shows every allowed name and no schema or description when expanded", () => {
+		const component = renderActivateToolsetResult(
+			result("already_active"),
+			{ expanded: true },
+			theme,
+		);
+		const text = component.render(80).join("\n");
+
+		expect(text).toContain('Toolset "files" is already active');
+		for (const name of toolNames) {
+			expect(text).toContain(name);
+		}
+		expect(text).not.toContain("parameters");
+		expect(text).not.toContain("description");
+	});
+
+	test("keeps collapsed and expanded output inside Pi default tool shell width", () => {
+		for (const expanded of [false, true]) {
+			const shell = new Box(1, 1);
+			shell.addChild(
+				renderActivateToolsetResult(result(), { expanded }, theme),
+			);
+			const lines = shell.render(32);
+			expect(lines.every((line) => visibleWidth(line) <= 32)).toBe(true);
+		}
+	});
+});

--- a/pi-package/shared/toolsets/rendering.test.ts
+++ b/pi-package/shared/toolsets/rendering.test.ts
@@ -14,6 +14,11 @@ const theme = {
 	fg: (_color: string, text: string) => text,
 } as unknown as Theme;
 
+const ansiTheme = {
+	bold: (text: string) => `\u001b[1m${text}\u001b[22m`,
+	fg: (_color: string, text: string) => `\u001b[32m${text}\u001b[39m`,
+} as unknown as Theme;
+
 const toolNames = [
 	"files_read",
 	"files_write",
@@ -49,6 +54,46 @@ describe("activate_toolset rendering", () => {
 		expect(lines).toHaveLength(1);
 		expect(lines[0]).toContain("activate_toolset");
 		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
+	});
+
+	/**
+	 * Purpose: narrow ANSI-styled rows must close every style after plain-text clipping.
+	 * Input and expected output: a 12-column call clips the fixed prefix to a complete styled row.
+	 * Edge case: the width is narrower than the fixed prefix and the row is rendered inside Box.
+	 * Dependencies: the equivalent ANSI theme and Pi visible-width contract.
+	 */
+	test("clips plain call text before applying ANSI styles", () => {
+		const line =
+			renderActivateToolsetCall(
+				{ name: "configured-toolset-name" },
+				ansiTheme,
+			).render(12)[0] ?? "";
+
+		expect(line).toBe("\u001b[32m\u001b[1mactivate_to…\u001b[22m\u001b[39m");
+		expect(visibleWidth(line)).toBeLessThanOrEqual(12);
+
+		const shell = new Box(1, 1);
+		shell.addChild(
+			renderActivateToolsetCall({ name: "configured-toolset-name" }, ansiTheme),
+		);
+		const shellLine = shell.render(14)[1] ?? "";
+		expect(shellLine).toContain(line);
+		expect(visibleWidth(shellLine)).toBeLessThanOrEqual(14);
+	});
+
+	/**
+	 * Purpose: fitting calls must retain the requested toolset name exactly.
+	 * Input and expected output: the 22-column prefix-plus-name call contains all five name characters.
+	 * Edge case: ANSI wrappers must not affect the fit calculation.
+	 * Dependencies: the equivalent ANSI theme and Pi visible-width contract.
+	 */
+	test("preserves the exact requested name when the full call fits", () => {
+		const line =
+			renderActivateToolsetCall({ name: "files" }, ansiTheme).render(22)[0] ??
+			"";
+
+		expect(line).toContain("files");
+		expect(visibleWidth(line)).toBe(22);
 	});
 
 	test("wraps comma-separated tools and reports exact hidden lines when collapsed", () => {

--- a/pi-package/shared/toolsets/rendering.test.ts
+++ b/pi-package/shared/toolsets/rendering.test.ts
@@ -23,11 +23,14 @@ const toolNames = [
 	"files_remove",
 ];
 
-function result(status: "activated" | "already_active" = "activated") {
+function result(
+	status: "activated" | "already_active" = "activated",
+	names: readonly string[] = toolNames,
+) {
 	const details: ToolsetActivationDetails = {
 		version: 1,
 		activeToolsets: ["files"],
-		activation: { name: "files", status, toolNames },
+		activation: { name: "files", status, toolNames: names },
 	};
 	return {
 		content: [{ type: "text", text: "LLM content must not drive rendering" }],
@@ -48,37 +51,116 @@ describe("activate_toolset rendering", () => {
 		expect(visibleWidth(lines[0] ?? "")).toBeLessThanOrEqual(24);
 	});
 
-	test("shows status, count, a bounded preview, and expansion hint when collapsed", () => {
+	test("wraps comma-separated tools and reports exact hidden lines when collapsed", () => {
 		const component = renderActivateToolsetResult(
 			result(),
 			{ expanded: false },
 			theme,
 		);
-		const lines = component.render(36);
+		const lines = component.render(36).map((line) => line.trimEnd());
 		const text = lines.join("\n");
 
-		expect(text).toContain('Activated "files"');
-		expect(text).toContain("6 tools");
-		expect(text).toContain("files_read");
-		expect(text).not.toContain("files_remove");
-		expect(text).toContain("to expand");
-		expect(lines.length).toBeLessThanOrEqual(4);
+		expect(lines.slice(0, 2)).toEqual([
+			"Activated: files_read, files_write,",
+			"files_search, files_list, ...",
+		]);
+		expect(lines[2]).toContain("... 1 more line");
+		expect(lines[2]).toContain("to expand");
+		expect(text).not.toContain('"files"');
+		expect(text).not.toContain("6 tools");
+		expect(text).not.toContain("- files_");
 	});
 
-	test("shows every allowed name and no schema or description when expanded", () => {
+	test("omits truncation and the hint when collapsed content fits", () => {
+		const component = renderActivateToolsetResult(
+			result("activated", ["files_read", "files_write"]),
+			{ expanded: false },
+			theme,
+		);
+		const lines = component.render(80).map((line) => line.trimEnd());
+
+		expect(lines).toEqual(["Activated: files_read, files_write"]);
+		expect(lines.join("\n")).not.toContain("to expand");
+	});
+
+	test("colors only the activation status as success", () => {
+		const colorCalls: Array<{ color: string; text: string }> = [];
+		const trackingTheme = {
+			bold: (text: string) => text,
+			fg: (color: string, text: string) => {
+				colorCalls.push({ color, text });
+				return text;
+			},
+		} as unknown as Theme;
+		const component = renderActivateToolsetResult(
+			result("activated", ["files_read", "files_write"]),
+			{ expanded: false },
+			trackingTheme,
+		);
+
+		component.render(80);
+
+		expect(colorCalls.filter(({ color }) => color === "success")).toEqual([
+			{ color: "success", text: "Activated:" },
+		]);
+		expect(colorCalls.filter(({ color }) => color === "muted")).toEqual([
+			{ color: "muted", text: " files_read, files_write" },
+		]);
+	});
+
+	test("shows every comma-separated name without truncation when expanded", () => {
 		const component = renderActivateToolsetResult(
 			result("already_active"),
 			{ expanded: true },
 			theme,
 		);
-		const text = component.render(80).join("\n");
+		const text = component.render(36).join("\n");
+		const unwrappedText = component
+			.render(36)
+			.map((line) => line.trim())
+			.join(" ");
 
-		expect(text).toContain('Toolset "files" is already active');
+		expect(unwrappedText).toBe(
+			"Already active: files_read, files_write, files_search, files_list, files_move, files_remove",
+		);
 		for (const name of toolNames) {
 			expect(text).toContain(name);
 		}
+		expect(text).not.toContain('"files"');
+		expect(text).not.toContain("to expand");
 		expect(text).not.toContain("parameters");
 		expect(text).not.toContain("description");
+		expect(text).not.toContain("- files_");
+	});
+
+	test("preserves Unicode names within narrow terminal width", () => {
+		const names = ["инструмент", "工具", "emoji_🧪"];
+		const component = renderActivateToolsetResult(
+			result("activated", names),
+			{ expanded: true },
+			theme,
+		);
+		const lines = component.render(24);
+		const text = lines.join("\n");
+
+		expect(lines.every((line) => visibleWidth(line) <= 24)).toBe(true);
+		for (const name of names) {
+			expect(text).toContain(name);
+		}
+	});
+
+	test("keeps fallback error rendering unchanged", () => {
+		const component = renderActivateToolsetResult(
+			{
+				content: [{ type: "text", text: "unknown toolset: missing" }],
+			},
+			{ expanded: false, isError: true },
+			theme,
+		);
+
+		expect(component.render(40).map((line) => line.trimEnd())).toEqual([
+			"unknown toolset: missing",
+		]);
 	});
 
 	test("keeps collapsed and expanded output inside Pi default tool shell width", () => {

--- a/pi-package/shared/toolsets/rendering.ts
+++ b/pi-package/shared/toolsets/rendering.ts
@@ -3,7 +3,7 @@ import { type Component, Text } from "@earendil-works/pi-tui";
 import { truncateTextByWidth } from "../display-width.ts";
 import type { ToolsetActivationPresentation } from "./contracts.ts";
 
-const COLLAPSED_TOOL_PREVIEW_LIMIT = 2;
+const COLLAPSED_CONTENT_LINE_LIMIT = 2;
 
 interface ActivationRenderResult {
 	readonly content: readonly {
@@ -42,57 +42,51 @@ class ActivationResult implements Component {
 	) {}
 
 	public render(width: number): string[] {
-		if (this.expanded) {
-			return new Text(this.expandedText(), 0, 0).render(width);
+		const wrappedLines = new Text(this.outputText(), 0, 0)
+			.render(width)
+			.map((line) => line.trimEnd());
+		// Plain rows own truncation math while styled rows keep status and names in separate colors.
+		const styledLines = new Text(this.styledOutputText(), 0, 0).render(width);
+		if (this.expanded || wrappedLines.length <= COLLAPSED_CONTENT_LINE_LIMIT) {
+			return styledLines;
 		}
 
-		// Collapsed rows are semantic units: status, bounded names, then one expansion hint.
-		const preview = this.activation.toolNames.slice(
-			0,
-			COLLAPSED_TOOL_PREVIEW_LIMIT,
+		const visibleLines = styledLines.slice(0, COLLAPSED_CONTENT_LINE_LIMIT);
+		const lastVisibleIndex = visibleLines.length - 1;
+		const lastVisibleLine = wrappedLines[lastVisibleIndex] ?? "";
+		// The suffix signals truncation without letting a long wrapped row exceed the shell.
+		visibleLines[lastVisibleIndex] = this.theme.fg(
+			"muted",
+			truncateTextByWidth(`${lastVisibleLine} ...`, width, " ..."),
 		);
-		const lines = [
-			truncateTextByWidth(
-				this.theme.fg("success", this.collapsedStatus()),
-				width,
-			),
-			...preview.map((name) =>
-				truncateTextByWidth(this.theme.fg("muted", `- ${name}`), width),
-			),
+		const hiddenLineCount = wrappedLines.length - visibleLines.length;
+		const hiddenLineLabel = hiddenLineCount === 1 ? "line" : "lines";
+		const hint = `... ${hiddenLineCount} more ${hiddenLineLabel} (${keyHint("app.tools.expand", "to expand")})`;
+		return [
+			...visibleLines,
+			this.theme.fg("dim", truncateTextByWidth(hint, width)),
 		];
-		const hiddenCount = this.activation.toolNames.length - preview.length;
-		if (hiddenCount > 0) {
-			lines.push(
-				truncateTextByWidth(
-					this.theme.fg(
-						"dim",
-						`... ${hiddenCount} more tools (${keyHint("app.tools.expand", "to expand")})`,
-					),
-					width,
-				),
-			);
-		}
-		return lines;
 	}
 
 	public invalidate(): void {}
 
-	private collapsedStatus(): string {
-		const status =
-			this.activation.status === "activated"
-				? `Activated "${this.activation.name}"`
-				: `Already active "${this.activation.name}"`;
-		return `${status} · ${this.activation.toolNames.length} tools`;
+	private outputText(): string {
+		return `${this.statusLabel()}: ${this.activation.toolNames.join(", ")}`;
 	}
 
-	private expandedText(): string {
-		const status =
-			this.activation.status === "activated"
-				? `Activated toolset "${this.activation.name}".`
-				: `Toolset "${this.activation.name}" is already active.`;
-		return `${status}\nAvailable tools (${this.activation.toolNames.length}):\n${this.activation.toolNames
-			.map((name) => `- ${name}`)
-			.join("\n")}`;
+	private styledOutputText(): string {
+		const status = this.theme.fg("success", `${this.statusLabel()}:`);
+		const toolNames = this.theme.fg(
+			"muted",
+			` ${this.activation.toolNames.join(", ")}`,
+		);
+		return `${status}${toolNames}`;
+	}
+
+	private statusLabel(): string {
+		return this.activation.status === "activated"
+			? "Activated"
+			: "Already active";
 	}
 }
 

--- a/pi-package/shared/toolsets/rendering.ts
+++ b/pi-package/shared/toolsets/rendering.ts
@@ -1,0 +1,153 @@
+import { keyHint, type Theme } from "@earendil-works/pi-coding-agent";
+import { type Component, Text } from "@earendil-works/pi-tui";
+import { truncateTextByWidth } from "../display-width.ts";
+import type { ToolsetActivationPresentation } from "./contracts.ts";
+
+const COLLAPSED_TOOL_PREVIEW_LIMIT = 2;
+
+interface ActivationRenderResult {
+	readonly content: readonly {
+		readonly type: string;
+		readonly text?: string;
+	}[];
+	readonly details?: unknown;
+}
+
+interface ActivationRenderOptions {
+	readonly expanded: boolean;
+	readonly isError?: boolean;
+}
+
+class SingleLineCall implements Component {
+	public constructor(
+		private readonly name: string,
+		private readonly theme: Theme,
+	) {}
+
+	public render(width: number): string[] {
+		const text =
+			this.theme.fg("toolTitle", this.theme.bold("activate_toolset ")) +
+			this.theme.fg("muted", this.name);
+		return [truncateTextByWidth(text, width)];
+	}
+
+	public invalidate(): void {}
+}
+
+class ActivationResult implements Component {
+	public constructor(
+		private readonly activation: ToolsetActivationPresentation,
+		private readonly expanded: boolean,
+		private readonly theme: Theme,
+	) {}
+
+	public render(width: number): string[] {
+		if (this.expanded) {
+			return new Text(this.expandedText(), 0, 0).render(width);
+		}
+
+		// Collapsed rows are semantic units: status, bounded names, then one expansion hint.
+		const preview = this.activation.toolNames.slice(
+			0,
+			COLLAPSED_TOOL_PREVIEW_LIMIT,
+		);
+		const lines = [
+			truncateTextByWidth(
+				this.theme.fg("success", this.collapsedStatus()),
+				width,
+			),
+			...preview.map((name) =>
+				truncateTextByWidth(this.theme.fg("muted", `- ${name}`), width),
+			),
+		];
+		const hiddenCount = this.activation.toolNames.length - preview.length;
+		if (hiddenCount > 0) {
+			lines.push(
+				truncateTextByWidth(
+					this.theme.fg(
+						"dim",
+						`... ${hiddenCount} more tools (${keyHint("app.tools.expand", "to expand")})`,
+					),
+					width,
+				),
+			);
+		}
+		return lines;
+	}
+
+	public invalidate(): void {}
+
+	private collapsedStatus(): string {
+		const status =
+			this.activation.status === "activated"
+				? `Activated "${this.activation.name}"`
+				: `Already active "${this.activation.name}"`;
+		return `${status} · ${this.activation.toolNames.length} tools`;
+	}
+
+	private expandedText(): string {
+		const status =
+			this.activation.status === "activated"
+				? `Activated toolset "${this.activation.name}".`
+				: `Toolset "${this.activation.name}" is already active.`;
+		return `${status}\nAvailable tools (${this.activation.toolNames.length}):\n${this.activation.toolNames
+			.map((name) => `- ${name}`)
+			.join("\n")}`;
+	}
+}
+
+export function renderActivateToolsetCall(
+	args: unknown,
+	theme: Theme,
+): Component {
+	const name =
+		isRecord(args) && typeof args["name"] === "string" ? args["name"] : "";
+	return new SingleLineCall(name, theme);
+}
+
+export function renderActivateToolsetResult(
+	result: ActivationRenderResult,
+	options: ActivationRenderOptions,
+	theme: Theme,
+): Component {
+	const activation = readActivationPresentation(result.details);
+	if (activation !== undefined) {
+		return new ActivationResult(activation, options.expanded, theme);
+	}
+	const text = result.content
+		.filter((item) => item.type === "text")
+		.map((item) => item.text ?? "")
+		.join("\n");
+	return new Text(
+		theme.fg(options.isError ? "error" : "toolOutput", text),
+		0,
+		0,
+	);
+}
+
+function readActivationPresentation(
+	details: unknown,
+): ToolsetActivationPresentation | undefined {
+	if (!isRecord(details) || !isRecord(details["activation"])) {
+		return undefined;
+	}
+	const activation = details["activation"];
+	if (
+		typeof activation["name"] !== "string" ||
+		(activation["status"] !== "activated" &&
+			activation["status"] !== "already_active") ||
+		!Array.isArray(activation["toolNames"]) ||
+		!activation["toolNames"].every((name) => typeof name === "string")
+	) {
+		return undefined;
+	}
+	return {
+		name: activation["name"],
+		status: activation["status"],
+		toolNames: activation["toolNames"],
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/pi-package/shared/toolsets/rendering.ts
+++ b/pi-package/shared/toolsets/rendering.ts
@@ -1,5 +1,5 @@
 import { keyHint, type Theme } from "@earendil-works/pi-coding-agent";
-import { type Component, Text } from "@earendil-works/pi-tui";
+import { type Component, Text, visibleWidth } from "@earendil-works/pi-tui";
 import { truncateTextByWidth } from "../display-width.ts";
 import type { ToolsetActivationPresentation } from "./contracts.ts";
 
@@ -25,10 +25,18 @@ class SingleLineCall implements Component {
 	) {}
 
 	public render(width: number): string[] {
-		const text =
-			this.theme.fg("toolTitle", this.theme.bold("activate_toolset ")) +
-			this.theme.fg("muted", this.name);
-		return [truncateTextByWidth(text, width)];
+		const prefix = "activate_toolset ";
+		const clippedPrefix = truncateTextByWidth(prefix, width);
+		const remainingWidth = Math.max(0, width - visibleWidth(clippedPrefix));
+		const clippedName =
+			clippedPrefix === prefix
+				? truncateTextByWidth(this.name, remainingWidth)
+				: "";
+		const styledName =
+			clippedName.length === 0 ? "" : this.theme.fg("muted", clippedName);
+		return [
+			this.theme.fg("toolTitle", this.theme.bold(clippedPrefix)) + styledName,
+		];
 	}
 
 	public invalidate(): void {}

--- a/pi-package/shared/toolsets/runtime.test.ts
+++ b/pi-package/shared/toolsets/runtime.test.ts
@@ -4,7 +4,7 @@ import {
 	type ExtensionAPI,
 } from "@earendil-works/pi-coding-agent";
 import { getAgentRuntimeComposition } from "../agent-runtime-composition.ts";
-import { getToolsetRuntime } from "./runtime.ts";
+import { getToolsetRuntime, type ToolsetHistoryContext } from "./runtime.ts";
 
 type ToolDefinition = Parameters<ExtensionAPI["registerTool"]>[0];
 type EventHandler = (event: unknown, ctx: unknown) => unknown;
@@ -111,16 +111,10 @@ describe("toolset runtime", () => {
 		}).not.toThrow();
 
 		runtimeReady = true;
-		for (const handler of handlers.get("session_start") ?? []) {
-			await handler(
-				{ type: "session_start" },
-				{
-					hasUI: false,
-					sessionManager: { getBranch: () => [] },
-					ui: { notify() {} },
-				},
-			);
-		}
+		runtime?.restoreFromBranch([], {
+			hasUI: false,
+			ui: { notify() {} },
+		});
 		expect(runtime).toBeDefined();
 		expect(activeTools).toEqual(["read", "activate_toolset"]);
 	});
@@ -207,6 +201,27 @@ describe("toolset runtime", () => {
 				toolNames: ["files_read"],
 			},
 		});
+	});
+
+	/**
+	 * Proves deferred activation remains inside the main-agent baseline intersection.
+	 * Input and expected output: a reordered main-agent allowlist restores the activated files tools as [read, files_read, files_write].
+	 * Edge case: the activation trigger remains available before activation but disappears when this is the last eligible toolset.
+	 * Dependencies: main-agent composition and the deferred-toolset restrictive filter reconcile on activation.
+	 */
+	test("restores deferred tools at baseline positions under a main-agent allowlist", async () => {
+		const controls = createFakePi(["read", "files_read", "files_write"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(controls.pi).setMainAgentContribution({
+			prompt: "Main-agent prompt",
+			tools: ["files_write", "read", "activate_toolset", "files_read"],
+		});
+
+		expect(controls.activeTools).toEqual(["read", "activate_toolset"]);
+
+		await runtime.activate("files");
+		expect(controls.activeTools).toEqual(["read", "files_read", "files_write"]);
 	});
 
 	test("keeps activation available until every eligible toolset is active", async () => {
@@ -427,7 +442,7 @@ describe("toolset runtime", () => {
 		];
 		const ctx = historyContext(controls, () => branch);
 
-		await controls.emit("session_start", { type: "session_start" }, ctx);
+		runtime.restoreFromBranch(branch, ctx);
 		expect(controls.activeTools).toEqual(["files_read"]);
 		expect(runtime.getVisibleToolsets()).toEqual([]);
 
@@ -448,9 +463,8 @@ describe("toolset runtime", () => {
 			}),
 		];
 
-		await controls.emit(
-			"session_start",
-			{ type: "session_start" },
+		runtime.restoreFromBranch(
+			branch,
 			historyContext(controls, () => branch),
 		);
 
@@ -476,7 +490,9 @@ function activationResult(details: unknown): unknown {
 function historyContext(
 	controls: FakePiControls,
 	getBranch: () => readonly unknown[],
-): unknown {
+): ToolsetHistoryContext & {
+	readonly sessionManager: { getBranch(): readonly unknown[] };
+} {
 	return {
 		hasUI: true,
 		sessionManager: { getBranch },

--- a/pi-package/shared/toolsets/runtime.test.ts
+++ b/pi-package/shared/toolsets/runtime.test.ts
@@ -1,0 +1,489 @@
+import { describe, expect, test } from "bun:test";
+import {
+	createEventBus,
+	type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import { getAgentRuntimeComposition } from "../agent-runtime-composition.ts";
+import { getToolsetRuntime } from "./runtime.ts";
+
+type ToolDefinition = Parameters<ExtensionAPI["registerTool"]>[0];
+type EventHandler = (event: unknown, ctx: unknown) => unknown;
+
+interface FakePiControls {
+	pi: ExtensionAPI;
+	readonly definitions: Map<string, ToolDefinition>;
+	readonly activeTools: string[];
+	readonly notifications: string[];
+	emit(event: string, value: unknown, ctx: unknown): Promise<void>;
+	failSetActiveToolsWhen?: (names: readonly string[]) => boolean;
+}
+
+function createFakePi(initialTools: readonly string[]): FakePiControls {
+	const handlers = new Map<string, EventHandler[]>();
+	const definitions = new Map<string, ToolDefinition>();
+	const activeTools = [...initialTools];
+	const notifications: string[] = [];
+	const controls = {
+		definitions,
+		activeTools,
+		notifications,
+		pi: undefined as unknown as ExtensionAPI,
+		async emit(event: string, value: unknown, ctx: unknown) {
+			for (const handler of handlers.get(event) ?? []) {
+				await handler(value, ctx);
+			}
+		},
+	} as FakePiControls;
+	controls.pi = {
+		events: createEventBus(),
+		on(event: string, handler: EventHandler) {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		registerTool(definition: ToolDefinition) {
+			definitions.set(definition.name, definition);
+			if (!activeTools.includes(definition.name)) {
+				activeTools.push(definition.name);
+			}
+		},
+		getActiveTools() {
+			return [...activeTools];
+		},
+		setActiveTools(names: string[]) {
+			if (controls.failSetActiveToolsWhen?.(names)) {
+				throw new Error("reconciliation failed");
+			}
+			activeTools.splice(0, activeTools.length, ...names);
+		},
+	} as unknown as ExtensionAPI;
+	return controls;
+}
+
+function filesToolset(
+	activate: () => Promise<readonly string[]> = async () => [
+		"files_read",
+		"files_write",
+	],
+): {
+	providerId: string;
+	name: string;
+	description: string;
+	toolNames: string[];
+	activate: () => Promise<readonly string[]>;
+} {
+	return {
+		providerId: "mcp",
+		name: "files",
+		description: "Read project files",
+		toolNames: ["files_read", "files_write"],
+		activate,
+	};
+}
+
+describe("toolset runtime", () => {
+	test("publishes its filter and provider catalog without extension-loading actions", async () => {
+		let runtimeReady = false;
+		let activeTools = ["read", "files_read"];
+		const handlers = new Map<string, EventHandler[]>();
+		const pi = {
+			events: createEventBus(),
+			on(event: string, handler: EventHandler) {
+				handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+			},
+			registerTool() {},
+			getActiveTools() {
+				if (!runtimeReady) {
+					throw new Error("Extension runtime not initialized");
+				}
+				return [...activeTools];
+			},
+			setActiveTools(names: string[]) {
+				if (!runtimeReady) {
+					throw new Error("Extension runtime not initialized");
+				}
+				activeTools = [...names];
+			},
+		} as unknown as ExtensionAPI;
+		let runtime: ReturnType<typeof getToolsetRuntime> | undefined;
+
+		expect(() => {
+			runtime = getToolsetRuntime(pi);
+			runtime.replaceProvider("mcp", [filesToolset()]);
+		}).not.toThrow();
+
+		runtimeReady = true;
+		for (const handler of handlers.get("session_start") ?? []) {
+			await handler(
+				{ type: "session_start" },
+				{
+					hasUI: false,
+					sessionManager: { getBranch: () => [] },
+					ui: { notify() {} },
+				},
+			);
+		}
+		expect(runtime).toBeDefined();
+		expect(activeTools).toEqual(["read", "activate_toolset"]);
+	});
+
+	test("filters deferred tools and exposes activation only for eligible allowed toolsets", () => {
+		const { pi, activeTools } = createFakePi([
+			"read",
+			"files_read",
+			"files_write",
+		]);
+		const runtime = getToolsetRuntime(pi);
+		const composition = getAgentRuntimeComposition(pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		composition.reconcileActiveTools();
+
+		expect(activeTools).toEqual(["read", "activate_toolset"]);
+		expect(runtime.getVisibleToolsets()).toEqual([
+			{
+				name: "files",
+				description: "Read project files",
+				toolNames: ["files_read", "files_write"],
+			},
+		]);
+
+		composition.setRestrictiveToolNames("agent", ["read", "activate_toolset"]);
+		expect(activeTools).toEqual(["read"]);
+
+		composition.setRestrictiveToolNames("agent", ["read", "files_read"]);
+		expect(activeTools).toEqual(["read"]);
+		expect(runtime.getVisibleToolsets()).toHaveLength(1);
+
+		composition.setRestrictiveToolNames("agent", [
+			"read",
+			"files_read",
+			"activate_toolset",
+		]);
+		expect(activeTools).toEqual(["read", "activate_toolset"]);
+	});
+
+	test("activates only allowed tools and removes the final activation trigger", async () => {
+		const { pi, definitions, activeTools } = createFakePi([
+			"read",
+			"files_read",
+			"files_write",
+		]);
+		let providerActivated = false;
+		const runtime = getToolsetRuntime(pi);
+		runtime.replaceProvider("mcp", [
+			filesToolset(async () => {
+				providerActivated = true;
+				return ["files_read", "files_write"];
+			}),
+		]);
+		getAgentRuntimeComposition(pi).setRestrictiveToolNames("agent", [
+			"read",
+			"files_read",
+			"activate_toolset",
+		]);
+
+		const definition = definitions.get("activate_toolset");
+		expect(definition).toBeDefined();
+		const result = await definition?.execute(
+			"call-1",
+			{ name: "files" },
+			undefined,
+			undefined,
+			{} as never,
+		);
+
+		expect(providerActivated).toBe(true);
+		expect(activeTools).toEqual(["read", "files_read"]);
+		expect(result?.content).toEqual([
+			{
+				type: "text",
+				text: 'Activated toolset "files".\nAvailable tools:\n- files_read',
+			},
+		]);
+		expect(result?.details).toEqual({
+			version: 1,
+			activeToolsets: ["files"],
+			activation: {
+				name: "files",
+				status: "activated",
+				toolNames: ["files_read"],
+			},
+		});
+	});
+
+	test("keeps activation available until every eligible toolset is active", async () => {
+		const controls = createFakePi(["files_read", "database_query"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [
+			filesToolset(),
+			{
+				providerId: "mcp",
+				name: "database",
+				description: "Query the database",
+				toolNames: ["database_query"],
+				activate: async () => ["database_query"],
+			},
+		]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+
+		await runtime.activate("files");
+		expect(controls.activeTools).toEqual(["files_read", "activate_toolset"]);
+		const activationTool = controls.definitions.get("activate_toolset");
+		const result = await activationTool?.execute(
+			"call-2",
+			{ name: "database" },
+			undefined,
+			undefined,
+			{} as never,
+		);
+		expect(controls.activeTools).toEqual(["files_read", "database_query"]);
+		expect(result?.details).toMatchObject({
+			version: 1,
+			activeToolsets: ["files", "database"],
+		});
+	});
+
+	test("ignores caller candidates that could bypass upstream restrictions", async () => {
+		const controls = createFakePi(["files_read", "files_write"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(controls.pi).setRestrictiveToolNames("agent", [
+			"files_read",
+			"activate_toolset",
+		]);
+
+		expect(await runtime.activate("files")).toMatchObject({
+			toolNames: ["files_read"],
+		});
+		expect(controls.activeTools).toEqual(["files_read"]);
+	});
+
+	test("uses exact case-sensitive names and preserves state for unknown names", async () => {
+		const controls = createFakePi(["files_read"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+
+		await expect(runtime.activate("Files")).rejects.toThrow(
+			"unknown toolset: Files",
+		);
+		expect(controls.activeTools).toEqual(["activate_toolset"]);
+		expect(runtime.getVisibleToolsets()).toHaveLength(1);
+	});
+
+	test("returns complete currently allowed names for an idempotent activation", async () => {
+		const controls = createFakePi(["files_read", "files_write"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+		await runtime.activate("files");
+		expect(await runtime.activate("files")).toEqual({
+			name: "files",
+			toolNames: ["files_read", "files_write"],
+			alreadyActive: true,
+		});
+
+		const activationTool = controls.definitions.get("activate_toolset");
+		const result = await activationTool?.execute(
+			"call-repeat",
+			{ name: "files" },
+			undefined,
+			undefined,
+			{} as never,
+		);
+		expect(result?.content).toEqual([
+			{
+				type: "text",
+				text: 'Toolset "files" is already active.\nAvailable tools:\n- files_read\n- files_write',
+			},
+		]);
+	});
+
+	test("rejects a provider activation result that disagrees with its catalog", async () => {
+		const controls = createFakePi(["files_read", "files_write"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset(async () => ["files_read"])]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+
+		await expect(runtime.activate("files")).rejects.toThrow(
+			"provider activation catalog mismatch: files",
+		);
+		expect(controls.activeTools).toEqual(["activate_toolset"]);
+		expect(runtime.getVisibleToolsets()).toHaveLength(1);
+	});
+
+	test("keeps provider and reconciliation failures deferred and retryable", async () => {
+		const providerFailure = createFakePi(["files_read"]);
+		const failedProviderRuntime = getToolsetRuntime(providerFailure.pi);
+		failedProviderRuntime.replaceProvider("mcp", [
+			filesToolset(async () => {
+				throw new Error("provider failed");
+			}),
+		]);
+		getAgentRuntimeComposition(providerFailure.pi).reconcileActiveTools();
+
+		await expect(failedProviderRuntime.activate("files")).rejects.toThrow(
+			"provider failed",
+		);
+		expect(failedProviderRuntime.getVisibleToolsets()).toHaveLength(1);
+		expect(providerFailure.activeTools).toEqual(["activate_toolset"]);
+
+		const reconciliationFailure = createFakePi(["files_read"]);
+		const failedReconciliationRuntime = getToolsetRuntime(
+			reconciliationFailure.pi,
+		);
+		failedReconciliationRuntime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(reconciliationFailure.pi).reconcileActiveTools();
+		reconciliationFailure.failSetActiveToolsWhen = (names) =>
+			names.includes("files_read");
+
+		await expect(failedReconciliationRuntime.activate("files")).rejects.toThrow(
+			"reconciliation failed",
+		);
+		expect(failedReconciliationRuntime.getVisibleToolsets()).toHaveLength(1);
+		expect(reconciliationFailure.activeTools).toEqual(["activate_toolset"]);
+	});
+
+	test("rejects duplicate provider catalogs without replacing the prior catalog", () => {
+		const controls = createFakePi(["files_read"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+
+		expect(() =>
+			runtime.replaceProvider("mcp", [filesToolset(), filesToolset()]),
+		).toThrow("duplicate toolset name: files");
+		expect(runtime.getVisibleToolsets()).toHaveLength(1);
+		expect(controls.activeTools).toEqual(["activate_toolset"]);
+	});
+
+	test("replaces a provider catalog atomically when reconciliation fails", () => {
+		const controls = createFakePi(["files_read"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+		controls.failSetActiveToolsWhen = (names) =>
+			!names.includes("activate_toolset");
+
+		expect(() => runtime.replaceProvider("mcp", [])).toThrow(
+			"reconciliation failed",
+		);
+		expect(runtime.getVisibleToolsets().map(({ name }) => name)).toEqual([
+			"files",
+		]);
+		expect(controls.activeTools).toEqual(["activate_toolset"]);
+	});
+
+	test("shares one runtime across extension APIs in the same Pi session", () => {
+		// Purpose: provider and prompt extensions must observe one deferred catalog and one restrictive filter.
+		// Input and expected output: distinct APIs share an event bus; the second lookup returns the provider runtime, trigger, and active list.
+		// Edge case: creating the prompt-side view must not overwrite the provider filter with an empty catalog.
+		// Dependencies: Pi-like dynamic registration auto-activates new definitions and composition is shared through the event bus.
+		const provider = createFakePi(["read", "files_read", "files_write"]);
+		const providerRuntime = getToolsetRuntime(provider.pi);
+		providerRuntime.replaceProvider("mcp", [filesToolset()]);
+		getAgentRuntimeComposition(provider.pi).reconcileActiveTools();
+		const promptPi = {
+			...provider.pi,
+			events: provider.pi.events,
+			on() {},
+		} as unknown as ExtensionAPI;
+
+		const promptRuntime = getToolsetRuntime(promptPi);
+
+		expect(promptRuntime).toBe(providerRuntime);
+		expect(provider.activeTools).toEqual(["read", "activate_toolset"]);
+		expect(promptRuntime.getVisibleToolsets()).toEqual([
+			{
+				name: "files",
+				description: "Read project files",
+				toolNames: ["files_read", "files_write"],
+			},
+		]);
+	});
+
+	test("isolates catalogs and activation state by ExtensionAPI", async () => {
+		const first = createFakePi(["files_read"]);
+		const second = createFakePi(["files_read"]);
+		const firstRuntime = getToolsetRuntime(first.pi);
+		const secondRuntime = getToolsetRuntime(second.pi);
+		firstRuntime.replaceProvider("mcp", [filesToolset()]);
+		secondRuntime.replaceProvider("mcp", [filesToolset()]);
+
+		getAgentRuntimeComposition(first.pi).reconcileActiveTools();
+		getAgentRuntimeComposition(second.pi).reconcileActiveTools();
+		await firstRuntime.activate("files");
+		expect(firstRuntime.getVisibleToolsets()).toEqual([]);
+		expect(secondRuntime.getVisibleToolsets()).toHaveLength(1);
+	});
+
+	test("restores only the last valid version-1 snapshot on the active branch", async () => {
+		const controls = createFakePi(["files_read"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		let branch = [
+			activationResult({ version: 1, activeToolsets: ["files"] }),
+			activationResult({ version: 1, activeToolsets: "files" }),
+			activationResult({ version: 2, activeToolsets: [] }),
+		];
+		const ctx = historyContext(controls, () => branch);
+
+		await controls.emit("session_start", { type: "session_start" }, ctx);
+		expect(controls.activeTools).toEqual(["files_read"]);
+		expect(runtime.getVisibleToolsets()).toEqual([]);
+
+		branch = [];
+		await controls.emit("session_tree", { type: "session_tree" }, ctx);
+		expect(controls.activeTools).toEqual(["activate_toolset"]);
+		expect(runtime.getVisibleToolsets()).toHaveLength(1);
+	});
+
+	test("warns for stale snapshot names without breaking valid restoration", async () => {
+		const controls = createFakePi(["files_read"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [filesToolset()]);
+		const branch = [
+			activationResult({
+				version: 1,
+				activeToolsets: ["removed", "files"],
+			}),
+		];
+
+		await controls.emit(
+			"session_start",
+			{ type: "session_start" },
+			historyContext(controls, () => branch),
+		);
+
+		expect(controls.activeTools).toEqual(["files_read"]);
+		expect(controls.notifications).toEqual([
+			"[toolsets] ignored stale activated toolsets: removed",
+		]);
+	});
+});
+
+function activationResult(details: unknown): unknown {
+	return {
+		type: "message",
+		message: {
+			role: "toolResult",
+			toolName: "activate_toolset",
+			isError: false,
+			details,
+		},
+	};
+}
+
+function historyContext(
+	controls: FakePiControls,
+	getBranch: () => readonly unknown[],
+): unknown {
+	return {
+		hasUI: true,
+		sessionManager: { getBranch },
+		ui: {
+			notify(message: string) {
+				controls.notifications.push(message);
+			},
+		},
+	};
+}

--- a/pi-package/shared/toolsets/runtime.ts
+++ b/pi-package/shared/toolsets/runtime.ts
@@ -1,0 +1,380 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { getAgentRuntimeComposition } from "../agent-runtime-composition.ts";
+import { registerPackageTool } from "../tool-presentation/registry.ts";
+import type {
+	Toolset,
+	ToolsetActivation,
+	ToolsetActivationDetails,
+	VisibleToolset,
+} from "./contracts.ts";
+import {
+	renderActivateToolsetCall,
+	renderActivateToolsetResult,
+} from "./rendering.ts";
+
+const ACTIVATE_TOOLSET_TOOL_NAME = "activate_toolset";
+const DEFERRED_TOOLSETS_FILTER_NAME = "deferred-toolsets";
+const TOOLSET_RUNTIME_REQUEST_CHANNEL = "pi-harness:toolset-runtime:request";
+
+interface HistoryContext {
+	readonly hasUI: boolean;
+	readonly sessionManager: { getBranch(): readonly unknown[] };
+	readonly ui: {
+		notify(message: string, level: "warning"): void;
+	};
+}
+
+export interface ToolsetRuntime {
+	replaceProvider(providerId: string, toolsets: readonly Toolset[]): void;
+	getVisibleToolsets(): readonly VisibleToolset[];
+	activate(name: string): Promise<ToolsetActivation>;
+}
+
+interface ToolsetRuntimeHolder {
+	readonly runtime: ToolsetRuntime;
+}
+
+interface ToolsetRuntimeSlot {
+	holder: ToolsetRuntimeHolder | undefined;
+}
+
+const holderByPi = new WeakMap<ExtensionAPI, ToolsetRuntimeHolder>();
+
+class ToolsetRuntimeImpl implements ToolsetRuntime {
+	private readonly toolsetsByProvider = new Map<string, readonly Toolset[]>();
+	private readonly activeToolsets = new Set<string>();
+	// Captured before this runtime removes deferred names, so activation can never grant an upstream-restricted tool.
+	private preDeferredToolNames: readonly string[] = [];
+
+	public constructor(private readonly pi: ExtensionAPI) {
+		const composition = getAgentRuntimeComposition(pi);
+		registerPackageTool(pi, {
+			name: ACTIVATE_TOOLSET_TOOL_NAME,
+			label: "Activate Toolset",
+			description:
+				"Activate a toolset listed in <toolsets> when its tools are needed.",
+			parameters: Type.Object(
+				{
+					name: Type.String({
+						minLength: 1,
+						description: "Exact case-sensitive toolset name from <toolsets>.",
+					}),
+				},
+				{ additionalProperties: false },
+			),
+			executionMode: "sequential",
+			renderCall: renderActivateToolsetCall,
+			renderResult: renderActivateToolsetResult,
+			execute: async (_toolCallId, params) => {
+				const activation = await this.activate(readActivationName(params));
+				const details: ToolsetActivationDetails = {
+					version: 1,
+					activeToolsets: [...this.activeToolsets],
+					activation: {
+						name: activation.name,
+						status: activation.alreadyActive ? "already_active" : "activated",
+						toolNames: activation.toolNames,
+					},
+				};
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: formatActivationContent(activation),
+						},
+					],
+					details,
+				};
+			},
+		});
+		composition.publishBaselineToolNames([ACTIVATE_TOOLSET_TOOL_NAME]);
+		composition.publishRestrictiveToolFilter(
+			DEFERRED_TOOLSETS_FILTER_NAME,
+			(candidates) => this.filterDeferredTools(candidates),
+		);
+		const restoreActiveBranch = (_event: unknown, ctx: HistoryContext) => {
+			this.restoreFromBranch(ctx.sessionManager.getBranch(), ctx);
+		};
+		pi.on("session_start", restoreActiveBranch);
+		pi.on("session_tree", restoreActiveBranch);
+	}
+
+	public replaceProvider(
+		providerId: string,
+		toolsets: readonly Toolset[],
+	): void {
+		validateProviderCatalog(providerId, toolsets, this.toolsetsByProvider);
+		const previousToolsets = this.toolsetsByProvider.get(providerId);
+		const previousActiveToolsets = new Set(this.activeToolsets);
+
+		this.toolsetsByProvider.set(providerId, [...toolsets]);
+		this.removeUnavailableActiveToolsets();
+		const composition = getAgentRuntimeComposition(this.pi);
+		try {
+			composition.publishRestrictiveToolFilter(
+				DEFERRED_TOOLSETS_FILTER_NAME,
+				(candidates) => this.filterDeferredTools(candidates),
+			);
+		} catch (error) {
+			// Catalog and activation state move together so a failed reconciliation
+			// cannot leave routes that disagree with the active-tool filter.
+			if (previousToolsets === undefined) {
+				this.toolsetsByProvider.delete(providerId);
+			} else {
+				this.toolsetsByProvider.set(providerId, previousToolsets);
+			}
+			this.replaceActiveToolsets(previousActiveToolsets);
+			composition.publishRestrictiveToolFilter(
+				DEFERRED_TOOLSETS_FILTER_NAME,
+				(candidates) => this.filterDeferredTools(candidates),
+			);
+			throw error;
+		}
+	}
+
+	public getVisibleToolsets(): readonly VisibleToolset[] {
+		return this.resolveVisibleToolsets(this.preDeferredToolNames);
+	}
+
+	private resolveVisibleToolsets(
+		candidateToolNames: readonly string[],
+	): readonly VisibleToolset[] {
+		return this.allToolsets()
+			.filter((toolset) => !this.activeToolsets.has(toolset.name))
+			.map((toolset) => ({
+				name: toolset.name,
+				description: toolset.description,
+				toolNames: toolset.toolNames.filter((name) =>
+					candidateToolNames.includes(name),
+				),
+			}))
+			.filter((toolset) => toolset.toolNames.length > 0);
+	}
+
+	public async activate(name: string): Promise<ToolsetActivation> {
+		const candidateToolNames = this.preDeferredToolNames;
+		const toolset = this.allToolsets().find(
+			(candidate) => candidate.name === name,
+		);
+		if (toolset === undefined) {
+			throw new Error(`unknown toolset: ${name}`);
+		}
+		const toolNames = toolset.toolNames.filter((toolName) =>
+			candidateToolNames.includes(toolName),
+		);
+		if (this.activeToolsets.has(name)) {
+			return { name, toolNames, alreadyActive: true };
+		}
+		if (toolNames.length === 0) {
+			throw new Error(`toolset is not available: ${name}`);
+		}
+
+		const providerToolNames = await toolset.activate();
+		if (!containSameNames(providerToolNames, toolset.toolNames)) {
+			throw new Error(`provider activation catalog mismatch: ${name}`);
+		}
+		this.activeToolsets.add(name);
+		try {
+			getAgentRuntimeComposition(this.pi).reconcileActiveTools();
+		} catch (error) {
+			// Activation is committed only after Pi accepts the recomposed list.
+			// Restoring the marker also restores the deferred filter on retry.
+			this.activeToolsets.delete(name);
+			getAgentRuntimeComposition(this.pi).reconcileActiveTools();
+			throw error;
+		}
+		return { name, toolNames, alreadyActive: false };
+	}
+
+	private restoreFromBranch(
+		branch: readonly unknown[],
+		ctx: HistoryContext,
+	): void {
+		let snapshot: readonly string[] = [];
+		for (const entry of branch) {
+			const details = readSuccessfulActivationDetails(entry);
+			if (details !== undefined) {
+				snapshot = details;
+			}
+		}
+
+		const loadedNames = new Set(
+			this.allToolsets().map((toolset) => toolset.name),
+		);
+		const restoredNames = snapshot.filter((name) => loadedNames.has(name));
+		const staleNames = snapshot.filter((name) => !loadedNames.has(name));
+		const previousActiveToolsets = new Set(this.activeToolsets);
+		this.replaceActiveToolsets(new Set(restoredNames));
+		try {
+			getAgentRuntimeComposition(this.pi).reconcileActiveTools();
+		} catch (error) {
+			// Branch restoration changes the complete activation snapshot as one
+			// unit; failed reconciliation leaves the prior branch state intact.
+			this.replaceActiveToolsets(previousActiveToolsets);
+			getAgentRuntimeComposition(this.pi).reconcileActiveTools();
+			throw error;
+		}
+		if (staleNames.length > 0 && ctx.hasUI) {
+			ctx.ui.notify(
+				`[toolsets] ignored stale activated toolsets: ${staleNames.join(", ")}`,
+				"warning",
+			);
+		}
+	}
+
+	private filterDeferredTools(
+		candidates: readonly string[],
+	): readonly string[] {
+		// Eligibility uses the unmodified candidates; activation-tool visibility additionally requires its name to survive upstream filters.
+		this.preDeferredToolNames = [...candidates];
+		const eligibleToolsets = this.resolveVisibleToolsets(candidates);
+		const deferredToolNames = new Set(
+			this.allToolsets()
+				.filter((toolset) => !this.activeToolsets.has(toolset.name))
+				.flatMap((toolset) => toolset.toolNames),
+		);
+		return candidates.filter((name) => {
+			if (name === ACTIVATE_TOOLSET_TOOL_NAME) {
+				return eligibleToolsets.length > 0;
+			}
+			return !deferredToolNames.has(name);
+		});
+	}
+
+	private removeUnavailableActiveToolsets(): void {
+		const loadedNames = new Set(
+			this.allToolsets().map((toolset) => toolset.name),
+		);
+		for (const name of this.activeToolsets) {
+			if (!loadedNames.has(name)) {
+				this.activeToolsets.delete(name);
+			}
+		}
+	}
+
+	private replaceActiveToolsets(names: ReadonlySet<string>): void {
+		this.activeToolsets.clear();
+		for (const name of names) {
+			this.activeToolsets.add(name);
+		}
+	}
+
+	private allToolsets(): readonly Toolset[] {
+		return [...this.toolsetsByProvider.values()].flat();
+	}
+}
+
+export function getToolsetRuntime(pi: ExtensionAPI): ToolsetRuntime {
+	const cached = holderByPi.get(pi);
+	if (cached !== undefined) {
+		return cached.runtime;
+	}
+
+	const slot: ToolsetRuntimeSlot = { holder: undefined };
+	if (typeof pi.events?.emit === "function") {
+		pi.events.emit(TOOLSET_RUNTIME_REQUEST_CHANNEL, slot);
+	}
+	if (slot.holder !== undefined) {
+		holderByPi.set(pi, slot.holder);
+		return slot.holder.runtime;
+	}
+
+	const holder: ToolsetRuntimeHolder = {
+		runtime: new ToolsetRuntimeImpl(pi),
+	};
+	holderByPi.set(pi, holder);
+
+	// Pi loads shared modules separately for each extension, so the session event bus carries the singleton across ExtensionAPI objects.
+	if (typeof pi.events?.on === "function") {
+		pi.events.on(TOOLSET_RUNTIME_REQUEST_CHANNEL, (data: unknown) => {
+			(data as ToolsetRuntimeSlot).holder = holder;
+		});
+	}
+
+	return holder.runtime;
+}
+
+function validateProviderCatalog(
+	providerId: string,
+	toolsets: readonly Toolset[],
+	catalogs: ReadonlyMap<string, readonly Toolset[]>,
+): void {
+	const names = new Set<string>();
+	for (const [registeredProviderId, registeredToolsets] of catalogs) {
+		if (registeredProviderId === providerId) {
+			continue;
+		}
+		for (const toolset of registeredToolsets) {
+			names.add(toolset.name);
+		}
+	}
+	for (const toolset of toolsets) {
+		if (toolset.providerId !== providerId) {
+			throw new Error(`toolset provider mismatch: ${toolset.name}`);
+		}
+		if (names.has(toolset.name)) {
+			throw new Error(`duplicate toolset name: ${toolset.name}`);
+		}
+		names.add(toolset.name);
+	}
+}
+
+function containSameNames(
+	left: readonly string[],
+	right: readonly string[],
+): boolean {
+	if (left.length !== right.length) {
+		return false;
+	}
+	const rightNames = new Set(right);
+	return left.every((name) => rightNames.has(name));
+}
+
+function formatActivationContent(activation: ToolsetActivation): string {
+	const status = activation.alreadyActive
+		? `Toolset "${activation.name}" is already active.`
+		: `Activated toolset "${activation.name}".`;
+	return `${status}\nAvailable tools:\n${activation.toolNames
+		.map((name) => `- ${name}`)
+		.join("\n")}`;
+}
+
+function readActivationName(params: unknown): string {
+	if (!isRecord(params) || typeof params["name"] !== "string") {
+		throw new Error("activate_toolset requires a name");
+	}
+	return params["name"];
+}
+
+/** Accepts only successful version-1 snapshots; malformed history never changes runtime state. */
+function readSuccessfulActivationDetails(
+	entry: unknown,
+): readonly string[] | undefined {
+	if (!isRecord(entry) || entry["type"] !== "message") {
+		return undefined;
+	}
+	const message = entry["message"];
+	if (
+		!isRecord(message) ||
+		message["role"] !== "toolResult" ||
+		message["toolName"] !== ACTIVATE_TOOLSET_TOOL_NAME ||
+		message["isError"] !== false
+	) {
+		return undefined;
+	}
+	const details = message["details"];
+	if (
+		!isRecord(details) ||
+		details["version"] !== 1 ||
+		!Array.isArray(details["activeToolsets"]) ||
+		!details["activeToolsets"].every((name) => typeof name === "string")
+	) {
+		return undefined;
+	}
+	return details["activeToolsets"];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/pi-package/shared/toolsets/runtime.ts
+++ b/pi-package/shared/toolsets/runtime.ts
@@ -17,9 +17,8 @@ const ACTIVATE_TOOLSET_TOOL_NAME = "activate_toolset";
 const DEFERRED_TOOLSETS_FILTER_NAME = "deferred-toolsets";
 const TOOLSET_RUNTIME_REQUEST_CHANNEL = "pi-harness:toolset-runtime:request";
 
-interface HistoryContext {
+export interface ToolsetHistoryContext {
 	readonly hasUI: boolean;
-	readonly sessionManager: { getBranch(): readonly unknown[] };
 	readonly ui: {
 		notify(message: string, level: "warning"): void;
 	};
@@ -27,19 +26,19 @@ interface HistoryContext {
 
 export interface ToolsetRuntime {
 	replaceProvider(providerId: string, toolsets: readonly Toolset[]): void;
+	restoreFromBranch(
+		branch: readonly unknown[],
+		ctx: ToolsetHistoryContext,
+	): void;
 	getVisibleToolsets(): readonly VisibleToolset[];
 	activate(name: string): Promise<ToolsetActivation>;
 }
 
-interface ToolsetRuntimeHolder {
-	readonly runtime: ToolsetRuntime;
-}
-
 interface ToolsetRuntimeSlot {
-	holder: ToolsetRuntimeHolder | undefined;
+	runtime: ToolsetRuntime | undefined;
 }
 
-const holderByPi = new WeakMap<ExtensionAPI, ToolsetRuntimeHolder>();
+const runtimeByPi = new WeakMap<ExtensionAPI, ToolsetRuntime>();
 
 class ToolsetRuntimeImpl implements ToolsetRuntime {
 	private readonly toolsetsByProvider = new Map<string, readonly Toolset[]>();
@@ -93,11 +92,17 @@ class ToolsetRuntimeImpl implements ToolsetRuntime {
 			DEFERRED_TOOLSETS_FILTER_NAME,
 			(candidates) => this.filterDeferredTools(candidates),
 		);
-		const restoreActiveBranch = (_event: unknown, ctx: HistoryContext) => {
-			this.restoreFromBranch(ctx.sessionManager.getBranch(), ctx);
-		};
-		pi.on("session_start", restoreActiveBranch);
-		pi.on("session_tree", restoreActiveBranch);
+		pi.on(
+			"session_tree",
+			(
+				_event: unknown,
+				ctx: ToolsetHistoryContext & {
+					readonly sessionManager: { getBranch(): readonly unknown[] };
+				},
+			) => {
+				this.restoreFromBranch(ctx.sessionManager.getBranch(), ctx);
+			},
+		);
 	}
 
 	public replaceProvider(
@@ -187,9 +192,9 @@ class ToolsetRuntimeImpl implements ToolsetRuntime {
 		return { name, toolNames, alreadyActive: false };
 	}
 
-	private restoreFromBranch(
+	public restoreFromBranch(
 		branch: readonly unknown[],
-		ctx: HistoryContext,
+		ctx: ToolsetHistoryContext,
 	): void {
 		let snapshot: readonly string[] = [];
 		for (const entry of branch) {
@@ -266,33 +271,31 @@ class ToolsetRuntimeImpl implements ToolsetRuntime {
 }
 
 export function getToolsetRuntime(pi: ExtensionAPI): ToolsetRuntime {
-	const cached = holderByPi.get(pi);
+	const cached = runtimeByPi.get(pi);
 	if (cached !== undefined) {
-		return cached.runtime;
+		return cached;
 	}
 
-	const slot: ToolsetRuntimeSlot = { holder: undefined };
+	const slot: ToolsetRuntimeSlot = { runtime: undefined };
 	if (typeof pi.events?.emit === "function") {
 		pi.events.emit(TOOLSET_RUNTIME_REQUEST_CHANNEL, slot);
 	}
-	if (slot.holder !== undefined) {
-		holderByPi.set(pi, slot.holder);
-		return slot.holder.runtime;
+	if (slot.runtime !== undefined) {
+		runtimeByPi.set(pi, slot.runtime);
+		return slot.runtime;
 	}
 
-	const holder: ToolsetRuntimeHolder = {
-		runtime: new ToolsetRuntimeImpl(pi),
-	};
-	holderByPi.set(pi, holder);
+	const runtime = new ToolsetRuntimeImpl(pi);
+	runtimeByPi.set(pi, runtime);
 
 	// Pi loads shared modules separately for each extension, so the session event bus carries the singleton across ExtensionAPI objects.
 	if (typeof pi.events?.on === "function") {
 		pi.events.on(TOOLSET_RUNTIME_REQUEST_CHANNEL, (data: unknown) => {
-			(data as ToolsetRuntimeSlot).holder = holder;
+			(data as ToolsetRuntimeSlot).runtime = runtime;
 		});
 	}
 
-	return holder.runtime;
+	return runtime;
 }
 
 function validateProviderCatalog(

--- a/test/extensions/consult-advisor/index.test.ts
+++ b/test/extensions/consult-advisor/index.test.ts
@@ -168,7 +168,7 @@ function createExtensionApiFake(
 	const commands: RegisteredCommandFake[] = [];
 	const activeToolCalls: string[][] = [];
 	const appendEntryCalls: Array<{ customType: string; data: unknown }> = [];
-	let activeTools: string[] = [];
+	let activeTools = [...allToolNames];
 
 	return {
 		handlers,

--- a/test/extensions/convene-council/runtime-composition.test.ts
+++ b/test/extensions/convene-council/runtime-composition.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import conveneCouncil from "../../../pi-package/extensions/convene-council/index";
+import { getAgentRuntimeComposition } from "../../../pi-package/shared/agent-runtime-composition";
 import {
 	withIsolatedAgentDir,
 	writeEnabledConfig,
@@ -38,12 +39,13 @@ describe("convene-council runtime composition", () => {
 			const pi = createExtensionApiFake();
 			conveneCouncil(pi);
 
-			pi.setActiveTools([]);
+			const composition = getAgentRuntimeComposition(pi);
+			composition.setRestrictiveToolNames("test-policy", []);
 			expect(
 				await emitBeforeAgentStartHandlers(pi, { systemPrompt: "Base" }),
 			).toBeUndefined();
 
-			pi.setActiveTools(["convene_council"]);
+			composition.setRestrictiveToolNames("test-policy", undefined);
 			const result = (await emitBeforeAgentStartHandlers(pi, {
 				systemPrompt: "Base",
 			})) as { readonly systemPrompt: string };

--- a/test/extensions/enable-tools/index.test.ts
+++ b/test/extensions/enable-tools/index.test.ts
@@ -49,7 +49,7 @@ function createExtensionApiFake(options?: {
 	const handlers: RegisteredHandler[] = [];
 	const setActiveToolsCalls: ActiveToolSetCall[] = [];
 
-	return {
+	const fake = {
 		handlers,
 		setActiveToolsCalls,
 		availableTools: options?.availableTools ?? [],
@@ -58,16 +58,23 @@ function createExtensionApiFake(options?: {
 			handlers.push({ eventName, handler });
 		},
 		getAllTools(): readonly ToolFake[] {
-			return this.availableTools;
+			return fake.availableTools;
 		},
 		getActiveTools(): readonly string[] {
-			return this.activeTools;
+			return fake.activeTools;
 		},
 		setActiveTools(names: readonly string[]): void {
 			setActiveToolsCalls.push({ names });
-			this.activeTools = names;
+			fake.activeTools = names;
 		},
-	} as ExtensionApiFake;
+		events: {
+			emit() {},
+			on() {
+				return () => {};
+			},
+		},
+	} as unknown as ExtensionApiFake;
+	return fake;
 }
 
 /** Creates a session context fake for invalid-config notifications. */
@@ -159,9 +166,7 @@ describe("enable-tools", () => {
 				createSessionContextFake(),
 			);
 
-			expect(pi.setActiveToolsCalls).toEqual([
-				{ names: ["read", "grep", "find", "ls"] },
-			]);
+			expect(pi.activeTools).toEqual(["read", "grep", "find", "ls"]);
 		});
 	});
 
@@ -192,7 +197,7 @@ describe("enable-tools", () => {
 				createSessionContextFake(),
 			);
 
-			expect(pi.setActiveToolsCalls).toEqual([{ names: ["read", "grep"] }]);
+			expect(pi.activeTools).toEqual(["read", "grep"]);
 		});
 	});
 

--- a/test/integration/mcp-wrapper-system-prompt.test.ts
+++ b/test/integration/mcp-wrapper-system-prompt.test.ts
@@ -229,7 +229,13 @@ describe("mcp-wrapper and system-prompt integration", () => {
 						},
 						widgetLineBudget: 5,
 						mcpServers: {
-							fetch: { type: "stdio", command: "node", args: [], env: {} },
+							fetch: {
+								type: "stdio",
+								command: "node",
+								args: [],
+								env: {},
+								additionalInstructions: "Prefer the fetch tool.",
+							},
 						},
 					},
 				}),
@@ -252,6 +258,8 @@ Project rule
 <mcp_instructions>
   <server name="fetch">
 Use fetch for web pages.
+
+Prefer the fetch tool.
   </server>
 </mcp_instructions>`);
 		} finally {
@@ -352,6 +360,8 @@ Use fetch for web pages.
 <mcp_instructions>
   <server name="fetch">
 Use fetch for web pages.
+
+Prefer the fetch tool.
   </server>
 </mcp_instructions>`,
 			},
@@ -420,6 +430,7 @@ Use fetch for web pages.
 									command: "node",
 									args: [],
 									env: {},
+									additionalInstructions: "Prefer the fetch tool.",
 								},
 							},
 						},

--- a/test/integration/mcp-wrapper-system-prompt.test.ts
+++ b/test/integration/mcp-wrapper-system-prompt.test.ts
@@ -14,6 +14,7 @@ import type { McpClientManager } from "../../pi-package/extensions/mcp-wrapper/c
 import mcpWrapper from "../../pi-package/extensions/mcp-wrapper/index";
 import projectRules from "../../pi-package/extensions/project-rules/index";
 import systemPrompt from "../../pi-package/extensions/system-prompt/index";
+import { getAgentRuntimeComposition } from "../../pi-package/shared/agent-runtime-composition";
 
 const AGENT_SUITE_DIR_ENV = "PI_AGENT_SUITE_DIR";
 const previousSuiteDir = process.env[AGENT_SUITE_DIR_ENV];
@@ -318,6 +319,7 @@ Use fetch for web pages.
 			});
 
 			await runSessionStart(pi);
+			getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", []);
 
 			expect(await runBeforeAgentStart(pi)).toBe(
 				"Suite template for /tmp/project",
@@ -426,7 +428,10 @@ Use fetch for web pages.
 				});
 
 				await runSessionStart(pi);
-				pi.setActiveTools([...toolNamesFromArgs(toolArgs.args)]);
+				getAgentRuntimeComposition(pi).setRestrictiveToolNames(
+					"test-policy",
+					toolNamesFromArgs(toolArgs.args),
+				);
 
 				expect(await runBeforeAgentStart(pi)).toBe(testCase.expectedPrompt);
 			} finally {

--- a/test/shared/agent-runtime-composition.test.ts
+++ b/test/shared/agent-runtime-composition.test.ts
@@ -74,7 +74,7 @@ test("does not reuse stale runtime composition objects from previous reloads", a
 	const module = await importIsolatedRuntimeCompositionModule("stale");
 	const composition = module.getAgentRuntimeComposition(pi);
 
-	expect(typeof composition.setSubagentsActiveToolFilter).toBe("function");
+	expect(typeof composition.setRestrictiveToolFilter).toBe("function");
 	expect(typeof composition.setConveneCouncilContribution).toBe("function");
 	expect(
 		handlers.filter((handler) => handler.event === "before_agent_start"),


### PR DESCRIPTION
## Problem
MCP servers currently expose all discovered tools immediately, which adds irrelevant context. Runtime extensions also manage active tools independently, and aborted agent runs can leave child work active.

## Solution
Add deferred MCP toolsets with `activate_toolset`, session-branch activation restoration, compact system-prompt triggers, and bounded activation rendering. Centralize active-tool reconciliation so restrictions compose safely and restored tools retain baseline order. Add conditional local MCP instructions, cascade cancellation for aborted root runs, and preserve subagent query diagnostics.

Also updates MCP and system-prompt documentation, adds feature and issue specifications, and expands unit and integration coverage for configuration, composition, toolsets, rendering, cancellation, and diagnostics.