### PR TITLE
Isolate run-subagent hierarchies across native forks

### DIFF
--- a/docs/extensions/run-subagent.md
+++ b/docs/extensions/run-subagent.md
@@ -412,6 +412,12 @@ Accepted session IDs increase within each saved owner session and remain stable 
 
 The original callable agent identity remains attached to the saved logical session. A terminal continuation uses that agent's current definition resolved for the owning runtime's working directory.
 
+## Native fork behavior
+
+A Pi native `/fork` or `/clone` retains the selected root branch and creates a new root Pi session ID. At fork materialization, that root branch selects only direct children whose latest state is terminal success. Each copied child's current source branch recursively selects its direct terminal-success descendants. Every selected child is copied from its current source branch, so copied child history can be later than the selected root fork point.
+
+The copied hierarchy preserves each direct owner's local session IDs. Every included child receives a new Pi session ID and independent session file. `subagent_steer`, `subagent_wait`, `subagent_query`, owner-local ID allocation, and the management screen operate on the copied hierarchy without affecting the original hierarchy. Materialization includes retained terminal-success descendants regardless of `maxDepth`; `maxDepth` limits only new delegation.
+
 ## Process lifetime and terminal outcomes
 
 Each active invocation runs in a separate saved child Pi process owned by the Pi runtime that started it. The process remains supervised after start or steer acceptance and does not outlive its owning runtime.

--- a/docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md
@@ -1,0 +1,16 @@
+# Domain Glossary
+
+- Child session file: A persisted Pi JSONL file that contains one subagent's conversation and extension journal entries.
+- Fork point: The root-session entry selected as the end of the branch retained by a native fork.
+- Forked hierarchy: The root session and subagent hierarchy created by a native fork.
+- Historical snapshot: The root branch and subordinate session state observable at a fork point, excluding changes recorded after that point.
+- Inherited subagent: A retained subagent represented in a forked hierarchy.
+- Logical subagent session: A `run-subagent` session identified by a `SessionKey` and backed by a child session file.
+- Native fork: Pi's `/fork` or `/clone` session operation that creates a root session with a new Pi session ID from one retained branch.
+- Original hierarchy: The root session and subagent hierarchy from which Pi creates a native fork.
+- Owner-local subagent ID: A positive integer that identifies a direct subagent within one owner Pi session.
+- Owner Pi session ID: The Pi session ID of the root or subagent session that directly owns an owner-local subagent ID.
+- Retained root branch: The ordered root-to-fork-point entries copied into a native fork.
+- Retained subagent: A logical subagent session represented by a `run-subagent` journal entry in the retained root branch or in a retained descendant branch.
+- Root session: The Pi session in which the top-level `run-subagent` tools execute.
+- Subagent hierarchy: The root session's recursively owned logical subagent sessions.

--- a/docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md
@@ -1,16 +1,18 @@
 # Domain Glossary
 
 - Child session file: A persisted Pi JSONL file that contains one subagent's conversation and extension journal entries.
+- Current source branch: The active root-to-leaf branch of a source child session when native-fork materialization occurs.
+- Fork materialization: The fork-time process that creates independent child session branches and rebased owner snapshots for a native fork.
 - Fork point: The root-session entry selected as the end of the branch retained by a native fork.
 - Forked hierarchy: The root session and subagent hierarchy created by a native fork.
-- Historical snapshot: The root branch and subordinate session state observable at a fork point, excluding changes recorded after that point.
-- Inherited subagent: A retained subagent represented in a forked hierarchy.
+- Inherited subagent: A retained terminal-success subagent copied into a forked hierarchy.
 - Logical subagent session: A `run-subagent` session identified by a `SessionKey` and backed by a child session file.
 - Native fork: Pi's `/fork` or `/clone` session operation that creates a root session with a new Pi session ID from one retained branch.
 - Original hierarchy: The root session and subagent hierarchy from which Pi creates a native fork.
+- Owner snapshot: A journal record that contains one owner's Pi session ID and complete rebased direct logical sessions.
 - Owner-local subagent ID: A positive integer that identifies a direct subagent within one owner Pi session.
 - Owner Pi session ID: The Pi session ID of the root or subagent session that directly owns an owner-local subagent ID.
 - Retained root branch: The ordered root-to-fork-point entries copied into a native fork.
-- Retained subagent: A logical subagent session represented by a `run-subagent` journal entry in the retained root branch or in a retained descendant branch.
+- Retained subagent: A terminal-success logical subagent selected from the retained root branch when directly owned by the root, or from a copied owner's current branch when nested.
 - Root session: The Pi session in which the top-level `run-subagent` tools execute.
 - Subagent hierarchy: The root session's recursively owned logical subagent sessions.

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_prd.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_prd.md
@@ -4,7 +4,8 @@
 
 - Native fork: Pi's `/fork` or `/clone` operation that creates a root session with a new Pi session ID from one retained branch.
 - Fork point: The last root-session entry included in a native fork.
-- Inherited subagent: A subagent represented in the retained branch of the root session or a nested session.
+- Fork materialization: The fork-time creation of independent child branches and rebased owner relationships.
+- Inherited subagent: A retained terminal-success subagent copied into a forked hierarchy.
 - Subagent hierarchy: All subagents owned recursively by the root session.
 
 ## Context and Problem
@@ -13,11 +14,12 @@ Pi creates a native root fork with a new session ID, but retained `run-subagent`
 
 ## Goal
 
-A native fork receives an accessible and independent copy of the subagent hierarchy in its state at the selected fork point.
+A native fork receives an accessible and independent copy of its retained terminal-success subagent hierarchy. Each included child is copied from its current source branch when the fork is materialized.
 
 ## Scenarios
 
 - A native fork inherits successful direct and nested subagent sessions.
+- An included child can contain history later than the selected root fork point because its current source branch is copied during materialization.
 - The original and inherited subagents continue independently.
 - `subagent_start` creates a new child session without reusing an inherited owner-local subagent ID.
 
@@ -26,8 +28,8 @@ A native fork receives an accessible and independent copy of the subagent hierar
 In scope:
 
 - Native `/fork` and `/clone` operations for a Pi root session.
-- Direct and nested subagent sessions.
-- Historical consistency at the fork point.
+- Direct and nested terminal-success subagent sessions.
+- Current source-branch copying at fork materialization.
 - Access to inherited sessions.
 - File isolation between the original and forked hierarchies.
 
@@ -36,14 +38,14 @@ Out of scope:
 - Compatibility with `run-subagent` journals created before this correction.
 - Changes to Pi's session format or native fork behavior.
 - Copying data outside the `run-subagent` hierarchy.
-- Subagent sessions whose latest state is `terminal-failure` or `terminal-aborted`.
+- Subagent sessions whose latest state is active, `terminal-failure`, or `terminal-aborted`.
 
 ## Requirements
 
-- The native fork receives every subagent whose latest state is `terminal-success` and that is represented in the retained root-session branch, including every nesting level.
+- The retained root-session branch selects direct children whose latest state is `terminal-success`.
+- Fork materialization copies every selected direct child from its current `SessionManager` branch. Each copied child's current branch recursively selects its direct terminal-success descendants. Child history later than the selected root fork point is permitted.
 - Every inherited subagent preserves its owner-local subagent ID.
 - Every inherited subagent receives a new Pi session ID and an independent child session file. Writes to the original child session file do not change the forked child session file, and writes to the forked child session file do not change the original child session file.
-- An inherited subagent contains only state that existed at the selected fork point.
 - The native fork receives the entire retained hierarchy regardless of the current `maxDepth`. The `maxDepth` setting restricts only new subagent invocations.
 - Inherited sessions are accessible through `subagent_steer`, `subagent_wait`, and `subagent_query` using their preserved owner-local subagent IDs.
 - The management screen displays the entire inherited subagent hierarchy.

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_prd.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_prd.md
@@ -1,0 +1,64 @@
+# Idea: Pi fork isolation for subagent sessions
+
+## Definitions
+
+- Native fork: Pi's `/fork` or `/clone` operation that creates a root session with a new Pi session ID from one retained branch.
+- Fork point: The last root-session entry included in a native fork.
+- Inherited subagent: A subagent represented in the retained branch of the root session or a nested session.
+- Subagent hierarchy: All subagents owned recursively by the root session.
+
+## Context and Problem
+
+Pi creates a native root fork with a new session ID, but retained `run-subagent` records continue to reference the previous owners and child session files. The inherited sessions are therefore inaccessible from the fork and are not isolated from the original hierarchy.
+
+## Goal
+
+A native fork receives an accessible and independent copy of the subagent hierarchy in its state at the selected fork point.
+
+## Scenarios
+
+- A native fork inherits successful direct and nested subagent sessions.
+- The original and inherited subagents continue independently.
+- `subagent_start` creates a new child session without reusing an inherited owner-local subagent ID.
+
+## Scope and Non-Scope
+
+In scope:
+
+- Native `/fork` and `/clone` operations for a Pi root session.
+- Direct and nested subagent sessions.
+- Historical consistency at the fork point.
+- Access to inherited sessions.
+- File isolation between the original and forked hierarchies.
+
+Out of scope:
+
+- Compatibility with `run-subagent` journals created before this correction.
+- Changes to Pi's session format or native fork behavior.
+- Copying data outside the `run-subagent` hierarchy.
+- Subagent sessions whose latest state is `terminal-failure` or `terminal-aborted`.
+
+## Requirements
+
+- The native fork receives every subagent whose latest state is `terminal-success` and that is represented in the retained root-session branch, including every nesting level.
+- Every inherited subagent preserves its owner-local subagent ID.
+- Every inherited subagent receives a new Pi session ID and an independent child session file. Writes to the original child session file do not change the forked child session file, and writes to the forked child session file do not change the original child session file.
+- An inherited subagent contains only state that existed at the selected fork point.
+- The native fork receives the entire retained hierarchy regardless of the current `maxDepth`. The `maxDepth` setting restricts only new subagent invocations.
+- Inherited sessions are accessible through `subagent_steer`, `subagent_wait`, and `subagent_query` using their preserved owner-local subagent IDs.
+- The management screen displays the entire inherited subagent hierarchy.
+- `subagent_start` assigns a new direct child session an owner-local subagent ID not used by an inherited direct child session.
+- Compatibility with `run-subagent` journals created before this correction is not required.
+
+## Open Questions
+
+None.
+
+## Technical Supplement
+
+Not required for the Light PRD.
+
+## References
+
+- `docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md`
+- `docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md`

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md
@@ -6,7 +6,7 @@ The `run-subagent` extension persists a root session's subagent hierarchy as cus
 
 ## Problem Statement
 
