### PR TITLE
Isolate run-subagent child session startup directories

### DIFF
--- a/docs/extensions/run-subagent.md
+++ b/docs/extensions/run-subagent.md
@@ -446,13 +446,13 @@ At a completion, process-exit, runtime-stop, or fail-stop boundary, the first ob
 
 ## Persistence and reopening
 
-Child sessions are stored under:
+Child sessions are stored under the suite's `run-subagent/sessions/` directory. The default path is:
 
 ```text
-~/.pi/agent/agent-suite/run-subagent/sessions/
+~/.pi/agent/agent-suite/run-subagent/sessions/<encoded-resolved-cwd>/<childPiSessionId>/
 ```
 
-When `PI_AGENT_SUITE_DIR` is set, the same `run-subagent/sessions/` path is used under that suite directory.
+When `PI_AGENT_SUITE_DIR` is set, the same `run-subagent/sessions/<encoded-resolved-cwd>/<childPiSessionId>/` path is used under that suite directory. Each project is grouped by Pi 0.84.2's encoded resolved working directory, and each fresh child gets its own `childPiSessionId` directory. Continuations reuse the persisted `childSessionDir` and `childSessionFile`; existing saved paths require no migration.
 
 The owning Pi session saves logical-session identity, direct-owner relationships, accepted continuations, terminal outcomes, and whether feedback was returned by a wait or added to history. This state remains outside model context. Reopening recursively restores every saved descendant with the same owner-local ID and saved child conversation, regardless of the current `maxDepth`. Lowering `maxDepth` prevents deeper `subagent_start` calls but does not hide historical sessions.
 