-When Pi creates a native fork of a root session that has retained subagents, `run-subagent` reconstructs journal entries with their original owner Pi session IDs. The forked root has a different Pi session ID, so the inherited subagents are inaccessible from the fork and may still reference mutable child session files used by the original hierarchy.
+When Pi creates a native fork of a root session that has retained subagents, `run-subagent` reconstructs the retained journal entries with their original owner Pi session IDs and child session file references. The forked root has a different Pi session ID, so inherited subagents are inaccessible from the fork and share mutable child state with the original hierarchy.
 
 ## Who is affected
 
@@ -41,19 +41,19 @@ The forked root receives a new Pi session ID, but retained `run-subagent` journa
 
 ## Desired Outcome
 
-A native root fork represents the retained root branch and retained subagent hierarchy as an independent historical snapshot. The fork can address every retained subagent by its owner-local ID. Work performed after the selected root fork point appears only in the hierarchy where that work occurred.
+A native root fork has an independent, accessible copy of the retained terminal-success subagent hierarchy. Each copied child uses its source branch when the fork is materialized. A child can therefore include history later than the selected root fork point.
 
 ## Success Metrics
 
 - An isolated native-fork behavior test can steer, wait for, and query inherited direct subagents through the forked root.
 - The forked management projection contains the retained subagent hierarchy.
 - Starting a new direct subagent in the fork does not reuse an inherited owner-local ID.
-- Continuing a subagent in the original hierarchy does not change the corresponding forked child session.
-- A fork created before a later child continuation contains child history only through the retained root fork point.
+- Continuing a subagent in either hierarchy does not change the corresponding child session in the other hierarchy.
+- A fork can include child history later than the selected root fork point while preserving independent child files and Pi session IDs.
 
 ## Scope
 
-The problem covers native Pi forks of root sessions, retained `run-subagent` journal state, inherited nested subagent sessions, owner-local identity, historical consistency, and isolation between original and forked session hierarchies.
+The problem covers native Pi forks of root sessions, retained `run-subagent` journal state, inherited nested terminal-success subagent sessions, owner-local identity, and isolation between original and forked session hierarchies.
 
 ## Out of Scope / Non-Goals
 

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md
@@ -1,0 +1,77 @@
+# Problem Statement
+
+## Context
+
+The `run-subagent` extension persists a root session's subagent hierarchy as custom journal entries. Pi 0.84.2 creates a native fork by retaining one root-session branch in a new session file with a new Pi session ID.
+
+## Problem Statement
+
+When Pi creates a native fork of a root session that has retained subagents, `run-subagent` reconstructs journal entries with their original owner Pi session IDs. The forked root has a different Pi session ID, so the inherited subagents are inaccessible from the fork and may still reference mutable child session files used by the original hierarchy.
+
+## Who is affected
+
+Users who invoke Pi's native `/fork` or `/clone` operation on a root session that contains `run-subagent` sessions are affected. The defect also affects `run-subagent` components that authorize, list, address, or allocate owner-local IDs for inherited sessions.
+
+## Evidence
+
+- Pi emits `session_start` with `reason: "fork"` and `previousSessionFile` after a native fork: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/docs/extensions.md:388-449`.
+- Pi assigns the forked root a new session ID while retaining custom entries from the selected branch: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.js:1077-1169`.
+- `run-subagent` ignores the `session_start` event payload: `pi-package/extensions/run-subagent/index.ts:263-270`.
+- `run-subagent` derives root ownership from the new root session ID: `pi-package/extensions/run-subagent/index.ts:1277-1282`.
+- Journal reconstruction preserves persisted session keys: `pi-package/extensions/run-subagent/persistence.ts:262-319` and `pi-package/extensions/run-subagent/persistence.ts:398-432`.
+- Direct access requires the caller's Pi session ID to match the persisted owner Pi session ID: `pi-package/extensions/run-subagent/session-ownership.ts:5-24`.
+- An isolated reproduction reconstructed a session under `old-root`, rejected access from the forked root, and reported `[not_owner] session 1 is not directly owned by the caller`.
+
+## Impact
+
+The fork cannot steer, wait for, or query inherited direct subagents. The management screen omits inherited sessions because traversal starts from the forked root session ID. New subagents can reuse inherited owner-local IDs because allocation only considers sessions owned by the forked root. Shared child session files also prevent the original and forked hierarchies from evolving independently.
+
+## Reproduction Steps
+
+1. Create a persisted root Pi session.
+2. Start at least one `run-subagent` session and retain its journal entry in the root branch.
+3. Create a native Pi fork from a branch point that retains the journal entry.
+4. Start `run-subagent` in the forked root session.
+5. Attempt to address the inherited subagent through `subagent_steer`, `subagent_wait`, or `subagent_query`.
+6. Observe that direct ownership authorization rejects the inherited owner-local session ID.
+
+## Current State
+
+The forked root receives a new Pi session ID, but retained `run-subagent` journal entries keep the original root owner Pi session ID and original child session file references. `run-subagent` reconstructs those entries without interpreting the native fork relationship.
+
+## Desired Outcome
+
+A native root fork represents the retained root branch and retained subagent hierarchy as an independent historical snapshot. The fork can address every retained subagent by its owner-local ID. Work performed after the selected root fork point appears only in the hierarchy where that work occurred.
+
+## Success Metrics
+
+- An isolated native-fork behavior test can steer, wait for, and query inherited direct subagents through the forked root.
+- The forked management projection contains the retained subagent hierarchy.
+- Starting a new direct subagent in the fork does not reuse an inherited owner-local ID.
+- Continuing a subagent in the original hierarchy does not change the corresponding forked child session.
+- A fork created before a later child continuation contains child history only through the retained root fork point.
+
+## Scope
+
+The problem covers native Pi forks of root sessions, retained `run-subagent` journal state, inherited nested subagent sessions, owner-local identity, historical consistency, and isolation between original and forked session hierarchies.
+
+## Out of Scope / Non-Goals
+
+- Compatibility with `run-subagent` session files written before this correction.
+- Changes to Pi's native session format or fork implementation.
+- General copying or synchronization of resources outside the persisted `run-subagent` hierarchy.
+
+## Constraints
+
+- Pi 0.84.2 provides the native fork lifecycle and `SessionManager` APIs.
+- The original root and child session files must remain unchanged by work in the fork.
+- The fork must preserve owner-local subagent IDs while using independent Pi session IDs for inherited child sessions.
+- Tests must use isolated temporary fixtures without real user sessions, models, network calls, authentication, or git state.
+
+## Assumptions
+
+None.
+
+## Open Questions
+
+None at the problem-definition level.

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_solution.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_solution.md
@@ -4,109 +4,82 @@
 
 - PRB-01: Pi creates a root fork with a new session ID but copies `run-subagent` journal records with the previous owner IDs and child session file paths.
 - PRB-02: Reconstruction preserves the previous keys, so inherited sessions are inaccessible through the subagent tools and management screen.
-- PRB-03: Copying the complete current child file violates historical consistency when a child continuation occurred after the selected root fork point.
-- CNS-01: The solution handles subagent sessions whose latest state is `terminal-success`. Sessions in `terminal-failure` or `terminal-aborted` are outside the approved scope.
-- CNS-02: Compatibility with journals that do not contain a persisted `leafId` is not required.
+- PRB-03: Source file references make the original and forked child hierarchies share mutable state.
+- CNS-01: The solution includes only subagent sessions whose latest state is `terminal-success`. Active, `terminal-failure`, and `terminal-aborted` sessions are excluded.
+- CNS-02: A copied child can include history later than the selected root fork point because materialization copies its current source branch.
 
 ## Proposed Solution
 
 ### Solution overview
 
-- DEC-01: Use the approved O9-1 approach: persist `leafId` at terminal completion and recursively create branched child session files.
-- SOL-01: Every `terminal-success` record stores `childLeafId`, obtained from the child Pi process through `get_entries`.
-- SOL-02: The `session_start` handler uses the event `reason`. For `reason: "fork"`, it materializes an independent hierarchy before normal runtime reconstruction.
-- SOL-03: For every inherited session, `SessionManager.createBranchedSession(childLeafId)` creates a new file and Pi session ID without changing the source file.
-- SOL-04: After nested sessions are cloned, the new owner file receives an owner snapshot containing its direct child sessions with rebased identities.
-- SOL-05: The root owner snapshot is appended last. Existing reconstruction, catalog, tools, and management projection then operate on the forked hierarchy.
+- DEC-01: At `session_start` with `reason: "fork"`, materialize the retained hierarchy before normal root runtime reconstruction.
+- SOL-01: For every included child, open its source `SessionManager`, obtain its current leaf with `getLeafId`, and call `createBranchedSession` with that leaf.
+- SOL-02: Materialize terminal-success descendants before their owner, then append an owner snapshot containing the owner's complete rebased direct logical sessions.
+- SOL-03: Preserve each session's `ownerLocalSessionId`. Rebase owner and child Pi session IDs, child session files, and child session directories to the independent copied hierarchy.
+- SOL-04: Append the forked root owner snapshot last. Existing reconstruction, catalog, tools, and management projection then operate on the forked hierarchy.
 
 ### Data flow
 
 - DGM-01:
 
 ```text
-subagent terminal completion
-  -> get_entries
-  -> childLeafId
-  -> terminal record in the owner journal
-
 session_start reason=fork
   -> retained root branch journal
-  -> recursive createBranchedSession(childLeafId)
-  -> owner snapshots with forked identities
+  -> source SessionManager.getLeafId
+  -> source SessionManager.createBranchedSession
+  -> descendant-first owner snapshots with rebased identities
   -> normal SessionStore reconstruction
   -> forked session catalog
 ```
 
 ### Journal model
 
-- ENT-01: `LogicalSession` gains `childLeafId`. The field is present when the latest session state is `terminal-success` and that state was created after this change.
-- EVC-01: A `terminal` record requires `childLeafId` only when its state is `terminal-success`. Records for `terminal-failure` and `terminal-aborted` remain unchanged.
-- EVC-02: A new owner snapshot record contains `ownerPiSessionId` and the complete list of that owner's direct `LogicalSession` values.
-- EVC-03: During journal folding, the last owner snapshot replaces session state derived from earlier records. Normal records after the snapshot apply to that snapshot.
-- EVC-04: The snapshot preserves `ownerLocalSessionId`, agent identity, task name, terminal invocation metadata, state, and `childLeafId`.
-- EVC-05: The snapshot replaces `SessionKey.ownerPiSessionId`, `childPiSessionId`, `childSessionFile`, and `childSessionDir` with values from the forked hierarchy.
-- EVC-06: The snapshot omits `ownerRuntimeLeaseId` because a completed hierarchy has no live relationship with the source owner process.
+- EVC-01: An owner snapshot contains `ownerPiSessionId` and the complete rebased direct `LogicalSession` list for that owner.
+- EVC-02: During journal folding, the last owner snapshot is a boundary. Folding clears earlier logical sessions and reconciliation records, applies the snapshot, then applies ordinary records after the snapshot.
+- EVC-03: A rebased logical session preserves `ownerLocalSessionId`, agent identity, task name, terminal invocation metadata, and terminal state.
+- EVC-04: A rebased logical session replaces `SessionKey.ownerPiSessionId`, `childPiSessionId`, `childSessionFile`, and `childSessionDir` with copied-hierarchy values.
+- EVC-05: The snapshot omits `ownerRuntimeLeaseId` because the copied hierarchy has no live relationship with the source owner process.
 
-### Capturing the child session point
+### Recursive hierarchy materialization
 
-- ALG-01: `InvocationSupervisor` obtains `leafId` after the final child event while the child process remains available.
-- STP-01: `InvocationSupervisor` calls the existing `get_entries` command.
-- STP-02: `InvocationSupervisor` adds the returned `leafId` to the terminal invocation event.
-- STP-03: `SubagentCoordinator` appends `childLeafId` with the `terminal` journal record.
-- STP-04: `SessionStore.fold` updates `LogicalSession.childLeafId` only when the terminal record's `invocationId` matches the logical session's invocation ID.
-- FLR-01: The coordinator does not append a `terminal-success` record without `childLeafId`. A checkpoint read failure uses the existing child runtime failure path.
+- ALG-01: A focused hierarchy materializer receives the forked root `SessionManager` and processes descendants before owners.
+- STP-01: The materializer folds the retained branch journal for one owner.
+- STP-02: For every direct child whose latest state is `terminal-success`, the materializer opens the source child manager, gets its current leaf through `getLeafId`, and creates an independent branch through `createBranchedSession`.
+- STP-03: The materializer folds each copied child branch and recursively materializes its terminal-success descendants.
+- STP-04: After descendants are prepared, the materializer appends the copied owner's snapshot with rebased direct logical sessions.
+- STP-05: The materializer does not read or apply `maxDepth` while traversing retained sessions.
 
-### Recursive hierarchy cloning
+### Current-history semantics
 
-- ALG-02: A focused hierarchy cloner receives the forked root `SessionManager` and materializes the new hierarchy from descendants to ancestors.
-- STP-05: The cloner folds the retained branch journal for one owner.
-- STP-06: For every direct child whose latest state is `terminal-success`, the cloner opens `childSessionFile` and calls `createBranchedSession(childLeafId)`. Sessions in other states are outside the cloning scope.
-- STP-07: The cloner folds the new child branch and recursively clones its direct descendants.
-- STP-08: After the descendants are prepared, the cloner appends the new child owner's snapshot.
-- STP-09: The cloner creates the rebased direct `LogicalSession`, preserving the owner-local ID and replacing the child session identity and path.
-- STP-10: After every direct child is prepared, the cloner appends the current owner's snapshot.
-- STP-11: The cloner does not read or apply `maxDepth` while traversing retained sessions.
-
-### Historical consistency
-
-- SOL-06: The terminal record after answer A stores `childLeafId=A`.
-- SOL-07: Continuation B modifies the source child file and later stores `childLeafId=B` in a new terminal record.
-- SOL-08: A retained root branch selected before B contains `childLeafId=A`, so `createBranchedSession(A)` copies only the child branch through A.
-- SOL-09: Nested journals are stored in child session branches, so the same algorithm applies recursively without a global mapping registry.
-
-### Failure handling and integrity
-
-- FLR-02: A missing source file, missing `childLeafId` for a `terminal-success` session, or `createBranchedSession` failure stops hierarchy materialization. Falling back to the source file's current leaf is prohibited because it would violate historical consistency.
-- FLR-03: The parent owner snapshot is appended only after every descendant hierarchy is prepared. The journal never receives a parent reference to a partially prepared child hierarchy.
-- LIM-01: `SessionManager` does not provide a transaction across multiple files. A process failure between child file creation and parent snapshot append can leave an unreferenced file but does not modify the source hierarchy.
+- SOL-05: The selected root branch selects direct children whose latest state is `terminal-success` for materialization.
+- SOL-06: Each copied child's current source branch recursively selects its direct terminal-success descendants for materialization.
+- SOL-07: Every selected child is copied from its active source root-to-leaf branch at materialization time. Child history later than the selected root fork point is included when it is present on that branch.
 
 ### Affected components
 
-- CMP-01: `invocation-contracts.ts`, `invocation-supervisor.ts`, and `coordinator.ts` carry `childLeafId` from child Pi to the terminal journal record.
-- CMP-02: `domain.ts` and `journal-codec.ts` define and validate the checkpoint field and owner snapshot record.
-- CMP-03: `persistence.ts` applies the owner snapshot as the new base state for an owner.
-- CMP-04: A new focused module performs recursive cloning through the public `SessionManager` API.
-- CMP-05: `index.ts` passes the `session_start` event and invokes cloning only for `reason: "fork"`.
+- CMP-01: `domain.ts` and `journal-codec.ts` define and validate the owner snapshot record.
+- CMP-02: `persistence.ts` applies the owner snapshot as the new base state for an owner.
+- CMP-03: A focused module recursively materializes current source branches through public `SessionManager` APIs.
+- CMP-04: `index.ts` passes the `session_start` event and invokes materialization only for `reason: "fork"`.
 
 ### Verification
 
-- ACC-01: A behavior test creates isolated root and child sessions through the public `SessionManager`, emits an actual `session_start` event with `reason: "fork"`, and verifies access through preserved owner-local IDs.
-- ACC-02: An A/B test proves that the source child file contains A and B while a root fork selected before B contains only A.
-- ACC-03: A nested `terminal-success` hierarchy test proves that every inherited level has a new Pi session ID and an independent file.
+- ACC-01: A behavior test creates isolated root and child sessions through public `SessionManager` APIs, emits `session_start` with `reason: "fork"`, and verifies access through preserved owner-local IDs.
+- ACC-02: A test proves that a root fork can include child history later than the selected root fork point.
+- ACC-03: A nested terminal-success hierarchy test proves that every inherited level has a new Pi session ID and an independent file.
 - ACC-04: A test with `maxDepth: 0` proves that the complete retained hierarchy is inherited.
 - ACC-05: `subagent_steer`, `subagent_wait`, and `subagent_query` do not return `not_owner` for an inherited direct session.
 - ACC-06: `subagent_start` assigns an owner-local ID after the maximum inherited direct ID.
 - ACC-07: Continuing the source child does not change the forked file, and continuing the inherited child does not change the source file.
-- ACC-08: Codec and fold tests prove that an owner snapshot excludes the previous owner keys.
+- ACC-08: Codec and fold tests prove that the last owner snapshot replaces earlier owner state and ordinary later records apply to it.
 - DOD-01: The change passes `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify`.
 
 ## Overengineering and Overspecification Considerations
 