--- a/docs/specs/issues/run-subagent-session-startup-scan/technical-solution.md
+++ b/docs/specs/issues/run-subagent-session-startup-scan/technical-solution.md
@@ -1,0 +1,54 @@
+# Technical Solution: Run-subagent session startup isolation
+
+## Problem Statement
+- PRB-01: A fresh launch that passes a shared `--session-dir` with a new `--session-id` makes Pi perform session discovery and scan the shared JSONL catalog before Node IPC readiness. The project-key and child-ID directory layout removes this unbounded shared scan while continuations reopen their persisted physical session.
+
+## Proposed Solution
+
+### Storage contract
+- APC-01: A fresh child stores its Pi session under `run-subagent/sessions/<encoded-resolved-cwd>/<childPiSessionId>/`. `createRootSupervisor` supplies the project directory and `InvocationSupervisor` appends the generated `childPiSessionId` before spawning Pi.
+- APC-02: A continuation reuses the persisted `childPiSessionId`, `childSessionDir`, and `childSessionFile` from `LogicalSession`. It passes `--session-dir <childSessionDir> --session <childSessionFile>` to Pi rather than selecting a new directory or session ID.
+
+### Pi project key
+- ALG-01: The project key matches Pi 0.84.2 exactly:
+  1. Resolve `cwd`.
+  2. Remove one leading slash or backslash.
+  3. Replace every slash, backslash, and colon with `-`.
+  4. Wrap the result with `--`.
+
+  The resulting expression is ``--${resolve(cwd).replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--``.
+
+### Startup branches
+- SCN-01: For a fresh child, `createInvocationHandle` generates `childPiSessionId`, selects `join(projectSessionDir, childPiSessionId)`, creates that directory before spawn, and `buildChildArgs` passes `--session-dir` with `--session-id`.
+- SCN-02: For a continuation, `InvocationSupervisor.continue` passes the saved physical identity to `launchAndAccept`. The explicit saved directory bypasses fresh-directory selection, and `buildChildArgs` passes `--session-dir` with `--session`.
+
+### Component responsibilities
+- CMP-01: `project-session-directory.ts` resolves and encodes the project working directory.
+- CMP-02: `createRootSupervisor` combines the run-subagent session root and `ctx.cwd` into the project directory.
+- CMP-03: `InvocationSupervisor.createInvocationHandle` owns fresh child ID generation, leaf-directory selection, and directory creation before process spawn. It preserves a request-provided directory.
+- CMP-04: `buildChildArgs` selects Pi's fresh `--session-id` form or continuation `--session` form from the presence of `childSessionFile`.
+
+### TDD verification
+- ACC-01: `project-session-directory.test.ts` checks the Pi 0.84.2 encoding for resolved paths, slash and backslash separators, colons, and storage-root joining.
+- ACC-02: `invocation-supervisor.test.ts`, "groups fresh child sessions by project and creates the directory before spawn", captures the spawned arguments and observes that the exact fresh directory exists at spawn time.
+- ACC-03: `invocation-supervisor.test.ts`, "waits for prior same-session teardown before continuation", checks reuse of the saved child Pi session ID, directory, and file, plus the exact `--session-dir` and `--session` arguments for a legacy flat directory.
+- ACC-04: `invocation-process.test.ts`, "builds new and resumed worker arguments with explicit launch policy", checks the mutually exclusive fresh and resumed Pi argument forms. The tests use captured arguments, directory state at spawn, and controlled process closure rather than elapsed startup-time assertions.
+
+### Trade-offs and boundaries
+- TRD-01: The extension keeps a small local implementation of Pi 0.84.2's pure project-key algorithm because Pi does not expose its default-session-directory helper through the package root export. Updating Pi requires reviewing this algorithm.
+- OSP-01: Timeout behavior, IPC, logical session identity, legacy migration, and fork behavior are not changed. Persisted directories remain authoritative for continuations, including legacy flat paths.
+
+## Overengineering and Overspecification Considerations
+- DEC-01: The solution adds one project-key helper and one child-ID leaf directory. It does not add a storage registry, migration path, alternate cwd source, or private Pi import.
+- NGL-01: This document defines only session-startup storage selection and continuation reuse. It does not define changes to session lifecycle, process control, or fork copying.
+
+## Open Questions
+None.
+
+## References
+- REF-01: `pi-package/extensions/run-subagent/project-session-directory.ts` - Pi-compatible project-key encoding and project-directory construction.
+- REF-02: `pi-package/extensions/run-subagent/index.ts` - root supervisor composition from the suite session root and `ctx.cwd`.
+- REF-03: `pi-package/extensions/run-subagent/invocation-supervisor.ts` - fresh directory creation and persisted continuation identity forwarding.
+- REF-04: `pi-package/extensions/run-subagent/invocation-process.ts` - fresh and continuation Pi command arguments.
+- REF-05: `pi-package/extensions/run-subagent/project-session-directory.test.ts`, `pi-package/extensions/run-subagent/invocation-supervisor.test.ts`, and `pi-package/extensions/run-subagent/invocation-process.test.ts` - behavioral coverage for encoding, startup isolation, continuation reuse, and Pi arguments.
+- REF-06: `@earendil-works/pi-coding-agent/dist/core/session-manager.js`, `getDefaultSessionDirPath` - Pi 0.84.2 project-key implementation.

--- a/pi-package/extensions/run-subagent/index.ts
+++ b/pi-package/extensions/run-subagent/index.ts
@@ -84,6 +84,7 @@ import {
 	SUBAGENT_HISTORY_CUSTOM_TYPE,
 	SUBAGENT_JOURNAL_CUSTOM_TYPE,
 } from "./persistence";
+import { projectSessionDirectory } from "./project-session-directory";
 import { QueryBranchAccess } from "./query-branch-access";
 import type { QueryBranchResponse } from "./query-branch-wire";
 import {
@@ -849,9 +850,9 @@ function createRootSupervisor(options: {
 		bridge: options.bridge,
 		childStartupConfig: options.childStartupConfig,
 		recordChildStartupAttempt: options.recordChildStartupAttempt,
-		sessionsDir: join(
-			getSuiteExtensionDir(SUBAGENTS_EXTENSION_DIR),
-			"sessions",
+		sessionsDir: projectSessionDirectory(
+			join(getSuiteExtensionDir(SUBAGENTS_EXTENSION_DIR), "sessions"),
+			options.ctx.cwd,
 		),
 		resolveLaunch: (request) =>
 			resolveLaunchConfiguration({

--- a/pi-package/extensions/run-subagent/invocation-supervisor.test.ts
+++ b/pi-package/extensions/run-subagent/invocation-supervisor.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
@@ -249,9 +249,23 @@ function createSupervisor(
 	).supervisor;
 }
 
+function createSupervisorSessionsRoot(): string {
+	return mkdtempSync(join(tmpdir(), "run-subagent-supervisor-"));
+}
+
+let supervisorSessionsRoot = "";
+beforeAll(() => {
+	supervisorSessionsRoot = createSupervisorSessionsRoot();
+});
+afterAll(() => {
+	rmSync(supervisorSessionsRoot, { recursive: true, force: true });
+});
+
 interface SupervisorHarnessOptions {
 	readonly resolveLaunch?: InvocationSupervisorOptions["resolveLaunch"];
 	readonly onSpawnEnvironment?: (environment: NodeJS.ProcessEnv) => void;
+	readonly onSpawn?: (args: readonly string[], cwd: string) => void;
+	readonly sessionsDir?: string;
 	readonly childStartupConfig?: ChildStartupConfig;
 	readonly recordChildStartupAttempt?: (
 		record: ChildAuthStartupAttemptRecord,
@@ -294,9 +308,10 @@ function createSupervisorHarness(
 					contextWindow: 128_000,
 				},
 			})),
-		sessionsDir: "/tmp",
-		spawnProcess: (_command, _args, spawnOptions) => {
+		sessionsDir: options.sessionsDir ?? supervisorSessionsRoot,
+		spawnProcess: (_command, args, spawnOptions) => {
 			options.onSpawnEnvironment?.(spawnOptions.env);
+			options.onSpawn?.(args, spawnOptions.cwd);
 			const child = children[spawnCount];
 			if (child === undefined) {
 				throw new Error("controlled child process queue is exhausted");
@@ -1533,6 +1548,46 @@ describe("InvocationSupervisor", () => {
 		await supervisor.terminateLease(acceptance.runtimeLeaseId);
 	});
 
+	test("groups fresh child sessions by project and creates the directory before spawn", async () => {
+		// Purpose: fresh child sessions must not share one project directory.
+		// Input and expected output: a fresh launch uses the Pi-compatible project directory plus its child ID, already created at spawn time.
+		// Edge case: the launch has no saved child session path and therefore must select the generated fresh path.
+		// Dependencies: supervisor handle creation and child argument construction.
+		const child = createChildProcess();
+		const sessionsRoot = mkdtempSync(join(tmpdir(), "run-subagent-sessions-"));
+		const projectSessionsDir = join(sessionsRoot, "--tmp--");
+		const spawnRecords: Array<{ args: readonly string[]; cwd: string }> = [];
+		const harness = createSupervisorHarness(
+			[child],
+			[],
+			undefined,
+			undefined,
+			true,
+			{
+				onSpawn: (args, cwd) => spawnRecords.push({ args, cwd }),
+				sessionsDir: projectSessionsDir,
+			},
+		);
+
+		const acceptance = await acceptStart(harness.supervisor, child);
+		const record = spawnRecords[0];
+		expect(record).toBeDefined();
+		expect(record?.cwd).toBe("/tmp");
+		expect(record?.args).toContain("--session-dir");
+		const sessionDirIndex = record?.args.indexOf("--session-dir") ?? -1;
+		const sessionDir =
+			sessionDirIndex < 0 ? undefined : record?.args[sessionDirIndex + 1];
+		expect(sessionDir).toBe(
+			`${projectSessionsDir}/${acceptance.childPiSessionId}`,
+		);
+		expect(sessionDir === undefined ? false : existsSync(sessionDir)).toBe(
+			true,
+		);
+		expect(record?.args).toContain("--session-id");
+		await harness.supervisor.terminateLease(acceptance.runtimeLeaseId);
+		rmSync(sessionsRoot, { recursive: true, force: true });
+	});
+
 	test("waits for prior same-session teardown before continuation", async () => {
 		// Purpose: terminal continuation must hand off one saved session only after the prior process fully closes.
 		// Input and expected output: normal completion reaches the event sink, continuation remains unspawned until close, then one new prompt accepts on the same session reference.
@@ -1542,9 +1597,14 @@ describe("InvocationSupervisor", () => {
 		const priorChild = createChildProcess({ closeOnStdinEnd: false });
 		const continuationChild = createChildProcess();
 		const events: InvocationEvent[] = [];
+		const spawnRecords: Array<{ args: readonly string[]; cwd: string }> = [];
 		const harness = createSupervisorHarness(
 			[priorChild, continuationChild],
 			events,
+			undefined,
+			undefined,
+			true,
+			{ onSpawn: (args, cwd) => spawnRecords.push({ args, cwd }) },
 		);
 		const priorAcceptance = await acceptStart(harness.supervisor, priorChild);
 		emitSuccessfulCompletion(priorChild, "done");
@@ -1552,8 +1612,17 @@ describe("InvocationSupervisor", () => {
 		let continuationSettled = false;
 
 		// Act.
+		const legacySessionDir = mkdtempSync(
+			join(tmpdir(), "run-subagent-legacy-sessions-"),
+		);
+		const savedSession = terminalSession({
+			...priorAcceptance,
+			childPiSessionId: "saved-child-id",
+			childSessionDir: legacySessionDir,
+			childSessionFile: join(legacySessionDir, "saved-child.jsonl"),
+		});
 		const pendingContinuation = harness.supervisor
-			.continue(terminalSession(priorAcceptance), "Continue saved work")
+			.continue(savedSession, "Continue saved work")
 			.then((acceptance) => {
 				continuationSettled = true;
 				return acceptance;
@@ -1582,6 +1651,9 @@ describe("InvocationSupervisor", () => {
 		);
 
 		// Assert.
+		const continuationArgs = spawnRecords[1]?.args ?? [];
+		const continuationSessionDirIndex =
+			continuationArgs.indexOf("--session-dir");
 		expect({
 			eventCount: events.filter((event) => event.kind === "terminal").length,
 			beforeClose,
@@ -1591,10 +1663,16 @@ describe("InvocationSupervisor", () => {
 			continuationWriteCount,
 			sameChildPiSession:
 				continuationAcceptance.childPiSessionId ===
-				priorAcceptance.childPiSessionId,
-			sameSessionFile:
-				continuationAcceptance.childSessionFile ===
-				priorAcceptance.childSessionFile,
+				savedSession.childPiSessionId,
+			continuationSessionArgs:
+				continuationSessionDirIndex < 0
+					? undefined
+					: continuationArgs.slice(
+							continuationSessionDirIndex,
+							continuationSessionDirIndex + 4,
+						),
+			sameSessionDir:
+				continuationAcceptance.childSessionDir === savedSession.childSessionDir,
 		}).toEqual({
 			eventCount: 1,
 			beforeClose: {
@@ -1608,8 +1686,15 @@ describe("InvocationSupervisor", () => {
 			spawnCount: 2,
 			continuationWriteCount: 1,
 			sameChildPiSession: true,
-			sameSessionFile: true,
+			continuationSessionArgs: [
+				"--session-dir",
+				legacySessionDir,
+				"--session",
+				join(legacySessionDir, "saved-child.jsonl"),
+			],
+			sameSessionDir: true,
 		});
+		rmSync(legacySessionDir, { recursive: true, force: true });
 	});
 
 	test("coordinates feedback completion before same-session handoff", async () => {

--- a/pi-package/extensions/run-subagent/invocation-supervisor.ts
+++ b/pi-package/extensions/run-subagent/invocation-supervisor.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
+import { join } from "node:path";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import {
 	normalizeChildPrompt,
@@ -351,7 +352,8 @@ export class InvocationSupervisor implements InvocationControl {
 		const runtimeLeaseId = randomUUID();
 		const childPiSessionId = request.childPiSessionId ?? randomUUID();
 		const childSessionDir =
-			request.childSessionDir ?? this.requireSessionsDir();
+			request.childSessionDir ??
+			join(this.requireSessionsDir(), childPiSessionId);
 		mkdirSync(childSessionDir, { recursive: true });
 		const process = this.spawnWorkerProcess(
 			request,

--- a/pi-package/extensions/run-subagent/project-session-directory.test.ts
+++ b/pi-package/extensions/run-subagent/project-session-directory.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import {
+	encodeProjectSessionDirectory,
+	projectSessionDirectory,
+} from "./project-session-directory";
+
+describe("project session directory", () => {
+	test("matches Pi's resolved cwd encoding", () => {
+		expect(encodeProjectSessionDirectory("/Users/example/project:demo")).toBe(
+			"--Users-example-project-demo--",
+		);
+		expect(encodeProjectSessionDirectory("/Users\\example/project")).toBe(
+			"--Users-example-project--",
+		);
+	});
+
+	test("joins the encoded project directory under the session root", () => {
+		expect(projectSessionDirectory("/sessions", "/Users/example/project")).toBe(
+			"/sessions/--Users-example-project--",
+		);
+	});
+});

--- a/pi-package/extensions/run-subagent/project-session-directory.ts
+++ b/pi-package/extensions/run-subagent/project-session-directory.ts
@@ -1,0 +1,18 @@
+import { join, resolve } from "node:path";
+
+const LEADING_SEPARATOR = /^[/\\]/;
+const PATH_SEPARATOR = /[/\\:]/g;
+
+/** Encodes a resolved working directory using Pi's project-session naming. */
+export function encodeProjectSessionDirectory(cwd: string): string {
+	const resolvedCwd = resolve(cwd);
+	return `--${resolvedCwd.replace(LEADING_SEPARATOR, "").replace(PATH_SEPARATOR, "-")}--`;
+}
+
+/** Returns the project-specific session directory under the supplied storage root. */
+export function projectSessionDirectory(
+	sessionsRoot: string,
+	cwd: string,
+): string {
+	return join(sessionsRoot, encodeProjectSessionDirectory(cwd));
+}


### PR DESCRIPTION
## Problem
Fresh child sessions shared one directory, causing Pi to scan a growing session catalog during startup and potentially delaying IPC readiness.

## Solution
Give each project and fresh child its own session directory, while continuations reuse their saved directory and session file.

- Match Pi 0.84.2's resolved-working-directory encoding.
- Create fresh child directories before spawning Pi.
- Preserve legacy continuation paths without migration.
- Document the new persistence layout.
- Add coverage for project encoding, directory creation, and continuation arguments.