-- TRD-01: The solution stores one `leafId` string per terminal completion instead of a complete child session copy.
-- TRD-02: The solution uses `SessionManager.createBranchedSession` and does not rewrite JSONL directly.
-- TRD-03: Each owner stores its own snapshot. No external registry or nested access to root state is required.
-- TRD-04: The solution does not clone `terminal-failure` or `terminal-aborted` sessions and does not add compatibility for previous journals.
-- TRD-05: The solution does not add a cross-file transaction or orphan-file collector because neither is required for correctness within the approved scope.
+- TRD-01: The solution uses public `SessionManager` branch operations and does not rewrite JSONL directly.
+- TRD-02: Each owner stores its own snapshot. No external registry or nested access to root state is required.
+- TRD-03: The solution copies only terminal-success sessions and does not add compatibility for previous journals.
+- TRD-04: The solution does not add transaction support, orphan cleanup, fallback source references, or other cross-file recovery behavior.
 
 ## Open Questions
 

--- a/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_solution.md
+++ b/docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_solution.md
@@ -1,0 +1,122 @@
+# Technical Solution: Pi fork isolation for subagent sessions
+
+## Problem Statement
+
+- PRB-01: Pi creates a root fork with a new session ID but copies `run-subagent` journal records with the previous owner IDs and child session file paths.
+- PRB-02: Reconstruction preserves the previous keys, so inherited sessions are inaccessible through the subagent tools and management screen.
+- PRB-03: Copying the complete current child file violates historical consistency when a child continuation occurred after the selected root fork point.
+- CNS-01: The solution handles subagent sessions whose latest state is `terminal-success`. Sessions in `terminal-failure` or `terminal-aborted` are outside the approved scope.
+- CNS-02: Compatibility with journals that do not contain a persisted `leafId` is not required.
+
+## Proposed Solution
+
+### Solution overview
+
+- DEC-01: Use the approved O9-1 approach: persist `leafId` at terminal completion and recursively create branched child session files.
+- SOL-01: Every `terminal-success` record stores `childLeafId`, obtained from the child Pi process through `get_entries`.
+- SOL-02: The `session_start` handler uses the event `reason`. For `reason: "fork"`, it materializes an independent hierarchy before normal runtime reconstruction.
+- SOL-03: For every inherited session, `SessionManager.createBranchedSession(childLeafId)` creates a new file and Pi session ID without changing the source file.
+- SOL-04: After nested sessions are cloned, the new owner file receives an owner snapshot containing its direct child sessions with rebased identities.
+- SOL-05: The root owner snapshot is appended last. Existing reconstruction, catalog, tools, and management projection then operate on the forked hierarchy.
+
+### Data flow
+
+- DGM-01:
+
+```text
+subagent terminal completion
+  -> get_entries
+  -> childLeafId
+  -> terminal record in the owner journal
+
+session_start reason=fork
+  -> retained root branch journal
+  -> recursive createBranchedSession(childLeafId)
+  -> owner snapshots with forked identities
+  -> normal SessionStore reconstruction
+  -> forked session catalog
+```
+
+### Journal model
+
+- ENT-01: `LogicalSession` gains `childLeafId`. The field is present when the latest session state is `terminal-success` and that state was created after this change.
+- EVC-01: A `terminal` record requires `childLeafId` only when its state is `terminal-success`. Records for `terminal-failure` and `terminal-aborted` remain unchanged.
+- EVC-02: A new owner snapshot record contains `ownerPiSessionId` and the complete list of that owner's direct `LogicalSession` values.
+- EVC-03: During journal folding, the last owner snapshot replaces session state derived from earlier records. Normal records after the snapshot apply to that snapshot.
+- EVC-04: The snapshot preserves `ownerLocalSessionId`, agent identity, task name, terminal invocation metadata, state, and `childLeafId`.
+- EVC-05: The snapshot replaces `SessionKey.ownerPiSessionId`, `childPiSessionId`, `childSessionFile`, and `childSessionDir` with values from the forked hierarchy.
+- EVC-06: The snapshot omits `ownerRuntimeLeaseId` because a completed hierarchy has no live relationship with the source owner process.
+
+### Capturing the child session point
+
+- ALG-01: `InvocationSupervisor` obtains `leafId` after the final child event while the child process remains available.
+- STP-01: `InvocationSupervisor` calls the existing `get_entries` command.
+- STP-02: `InvocationSupervisor` adds the returned `leafId` to the terminal invocation event.
+- STP-03: `SubagentCoordinator` appends `childLeafId` with the `terminal` journal record.
+- STP-04: `SessionStore.fold` updates `LogicalSession.childLeafId` only when the terminal record's `invocationId` matches the logical session's invocation ID.
+- FLR-01: The coordinator does not append a `terminal-success` record without `childLeafId`. A checkpoint read failure uses the existing child runtime failure path.
+
+### Recursive hierarchy cloning
+
+- ALG-02: A focused hierarchy cloner receives the forked root `SessionManager` and materializes the new hierarchy from descendants to ancestors.
+- STP-05: The cloner folds the retained branch journal for one owner.
+- STP-06: For every direct child whose latest state is `terminal-success`, the cloner opens `childSessionFile` and calls `createBranchedSession(childLeafId)`. Sessions in other states are outside the cloning scope.
+- STP-07: The cloner folds the new child branch and recursively clones its direct descendants.
+- STP-08: After the descendants are prepared, the cloner appends the new child owner's snapshot.
+- STP-09: The cloner creates the rebased direct `LogicalSession`, preserving the owner-local ID and replacing the child session identity and path.
+- STP-10: After every direct child is prepared, the cloner appends the current owner's snapshot.
+- STP-11: The cloner does not read or apply `maxDepth` while traversing retained sessions.
+
+### Historical consistency
+
+- SOL-06: The terminal record after answer A stores `childLeafId=A`.
+- SOL-07: Continuation B modifies the source child file and later stores `childLeafId=B` in a new terminal record.
+- SOL-08: A retained root branch selected before B contains `childLeafId=A`, so `createBranchedSession(A)` copies only the child branch through A.
+- SOL-09: Nested journals are stored in child session branches, so the same algorithm applies recursively without a global mapping registry.
+
+### Failure handling and integrity
+
+- FLR-02: A missing source file, missing `childLeafId` for a `terminal-success` session, or `createBranchedSession` failure stops hierarchy materialization. Falling back to the source file's current leaf is prohibited because it would violate historical consistency.
+- FLR-03: The parent owner snapshot is appended only after every descendant hierarchy is prepared. The journal never receives a parent reference to a partially prepared child hierarchy.
+- LIM-01: `SessionManager` does not provide a transaction across multiple files. A process failure between child file creation and parent snapshot append can leave an unreferenced file but does not modify the source hierarchy.
+
+### Affected components
+
+- CMP-01: `invocation-contracts.ts`, `invocation-supervisor.ts`, and `coordinator.ts` carry `childLeafId` from child Pi to the terminal journal record.
+- CMP-02: `domain.ts` and `journal-codec.ts` define and validate the checkpoint field and owner snapshot record.
+- CMP-03: `persistence.ts` applies the owner snapshot as the new base state for an owner.
+- CMP-04: A new focused module performs recursive cloning through the public `SessionManager` API.
+- CMP-05: `index.ts` passes the `session_start` event and invokes cloning only for `reason: "fork"`.
+
+### Verification
+
+- ACC-01: A behavior test creates isolated root and child sessions through the public `SessionManager`, emits an actual `session_start` event with `reason: "fork"`, and verifies access through preserved owner-local IDs.
+- ACC-02: An A/B test proves that the source child file contains A and B while a root fork selected before B contains only A.
+- ACC-03: A nested `terminal-success` hierarchy test proves that every inherited level has a new Pi session ID and an independent file.
+- ACC-04: A test with `maxDepth: 0` proves that the complete retained hierarchy is inherited.
+- ACC-05: `subagent_steer`, `subagent_wait`, and `subagent_query` do not return `not_owner` for an inherited direct session.
+- ACC-06: `subagent_start` assigns an owner-local ID after the maximum inherited direct ID.
+- ACC-07: Continuing the source child does not change the forked file, and continuing the inherited child does not change the source file.
+- ACC-08: Codec and fold tests prove that an owner snapshot excludes the previous owner keys.
+- DOD-01: The change passes `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify`.
+
+## Overengineering and Overspecification Considerations
+
+- TRD-01: The solution stores one `leafId` string per terminal completion instead of a complete child session copy.
+- TRD-02: The solution uses `SessionManager.createBranchedSession` and does not rewrite JSONL directly.
+- TRD-03: Each owner stores its own snapshot. No external registry or nested access to root state is required.
+- TRD-04: The solution does not clone `terminal-failure` or `terminal-aborted` sessions and does not add compatibility for previous journals.
+- TRD-05: The solution does not add a cross-file transaction or orphan-file collector because neither is required for correctness within the approved scope.
+
+## Open Questions
+
+None.
+
+## References
+
+- REF-01: `docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_problem.md` - Approved problem statement.
+- REF-02: `docs/specs/issues/run-subagent-fork-isolation/domain-glossary.md` - Domain definitions.
+- REF-03: `docs/specs/issues/run-subagent-fork-isolation/run-subagent-fork-isolation_prd.md` - Approved requirements.
+- REF-04: `/opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.js:1077-1169` - `createBranchedSession` behavior.
+- REF-05: `pi-package/extensions/run-subagent/persistence.ts:262-432` - Journal folding and recursive reconstruction.
+- REF-06: `pi-package/extensions/run-subagent/index.ts:263-332` - `session_start` handling.

--- a/pi-package/extensions/run-subagent/domain.ts
+++ b/pi-package/extensions/run-subagent/domain.ts
@@ -119,6 +119,11 @@ export type AgentOperationEvidence =
 /** Records direct-owner state transitions outside model context. */
 export type JournalRecord =
 	| {
+			readonly kind: "owner-snapshot";
+			readonly ownerPiSessionId: string;
+			readonly sessions: readonly LogicalSession[];
+	  }
+	| {
 			readonly kind: "session-accepted";
 			readonly session: LogicalSession;
 	  }

--- a/pi-package/extensions/run-subagent/fork-hierarchy.test.ts
+++ b/pi-package/extensions/run-subagent/fork-hierarchy.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { createPersistedSession } from "../../../test/support/persisted-session.ts";
+import type { JournalRecord, LogicalSession } from "./domain";
+import { materializeForkHierarchy } from "./fork-hierarchy";
+import { SUBAGENT_JOURNAL_CUSTOM_TYPE } from "./persistence";
+
+const metadata = {
+	startedAtMs: 1,
+	elapsedMs: 1_000,
+	modelId: "openai/test-model",
+	thinking: "high",
+	contextWindow: 128_000,
+	contextTokens: 2_000,
+	projectionSavedTokens: 300,
+} as const;
+
+function session(
+	ownerPiSessionId: string,
+	ownerSessionDir: string,
+	ownerLocalSessionId: number,
+	state: LogicalSession["state"],
+): LogicalSession {
+	return {
+		key: { ownerPiSessionId, ownerLocalSessionId },
+		childPiSessionId: `child-${ownerLocalSessionId}`,
+		childSessionDir: ownerSessionDir,
+		childSessionFile: join(
+			ownerSessionDir,
+			`child-${ownerLocalSessionId}.jsonl`,
+		),
+		agentId: "SubAgentCoder",
+		taskName: `task-${ownerLocalSessionId}`,
+		creationOrder: ownerLocalSessionId,
+		invocationId: `invocation-${ownerLocalSessionId}`,
+		runtimeLeaseId: `lease-${ownerLocalSessionId}`,
+		invocationMetadata: metadata,
+		state,
+	};
+}
+
+function appendLifecycle(manager: SessionManager, child: LogicalSession): void {
+	manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+		kind: "session-accepted",
+		session: { ...child, state: "active" },
+	} satisfies JournalRecord);
+	if (child.state === "starting" || child.state === "active") {
+		return;
+	}
+	manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+		kind: "terminal",
+		sessionKey: child.key,
+		invocationId: child.invocationId,
+		state:
+			child.state === "terminal-success" ? "terminal-success" : child.state,
+		disposition: "pending",
+	} satisfies JournalRecord);
+}
+
+describe("materializeForkHierarchy", () => {
+	test("copies current successful branches recursively and rebases snapshots", () => {
+		// Purpose: materialization must recursively copy current terminal-success branches through public Pi APIs.
+		// Inputs and expected outputs: a forked root references successful, active, failed, and aborted children; the callback receives only rebased successful sessions with copied nested history.
+		// Edge cases: nested descendants, history appended after the root fork, and writes after materialization must remain isolated.
+		// Dependencies: public SessionManager persistence and the persisted-session fixture helper.
+		const directory = mkdtempSync(join(tmpdir(), "fork-hierarchy-"));
+		try {
+			const root = createPersistedSession(join(directory, "root"), {
+				id: "root",
+				text: "root seed",
+			});
+			const child = createPersistedSession(join(directory, "child"), {
+				id: "child",
+				text: "child seed",
+			});
+			const grandchild = createPersistedSession(join(directory, "grandchild"), {
+				id: "grandchild",
+				text: "grandchild seed",
+			});
+			const childFile = child.getSessionFile();
+			const grandchildFile = grandchild.getSessionFile();
+			if (childFile === undefined || grandchildFile === undefined) {
+				throw new Error("fixture sessions must be persisted");
+			}
+			const nested = {
+				...session(
+					child.getSessionId(),
+					child.getSessionDir(),
+					1,
+					"terminal-success",
+				),
+				childPiSessionId: grandchild.getSessionId(),
+				childSessionFile: grandchildFile,
+			};
+			appendLifecycle(child, nested);
+			const selected = {
+				...session(
+					root.getSessionId(),
+					root.getSessionDir(),
+					1,
+					"terminal-success",
+				),
+				childPiSessionId: child.getSessionId(),
+				childSessionDir: child.getSessionDir(),
+				childSessionFile: childFile,
+			};
+			appendLifecycle(root, selected);
+			for (const [state, localId] of [
+				["active", 2],
+				["terminal-failure", 3],
+				["terminal-aborted", 4],
+			] as const) {
+				appendLifecycle(
+					root,
+					session(root.getSessionId(), root.getSessionDir(), localId, state),
+				);
+			}
+			const forkFile = root.createBranchedSession(root.getLeafId() as string);
+			if (forkFile === undefined) {
+				throw new Error("root fork must persist");
+			}
+			child.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "child current history" }],
+				timestamp: 2,
+			});
+			const fork = SessionManager.open(forkFile, root.getSessionDir());
+			let snapshot:
+				| Extract<JournalRecord, { kind: "owner-snapshot" }>
+				| undefined;
+			materializeForkHierarchy(fork, (value) => {
+				snapshot = value;
+			});
+			expect(snapshot).toBeDefined();
+			if (snapshot === undefined) {
+				return;
+			}
+			const selectedSnapshot = snapshot.sessions[0];
+			if (selectedSnapshot === undefined) {
+				throw new Error("selected snapshot session was not delivered");
+			}
+			expect(snapshot.ownerPiSessionId).toBe(fork.getSessionId());
+			expect(snapshot.sessions).toHaveLength(1);
+			expect(selectedSnapshot.key.ownerLocalSessionId).toBe(1);
+			expect(selectedSnapshot.childPiSessionId).not.toBe(child.getSessionId());
+			expect(selectedSnapshot.childSessionFile).not.toBe(childFile);
+			expect(selectedSnapshot.ownerRuntimeLeaseId).toBeUndefined();
+			expect(selectedSnapshot.agentId).toBe(selected.agentId);
+			expect(selectedSnapshot.taskName).toBe(selected.taskName);
+			expect(selectedSnapshot.invocationId).toBe(selected.invocationId);
+			expect(selectedSnapshot.runtimeLeaseId).toBe(selected.runtimeLeaseId);
+			expect(selectedSnapshot.invocationMetadata).toEqual(
+				selected.invocationMetadata,
+			);
+			const clonedChild = SessionManager.open(
+				selectedSnapshot.childSessionFile,
+				selectedSnapshot.childSessionDir,
+			);
+			const clonedChildEntries = clonedChild.getBranch();
+			expect(
+				clonedChildEntries.some(
+					(entry) =>
+						entry.type === "message" &&
+						JSON.stringify(entry.message).includes("child current history"),
+				),
+			).toBe(true);
+			const childSnapshot = clonedChildEntries.at(-1);
+			expect(childSnapshot?.type).toBe("custom");
+			const nestedSnapshot =
+				childSnapshot?.type === "custom"
+					? (childSnapshot.data as Extract<
+							JournalRecord,
+							{ kind: "owner-snapshot" }
+						>)
+					: undefined;
+			expect(nestedSnapshot?.ownerPiSessionId).toBe(
+				selectedSnapshot.childPiSessionId,
+			);
+			expect(nestedSnapshot?.sessions).toHaveLength(1);
+			const nestedRetained = nestedSnapshot?.sessions[0];
+			expect(nestedRetained?.key.ownerLocalSessionId).toBe(1);
+			expect(nestedRetained?.childPiSessionId).not.toBe(
+				grandchild.getSessionId(),
+			);
+			expect(nestedRetained?.childSessionFile).not.toBe(grandchildFile);
+			expect(nestedRetained?.ownerRuntimeLeaseId).toBeUndefined();
+			expect(nestedRetained?.agentId).toBe(nested.agentId);
+			expect(nestedRetained?.taskName).toBe(nested.taskName);
+			expect(nestedRetained?.invocationId).toBe(nested.invocationId);
+			expect(nestedRetained?.runtimeLeaseId).toBe(nested.runtimeLeaseId);
+			expect(nestedRetained?.invocationMetadata).toEqual(
+				nested.invocationMetadata,
+			);
+			child.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "source only" }],
+				timestamp: 3,
+			});
+			expect(
+				clonedChild
+					.getBranch()
+					.some(
+						(entry) =>
+							entry.type === "message" &&
+							JSON.stringify(entry.message).includes("source only"),
+					),
+			).toBe(false);
+			clonedChild.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: "clone only" }],
+				timestamp: 4,
+			});
+			const reopenedSourceChild = SessionManager.open(
+				childFile,
+				child.getSessionDir(),
+			);
+			expect(
+				reopenedSourceChild
+					.getBranch()
+					.some(
+						(entry) =>
+							entry.type === "message" &&
+							JSON.stringify(entry.message).includes("clone only"),
+					),
+			).toBe(false);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/pi-package/extensions/run-subagent/fork-hierarchy.ts
+++ b/pi-package/extensions/run-subagent/fork-hierarchy.ts
@@ -1,0 +1,89 @@
+import {
+	type ExtensionContext,
+	SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import type { JournalRecord, LogicalSession } from "./domain";
+import { SessionStore, SUBAGENT_JOURNAL_CUSTOM_TYPE } from "./persistence";
+
+type ReadonlySessionManager = ExtensionContext["sessionManager"];
+type OwnerSnapshot = Extract<JournalRecord, { kind: "owner-snapshot" }>;
+type AppendRootSnapshot = (snapshot: OwnerSnapshot) => void;
+
+/** Copies retained terminal-success owner branches into independent Pi sessions. */
+export function materializeForkHierarchy(
+	root: ReadonlySessionManager,
+	appendRootSnapshot: AppendRootSnapshot,
+): void {
+	const store = new SessionStore();
+	const sessions = materializeOwner(store, root);
+	appendRootSnapshot({
+		kind: "owner-snapshot",
+		ownerPiSessionId: root.getSessionId(),
+		sessions,
+	});
+}
+
+/** Copies one owner's retained direct children and persists its snapshot after descendants. */
+function materializeOwner(
+	store: SessionStore,
+	owner: ReadonlySessionManager,
+): LogicalSession[] {
+	const folded = store.fold(owner.getBranch());
+	const retained: LogicalSession[] = [];
+	for (const sourceSession of folded.sessions) {
+		if (sourceSession.state !== "terminal-success") {
+			continue;
+		}
+		const sourceChild = SessionManager.open(
+			sourceSession.childSessionFile,
+			sourceSession.childSessionDir,
+		);
+		const leafId = sourceChild.getLeafId();
+		if (leafId === null) {
+			throw new Error(
+				`cannot materialize ${sourceSession.key.ownerPiSessionId}:${sourceSession.key.ownerLocalSessionId}: source child has no current leaf`,
+			);
+		}
+		const branchedFile = sourceChild.createBranchedSession(leafId);
+		if (branchedFile === undefined) {
+			throw new Error(
+				`cannot materialize ${sourceSession.key.ownerPiSessionId}:${sourceSession.key.ownerLocalSessionId}: branch was not persisted`,
+			);
+		}
+		const clonedChild = sourceChild;
+		const descendants = materializeOwner(store, clonedChild);
+		clonedChild.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+			kind: "owner-snapshot",
+			ownerPiSessionId: clonedChild.getSessionId(),
+			sessions: descendants,
+		});
+		retained.push(rebaseSession(sourceSession, owner, clonedChild));
+	}
+	return retained;
+}
+
+/** Replaces physical hierarchy identity while retaining logical invocation metadata. */
+function rebaseSession(
+	source: LogicalSession,
+	owner: ReadonlySessionManager,
+	clonedChild: ReadonlySessionManager,
+): LogicalSession {
+	const { ownerRuntimeLeaseId: _ownerRuntimeLeaseId, ...withoutOwnerLease } =
+		source;
+	const childSessionFile = clonedChild.getSessionFile();
+	if (childSessionFile === undefined) {
+		throw new Error(
+			`cannot materialize ${source.key.ownerPiSessionId}:${source.key.ownerLocalSessionId}: cloned child has no persisted path`,
+		);
+	}
+	return {
+		...withoutOwnerLease,
+		key: {
+			...source.key,
+			ownerPiSessionId: owner.getSessionId(),
+		},
+		childPiSessionId: clonedChild.getSessionId(),
+		childSessionDir: clonedChild.getSessionDir(),
+		childSessionFile,
+	};
+}

--- a/pi-package/extensions/run-subagent/index.test.ts
+++ b/pi-package/extensions/run-subagent/index.test.ts
@@ -16,6 +16,7 @@ import {
 	type ExtensionContext,
 	initTheme,
 	SessionManager,
+	type SessionStartEvent,
 	type Theme,
 	type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
@@ -112,7 +113,11 @@ interface RegisteredShortcutLike {
 }
 
 /** Builds the narrow public extension API surface needed by entry tests. */
-function createPiFake(): ExtensionAPI & {
+function createPiFake(
+	options: {
+		readonly appendEntry?: (customType: string, data: unknown) => void;
+	} = {},
+): ExtensionAPI & {
 	readonly appendedEntries: unknown[];
 	readonly commands: RegisteredCommandLike[];
 	readonly messageRenderers: Array<{
@@ -176,6 +181,10 @@ function createPiFake(): ExtensionAPI & {
 		) => shortcuts.push({ shortcut, ...options }),
 		appendEntry: (...args: unknown[]) => {
 			appendedEntries.push(args);
+			const [customType, data] = args;
+			if (typeof customType === "string") {
+				options.appendEntry?.(customType, data);
+			}
 		},
 		sendMessage: (...args: unknown[]) => {
 			sentMessages.push(args);
@@ -2598,6 +2607,344 @@ describe("subagents entry", () => {
 			grandchildSelectedAgentId: "NestedParent",
 			grandchildAvailability: { allowed: true, blocked: false },
 		});
+	});
+
+	test("materializes forked direct and nested sessions for root consumers", async () => {
+		// Purpose: a native fork must rebase retained terminal-success hierarchy before root reconstruction.
+		// Input and expected output: persisted direct and nested successful source sessions become independent fork-owned sessions that steer, wait, query, and management resolve without not_owner.
+		// Edge cases: maxDepth zero disables new delegation but retains nested hierarchy, and source paths must not survive in fork snapshots.
+		// Dependencies: public SessionManager fixtures, actual session_start fork emission, production materialization, management projection, and injected completion and supervisor fakes.
+		initTheme(undefined, false);
+		const configDir = join(suiteDir, "run-subagent");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.json"),
+			JSON.stringify({ enabled: true, maxDepth: 0 }),
+		);
+		const sourceRoot = createPersistedSession(join(suiteDir, "source-root"), {
+			id: "source-root",
+			text: "source root",
+		});
+		const sourceChild = createPersistedSession(join(suiteDir, "source-child"), {
+			id: "source-child",
+			text: "source child",
+		});
+		const sourceGrandchild = createPersistedSession(
+			join(suiteDir, "source-grandchild"),
+			{ id: "source-grandchild", text: "source grandchild" },
+		);
+		const sourceChildFile = sourceChild.getSessionFile();
+		const sourceGrandchildFile = sourceGrandchild.getSessionFile();
+		if (sourceChildFile === undefined || sourceGrandchildFile === undefined) {
+			throw new Error("source fixture sessions must be persisted");
+		}
+		const nested = {
+			key: {
+				ownerPiSessionId: sourceChild.getSessionId(),
+				ownerLocalSessionId: 1,
+			},
+			childPiSessionId: sourceGrandchild.getSessionId(),
+			childSessionDir: sourceGrandchild.getSessionDir(),
+			childSessionFile: sourceGrandchildFile,
+			agentId: "SubAgentCoder",
+			taskName: "Nested retained task",
+			creationOrder: 1,
+			invocationId: "nested-invocation",
+			runtimeLeaseId: "nested-lease",
+			invocationMetadata: TEST_INVOCATION_METADATA,
+			state: "terminal-success",
+		} satisfies LogicalSession;
+		sourceChild.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+			kind: "owner-snapshot",
+			ownerPiSessionId: sourceChild.getSessionId(),
+			sessions: [nested],
+		} satisfies JournalRecord);
+		const direct = {
+			key: {
+				ownerPiSessionId: sourceRoot.getSessionId(),
+				ownerLocalSessionId: 4,
+			},
+			childPiSessionId: sourceChild.getSessionId(),
+			childSessionDir: sourceChild.getSessionDir(),
+			childSessionFile: sourceChildFile,
+			agentId: "SubAgentCoder",
+			taskName: "Direct retained task",
+			creationOrder: 1,
+			invocationId: "direct-invocation",
+			runtimeLeaseId: "direct-lease",
+			invocationMetadata: TEST_INVOCATION_METADATA,
+			state: "terminal-success",
+		} satisfies LogicalSession;
+		sourceRoot.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+			kind: "owner-snapshot",
+			ownerPiSessionId: sourceRoot.getSessionId(),
+			sessions: [direct],
+		} satisfies JournalRecord);
+		const forkFile = sourceRoot.createBranchedSession(
+			sourceRoot.getLeafId() ?? "",
+		);
+		if (forkFile === undefined) {
+			throw new Error("fork fixture must be persisted");
+		}
+		const fork = SessionManager.open(forkFile, sourceRoot.getSessionDir());
+		let screen: ManagementScreen | undefined;
+		const pi = createPiFake({
+			appendEntry: (customType, data) =>
+				fork.appendCustomEntry(customType, data),
+		});
+		const ctx = {
+			...createContext(suiteDir, [], {
+				mode: "tui",
+				model: TEST_MODEL,
+				authenticated: true,
+				custom: async (factory: unknown) => {
+					screen = (
+						factory as (
+							tui: TUI,
+							theme: Theme,
+							keybindings: KeybindingsManager,
+							done: () => void,
+						) => ManagementScreen
+					)(
+						{
+							terminal: { rows: 18, columns: 100 },
+							requestRender: () => undefined,
+							setFocus: () => undefined,
+						} as unknown as TUI,
+						{
+							fg: (_color: string, text: string) => text,
+							bg: (_color: string, text: string) => text,
+							bold: (text: string) => text,
+						} as Theme,
+						new KeybindingsManager({
+							"tui.input.submit": { defaultKeys: "enter" },
+							"tui.select.up": { defaultKeys: "up" },
+							"tui.select.down": { defaultKeys: "down" },
+							"tui.select.pageUp": { defaultKeys: "pageUp" },
+							"tui.select.pageDown": { defaultKeys: "pageDown" },
+							"tui.select.confirm": { defaultKeys: "enter" },
+							"app.tools.expand": { defaultKeys: "ctrl+o" },
+						}),
+						() => undefined,
+					);
+					return undefined;
+				},
+			}),
+			sessionManager: fork,
+		} as ExtensionContext;
+		const response: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "fork query answer" }],
+			api: TEST_MODEL.api,
+			provider: TEST_MODEL.provider,
+			model: TEST_MODEL.id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 1,
+		};
+		const continueSpy = spyOn(
+			InvocationSupervisor.prototype,
+			"continue",
+		).mockResolvedValue({
+			invocationId: "continued-direct",
+			runtimeLeaseId: "continued-direct-lease",
+			childPiSessionId: "continued-direct-child",
+			childSessionDir: join(suiteDir, "continued"),
+			childSessionFile: join(suiteDir, "continued", "child.jsonl"),
+		});
+		try {
+			await subagents(pi, { completeSimple: async () => response });
+			await pi.emit(
+				"session_start",
+				{ type: "session_start", reason: "fork" } satisfies SessionStartEvent,
+				ctx,
+			);
+			const persisted = new SessionStore().fold(fork.getBranch()).sessions;
+			const forkedDirect = persisted.find(
+				(session) => session.key.ownerLocalSessionId === 4,
+			);
+			const command = pi.commands.find(({ name }) => name === "subagents");
+			await command?.handler("", ctx);
+			if (screen === undefined || forkedDirect === undefined) {
+				throw new Error("fork runtime did not reconstruct retained hierarchy");
+			}
+			screen.handleInput("\u001b[C");
+			const query = await getTool(pi, "subagent_query").execute(
+				"fork-query",
+				{ sessionId: 4, question: "What was retained?" },
+				undefined,
+				undefined,
+				ctx,
+			);
+			const wait = await getTool(pi, "subagent_wait").execute(
+				"fork-wait",
+				{ sessionIds: [4], timeout: 1 },
+				undefined,
+				undefined,
+				ctx,
+			);
+			const steer = await getTool(pi, "subagent_steer").execute(
+				"fork-steer",
+				{ sessionId: 4, prompt: "continue" },
+				undefined,
+				undefined,
+				ctx,
+			);
+
+			expect({
+				rootSnapshotWrites: pi.appendedEntries.filter(
+					(entry) =>
+						Array.isArray(entry) &&
+						entry[0] === SUBAGENT_JOURNAL_CUSTOM_TYPE &&
+						Reflect.get(entry[1] as object, "kind") === "owner-snapshot",
+				).length,
+				forkedOwner: forkedDirect.key.ownerPiSessionId,
+				independentChildId:
+					forkedDirect.childPiSessionId !== sourceChild.getSessionId(),
+				independentChildFile: forkedDirect.childSessionFile !== sourceChildFile,
+				query: query.content,
+				wait: readOutcome(wait),
+				steer: readOutcome(steer),
+				continueCalls: continueSpy.mock.calls.length,
+				hierarchyHasNested: screen
+					.render(100)
+					.join("\n")
+					.includes("Nested retained task"),
+			}).toEqual({
+				rootSnapshotWrites: 1,
+				forkedOwner: fork.getSessionId(),
+				independentChildId: true,
+				independentChildFile: true,
+				query: [{ type: "text", text: "fork query answer" }],
+				wait: "no_active_sessions",
+				steer: "accepted",
+				continueCalls: 1,
+				hierarchyHasNested: true,
+			});
+			await pi.emit("session_shutdown", { type: "session_shutdown" }, ctx);
+		} finally {
+			continueSpy.mockRestore();
+			screen?.dispose();
+		}
+	});
+
+	test("allocates above inherited direct IDs after fork materialization", async () => {
+		// Purpose: rebased direct sessions must seed owner-local allocation in the fork root.
+		// Input and expected output: inherited direct ID 7 followed by a new root start invokes the supervisor with owner-local ID 8.
+		// Edge case: the source owner ID differs from the fork owner ID, so stale ownership would reset allocation.
+		// Dependencies: public SessionManager fixtures, actual fork session_start emission, and a controlled invocation supervisor start fake.
+		const configDir = join(suiteDir, "run-subagent");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.json"),
+			JSON.stringify({ enabled: true, maxDepth: 1 }),
+		);
+		writeFileSync(
+			join(suiteDir, "agent-selection", "agents", "Allowed.md"),
+			[
+				"---",
+				"description: Allowed",
+				"type: subagent",
+				"---",
+				"Allowed prompt",
+			].join("\n"),
+		);
+		const sourceRoot = createPersistedSession(
+			join(suiteDir, "allocation-root"),
+			{ id: "allocation-source", text: "root" },
+		);
+		const sourceChild = createPersistedSession(
+			join(suiteDir, "allocation-child"),
+			{ id: "allocation-child", text: "child" },
+		);
+		const sourceChildFile = sourceChild.getSessionFile();
+		if (sourceChildFile === undefined) {
+			throw new Error("allocation child must persist");
+		}
+		sourceRoot.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+			kind: "owner-snapshot",
+			ownerPiSessionId: sourceRoot.getSessionId(),
+			sessions: [
+				{
+					key: {
+						ownerPiSessionId: sourceRoot.getSessionId(),
+						ownerLocalSessionId: 7,
+					},
+					childPiSessionId: sourceChild.getSessionId(),
+					childSessionDir: sourceChild.getSessionDir(),
+					childSessionFile: sourceChildFile,
+					agentId: "Allowed",
+					taskName: "Inherited",
+					creationOrder: 1,
+					invocationId: "inherited",
+					runtimeLeaseId: "inherited-lease",
+					invocationMetadata: TEST_INVOCATION_METADATA,
+					state: "terminal-success",
+				},
+			],
+		} satisfies JournalRecord);
+		const forkFile = sourceRoot.createBranchedSession(
+			sourceRoot.getLeafId() ?? "",
+		);
+		if (forkFile === undefined) {
+			throw new Error("allocation fork must persist");
+		}
+		const fork = SessionManager.open(forkFile, sourceRoot.getSessionDir());
+		const pi = createPiFake({
+			appendEntry: (customType, data) =>
+				fork.appendCustomEntry(customType, data),
+		});
+		const ctx = {
+			...createContext(suiteDir, [], { model: TEST_MODEL }),
+			sessionManager: fork,
+		} as ExtensionContext;
+		getAgentRuntimeComposition(pi).setMainAgentContribution({
+			prompt: "Main",
+			tools: ["subagent_start"],
+			agent: { id: "Main", tools: ["subagent_start"], agents: ["Allowed"] },
+		});
+		const startSpy = spyOn(
+			InvocationSupervisor.prototype,
+			"start",
+		).mockResolvedValue({
+			invocationId: "new",
+			runtimeLeaseId: "new-lease",
+			childPiSessionId: "new-child",
+			childSessionDir: join(suiteDir, "new-child"),
+			childSessionFile: join(suiteDir, "new-child", "child.jsonl"),
+			modelId: "openai/test-model",
+			thinking: "high",
+			contextWindow: 128_000,
+		} as InvocationAcceptance);
+		try {
+			await subagents(pi);
+			await pi.emit(
+				"session_start",
+				{ type: "session_start", reason: "fork" } satisfies SessionStartEvent,
+				ctx,
+			);
+			await getTool(pi, "subagent_start").execute(
+				"allocation-start",
+				{ agentId: "Allowed", taskName: "New", prompt: "work" },
+				undefined,
+				undefined,
+				ctx,
+			);
+			expect(startSpy.mock.calls[0]?.[0].sessionKey).toEqual({
+				ownerPiSessionId: fork.getSessionId(),
+				ownerLocalSessionId: 8,
+			});
+			await pi.emit("session_shutdown", { type: "session_shutdown" }, ctx);
+		} finally {
+			startSpy.mockRestore();
+		}
 	});
 
 	test("returns no_active_sessions for a reconstructed terminal child", async () => {

--- a/pi-package/extensions/run-subagent/index.ts
+++ b/pi-package/extensions/run-subagent/index.ts
@@ -5,6 +5,7 @@ import type {
 	AgentToolResult,
 	ExtensionAPI,
 	ExtensionContext,
+	SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import { isAbortedAgentRun } from "../../shared/agent-end-state";
@@ -59,6 +60,7 @@ import {
 } from "./entry-config";
 import { readSubagentAgentId } from "./environment";
 import { errorMessage } from "./error-message";
+import { materializeForkHierarchy } from "./fork-hierarchy";
 import { InvocationSupervisor } from "./invocation-supervisor";
 import { parseFeedback, parseJournalRecord } from "./journal-codec";
 import {
@@ -265,8 +267,8 @@ function registerLifecycleHandlers(
 	pi: ExtensionAPI,
 	state: RuntimeState,
 ): void {
-	pi.on("session_start", (_event, ctx) => {
-		state.initialization = handleSessionStart(pi, state, ctx);
+	pi.on("session_start", (event, ctx) => {
+		state.initialization = handleSessionStart(pi, state, event, ctx);
 		return state.initialization;
 	});
 	pi.on("message_end", (_event, ctx) => reconcileRuntime(state, ctx));
@@ -289,6 +291,7 @@ function registerLifecycleHandlers(
 async function handleSessionStart(
 	pi: ExtensionAPI,
 	state: RuntimeState,
+	event: SessionStartEvent,
 	ctx: ExtensionContext,
 ): Promise<void> {
 	const config = await state.resolveConfig();
@@ -311,6 +314,11 @@ async function handleSessionStart(
 	state.workerBridge ??= installWorkerRuntimeBridge();
 	if (state.workerBridge === undefined) {
 		state.rootRuntime?.management?.dispose();
+		if (event.reason === "fork") {
+			materializeForkHierarchy(ctx.sessionManager, (snapshot) => {
+				pi.appendEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, snapshot);
+			});
+		}
 		state.rootRuntime = await createRootRuntime(pi, ctx, state);
 		registerManagementEntries(pi, state, ctx);
 		return;

--- a/pi-package/extensions/run-subagent/journal-codec.test.ts
+++ b/pi-package/extensions/run-subagent/journal-codec.test.ts
@@ -24,6 +24,15 @@ const SESSION: LogicalSession = {
 	},
 	state: "active",
 } as unknown as LogicalSession;
+const {
+	ownerRuntimeLeaseId: _ownerRuntimeLeaseId,
+	...SESSION_WITHOUT_OWNER_LEASE
+} = SESSION;
+const SNAPSHOT_SESSION: LogicalSession = {
+	...SESSION_WITHOUT_OWNER_LEASE,
+	state: "terminal-success",
+};
+
 const FEEDBACK = {
 	feedbackId: "feedback-1",
 	invocationId: "invocation-1",
@@ -45,6 +54,16 @@ describe("journal codec", () => {
 		// Dependencies: production journal parser and representative subagent domain values.
 		const records: JournalRecord[] = [
 			{ kind: "session-accepted", session: SESSION },
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [],
+			},
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [SNAPSHOT_SESSION],
+			},
 			{
 				kind: "continuation-accepted",
 				sessionKey: SESSION.key,
@@ -118,6 +137,39 @@ describe("journal codec", () => {
 		} as unknown as SubagentFeedback;
 		const malformed: unknown[] = [
 			null,
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [],
+				extra: true,
+			},
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+			},
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [{ ...SNAPSHOT_SESSION, state: "active" }],
+			},
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [
+					{
+						...SNAPSHOT_SESSION,
+						key: {
+							...SNAPSHOT_SESSION.key,
+							ownerPiSessionId: "other-owner",
+						},
+					},
+				],
+			},
+			{
+				kind: "owner-snapshot",
+				ownerPiSessionId: SNAPSHOT_SESSION.key.ownerPiSessionId,
+				sessions: [{ ...SNAPSHOT_SESSION, ownerRuntimeLeaseId: "lease" }],
+			},
 			{},
 			{ kind: "unknown" },
 			{ kind: "session-accepted", session: { ...SESSION, state: "invalid" } },

--- a/pi-package/extensions/run-subagent/journal-codec.ts
+++ b/pi-package/extensions/run-subagent/journal-codec.ts
@@ -30,6 +30,8 @@ const LOGICAL_SESSION_KEYS = [
 export function parseJournalRecord(value: unknown): JournalRecord | undefined {
 	const kind = readStringField(value, "kind");
 	switch (kind) {
+		case "owner-snapshot":
+			return parseOwnerSnapshotRecord(value);
 		case "session-accepted":
 			return parseAcceptedRecord(value);
 		case "continuation-accepted":
@@ -45,6 +47,38 @@ export function parseJournalRecord(value: unknown): JournalRecord | undefined {
 		default:
 			return undefined;
 	}
+}
+
+/** Parses one owner snapshot that establishes a new journal boundary. */
+function parseOwnerSnapshotRecord(value: unknown): JournalRecord | undefined {
+	if (!hasExactKeys(value, ["kind", "ownerPiSessionId", "sessions"])) {
+		return undefined;
+	}
+	const ownerPiSessionId = readStringField(value, "ownerPiSessionId");
+	const rawSessions = readField(value, "sessions");
+	if (ownerPiSessionId === undefined || !Array.isArray(rawSessions)) {
+		return undefined;
+	}
+	const sessions: LogicalSession[] = [];
+	for (const sessionValue of rawSessions) {
+		if (
+			typeof sessionValue !== "object" ||
+			sessionValue === null ||
+			Object.hasOwn(sessionValue, "ownerRuntimeLeaseId")
+		) {
+			return undefined;
+		}
+		const session = parseLogicalSession(sessionValue);
+		if (
+			session === undefined ||
+			session.key.ownerPiSessionId !== ownerPiSessionId ||
+			session.state !== "terminal-success"
+		) {
+			return undefined;
+		}
+		sessions.push(session);
+	}
+	return { kind: "owner-snapshot", ownerPiSessionId, sessions };
 }
 
 /** Parses one accepted-session journal record. */

--- a/pi-package/extensions/run-subagent/persistence.test.ts
+++ b/pi-package/extensions/run-subagent/persistence.test.ts
@@ -432,6 +432,108 @@ describe("SessionStore", () => {
 		}
 	});
 
+	test("rebases fold state at the last owner snapshot boundary", () => {
+		// Purpose: an owner snapshot must replace stale session and reconciliation state while preserving later append-order updates.
+		// Input and expected output: two snapshots, a stale earlier session, and later continuation and terminal records produce only the last snapshot and its terminal session.
+		// Edge case: an empty first snapshot and a non-empty last snapshot prove that the last boundary wins and that zero-session snapshots are valid.
+		// Dependencies: public SessionManager custom entries, closed journal parsing, and SessionStore.fold.
+		const directory = mkdtempSync(join(tmpdir(), "subagents-owner-snapshot-"));
+		try {
+			const manager = createPersistedSession(directory);
+			const ownerPiSessionId = manager.getSessionId();
+			const staleSession: LogicalSession = {
+				key: { ownerPiSessionId, ownerLocalSessionId: 1 },
+				childPiSessionId: "stale-child",
+				childSessionDir: directory,
+				childSessionFile: join(directory, "stale-child.jsonl"),
+				agentId: "SubAgentCoder",
+				taskName: "Stale session",
+				creationOrder: 1,
+				invocationId: "stale-invocation",
+				runtimeLeaseId: "stale-lease",
+				invocationMetadata: INVOCATION_METADATA,
+				state: "active",
+			};
+			const snapshotSession: LogicalSession = {
+				...staleSession,
+				key: { ownerPiSessionId, ownerLocalSessionId: 2 },
+				childPiSessionId: "snapshot-child",
+				childSessionFile: join(directory, "snapshot-child.jsonl"),
+				invocationId: "snapshot-invocation",
+				runtimeLeaseId: "snapshot-lease",
+				state: "terminal-success",
+			};
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "session-accepted",
+				session: staleSession,
+			});
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "history-pending",
+				feedbackId: "stale-feedback",
+				invocationId: staleSession.invocationId,
+				sessionKey: staleSession.key,
+			});
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "owner-snapshot",
+				ownerPiSessionId,
+				sessions: [],
+			});
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "owner-snapshot",
+				ownerPiSessionId,
+				sessions: [snapshotSession],
+			});
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "continuation-accepted",
+				sessionKey: snapshotSession.key,
+				invocationId: "continued-invocation",
+				runtimeLeaseId: "continued-lease",
+				invocationMetadata: INVOCATION_METADATA,
+			});
+			manager.appendCustomEntry(SUBAGENT_JOURNAL_CUSTOM_TYPE, {
+				kind: "terminal",
+				sessionKey: snapshotSession.key,
+				invocationId: "continued-invocation",
+				state: "terminal-success",
+				disposition: "pending",
+			});
+
+			const folded = new SessionStore().fold(manager.getBranch());
+
+			expect(folded.records).toEqual([
+				{
+					kind: "owner-snapshot",
+					ownerPiSessionId,
+					sessions: [snapshotSession],
+				},
+				{
+					kind: "continuation-accepted",
+					sessionKey: snapshotSession.key,
+					invocationId: "continued-invocation",
+					runtimeLeaseId: "continued-lease",
+					invocationMetadata: INVOCATION_METADATA,
+				},
+				{
+					kind: "terminal",
+					sessionKey: snapshotSession.key,
+					invocationId: "continued-invocation",
+					state: "terminal-success",
+					disposition: "pending",
+				},
+			]);
+			expect(folded.sessions).toEqual([
+				{
+					...snapshotSession,
+					invocationId: "continued-invocation",
+					runtimeLeaseId: "continued-lease",
+					invocationMetadata: INVOCATION_METADATA,
+				},
+			]);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
 	test("folds current parent lease from nested continuation records", () => {
 		// Purpose: durable continuation state must replace the nested session's prior parent runtime lease.
 		// Input and expected output: terminal session under old-parent becomes active under new-parent with the continued invocation and runtime lease.

--- a/pi-package/extensions/run-subagent/persistence.ts
+++ b/pi-package/extensions/run-subagent/persistence.ts
@@ -274,6 +274,15 @@ export class SessionStore implements OwnerSessionStore {
 			if (record === undefined) {
 				continue;
 			}
+			if (record.kind === "owner-snapshot") {
+				records.length = 0;
+				sessions.clear();
+				records.push(record);
+				for (const session of record.sessions) {
+					sessions.set(keyOf(session.key), session);
+				}
+				continue;
+			}
 			records.push(record);
 			applyRecord(sessions, record);
 		}


### PR DESCRIPTION
## Problem
Native Pi forks retain subagent records that still point to the original owner sessions and child files. This makes inherited subagents inaccessible and lets the original and forked hierarchies share mutable state.

## Solution
Materialize an independent copy of each retained terminal-success subagent hierarchy during `/fork` and `/clone`. Rebase owner and child session IDs/files while preserving owner-local IDs, recursively copy current child branches, and store owner snapshots for reconstruction.

### Details
- Excludes active and failed/aborted subagents from inheritance.
- Preserves nested hierarchies regardless of `maxDepth`; `maxDepth` only limits new delegation.
- Keeps inherited sessions accessible to steer, wait, query, and management views.
- Ensures new subagents receive unused owner-local IDs.
- Adds documentation, domain glossary, PRD, problem statement, and technical solution.

### Testing
Adds coverage for recursive hierarchy copying, current-branch history, file/session isolation, owner snapshot folding, inherited-session operations, and ID allocation.