### PR TITLE
Add get/edit capabilities for active dynamic workflow stages

### DIFF
--- a/docs/extensions/workflow.md
+++ b/docs/extensions/workflow.md
@@ -98,6 +98,8 @@ Optional prompt overrides belong in `~/.pi/agent/agent-suite/workflow/config.jso
   "extensionDescriptionPromptFile": "/absolute/path/extension-description.md",
   "createDescriptionPromptFile": "/absolute/path/create-description.md",
   "activateDescriptionPromptFile": "/absolute/path/activate-description.md",
+  "getStageDescriptionPromptFile": "/absolute/path/get-stage-description.md",
+  "editStageDescriptionPromptFile": "/absolute/path/edit-stage-description.md",
   "transitionDescriptionPromptFile": "/absolute/path/transition-description.md"
 }
 ```
@@ -108,7 +110,7 @@ Each configured path must be absolute and reference a readable file with non-emp
 
 ## Tools
 
-All workflow tools run sequentially and return model-visible success content `{"success":true}`.
+All workflow tools run sequentially. Mutating tools return model-visible success content `{"success":true}`. `workflow_get_stage` returns the requested stage as JSON.
 
 After creation, activation, advance, or rework persists the entered stage, its triggers run sequentially in listed order. Duplicate triggers are preserved. A reported or thrown trigger failure stops the remaining stage triggers but does not change workflow success. Restoring an active stage during session start or branch reconstruction runs no triggers.
 
@@ -163,11 +165,36 @@ The `workflow_create` TypeBox schema adds LLM-facing length and collection-size 
 
 `workflow_activate` activates one ready-made workflow listed in `<workflow_activation_options>`. Activation replaces prior workflow state. Only the exact active workflow ID after NFC normalization is excluded from options. The tool is unavailable when policy filtering and that exclusion leave no activation options.
 
+### `workflow_get_stage`
+
+`workflow_get_stage` is available only while a workflow created through `workflow_create` is active. It accepts only `stageId` and reads that stage from the current workflow. It does not accept `workflowId` and cannot read catalog workflows.
+
+The JSON result contains `id`, `description`, `prompt`, `model.thinking`, `initial`, and `final`. The tool rejects an unknown stage without changing workflow state.
+
+### `workflow_edit_stage`
+
+`workflow_edit_stage` has the same dynamic active-workflow availability rule. It requires one closed replacement object:
+
+```json
+{
+  "stageId": "implementation",
+  "description": "Implement the corrected change",
+  "prompt": "Follow the corrected requirements.",
+  "model": {
+    "thinking": "high"
+  }
+}
+```
+
+The tool replaces only `description`, `prompt`, and `model.thinking`. It preserves `id`, `initial`, `final`, `triggers`, transitions, workflow fields, route, status, source, and restoration settings. All replacement fields are required. `model.thinking` accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
+
+The edit appends a `stage_edited` session entry. Editing the active stage applies its thinking level immediately and updates the prompt and description used by the next provider request. Editing another stage stores the new fields without changing current runtime thinking. A later transition applies that stage's edited thinking level. Editing does not enter the stage and does not run its triggers.
+
 ### `workflow_transition`
 
 `workflow_transition` moves the active workflow to one target listed in `<available_transitions>`. Permission for `workflow_create` does not grant transition permission.
 
-Every tool rechecks its input and current state before appending a session entry. Creation and activation also recheck the policy information they require. A malformed policy blocks all workflow operations. Validation or persistence errors leave the previous workflow state unchanged.
+Every tool rechecks its input and current state before reading or appending session state. Creation and activation also recheck the policy information they require. A malformed policy blocks all workflow operations. Validation or persistence errors leave the previous workflow state unchanged.
 
 ## Compact session status panel
 
@@ -181,7 +208,7 @@ The row contains the workflow ID and active stage description. It never includes
 
 A completed workflow is still retained for rework, but its provider context uses `<completed_workflow>` and omits `<active_stage_guidelines>` until rework makes the workflow active again.
 
-Creation, activation, transition, session start, and branch changes replace the row with the saved active state. Changing the selected agent or its workflow allowlist does not hide this row or the saved active workflow. The agent's tool policy still controls provider-context availability. A branch without saved active workflow state removes only the `Workflow` row; other shared panel rows remain visible.
+Creation, activation, stage editing, transition, session start, and branch changes replace the row with the saved active state. Changing the selected agent or its workflow allowlist does not hide this row or the saved active workflow. The agent's tool policy still controls provider-context availability. A branch without saved active workflow state removes only the `Workflow` row; other shared panel rows remain visible.
 
 ## Tool presentation
 
@@ -195,6 +222,14 @@ Content: ctrl+o to show
 
 workflow_activate
 Workflow: delivery · Software delivery
+
+workflow_get_stage
+Stage: implementation · Implement the approved change
+Content: ctrl+o to show
+
+workflow_edit_stage
+Stage: implementation · Implement the corrected change
+Content: ctrl+o to show
 
 workflow_transition
 From: implementation · Implement the approved change
@@ -230,13 +265,14 @@ transitions:
     type: advance
 ```
 
-Collapsed mode wraps references to the available width and shows at most four content rows per reference. Expanded mode shows complete references and creation YAML. A failed call keeps the identity captured before execution and adds `Error: <message>`. Workflow and stage references are stored in result `details`. Expanded creation YAML is reconstructed from the stored tool-call arguments. These two stored sources keep the active screen and subagent session screen consistent.
+Collapsed mode wraps references to the available width and shows at most four content rows per reference. Expanded mode shows complete references, creation YAML, and stage YAML for `workflow_get_stage` and `workflow_edit_stage`. A failed call keeps the identity captured before execution and adds `Error: <message>`. Workflow and stage references are stored in result `details`. Expanded creation YAML is reconstructed from the stored tool-call arguments. These two stored sources keep the active screen and subagent session screen consistent.
 
 ## Provider context
 
 The extension computes tool availability independently:
 - `workflow_create` requires a valid catalog, including a valid empty catalog;
 - `workflow_activate` requires at least one allowed activation option;
+- `workflow_get_stage` and `workflow_edit_stage` require an active dynamic workflow created through `workflow_create`;
 - `workflow_transition` requires a projected active state or at least one allowed catalog workflow.
 
 The agent's `tools` policy remains a second gate. The extension never restores a tool removed by that policy.
@@ -264,11 +300,12 @@ Catalog activation options are filtered through `workflows`. The current active 
 
 ## Session snapshots
 
-Catalog activation stores an `activated` snapshot with the validated workflow definition, route, and pre-workflow restoration settings. Dynamic creation stores the same data in a `created` snapshot. Later transitions store only the updated route and preserve the workflow source and restoration settings. Completion stores a `completed` snapshot with the final route. Stored workflow definitions preserve stage triggers, but replaying snapshots never executes them.
+Catalog activation stores an `activated` snapshot with the validated workflow definition, route, and pre-workflow restoration settings. Dynamic creation stores the same data in a `created` snapshot. Stage edits store the stage ID and normalized replacement fields. Later transitions store only the updated route and preserve the workflow source and restoration settings. Completion stores a `completed` snapshot with the final route. Stored workflow definitions preserve stage triggers, but replaying snapshots never executes them.
 
 The active branch reconstructs state on session start and branch changes:
 - `activated` restores catalog-backed active state and its restoration settings;
 - `created` restores dynamic active state and its restoration settings;
+- `stage_edited` replaces `description`, `prompt`, and `model.thinking` in the preceding active dynamic snapshot;
 - `transitioned` updates the route of the preceding snapshot;
 - `completed` restores completed state and the persisted pre-workflow runtime settings without applying final-stage settings.
 

--- a/docs/specs/features/workflow-edit-stage/technical-solution.md
+++ b/docs/specs/features/workflow-edit-stage/technical-solution.md
@@ -1,0 +1,56 @@
+# Technical Solution: Dynamic Workflow Stage Editing
+
+## Problem Statement
+- PRB-01: A workflow created through `workflow_create` cannot repair incorrect stage instructions without replacing the complete workflow and losing its saved route.
+- PRB-02: A stage edit must survive session replay and affect the next provider request without changing workflow identity, graph structure, or progress.
+
+## Proposed Solution
+
+### SOL-01: Tool availability
+- Register `workflow_get_stage` and `workflow_edit_stage` as sequential workflow tools.
+- Expose both tools only when the saved workflow has `source === "dynamic"` and `status === "active"`.
+- Keep agent tool policy, workflow policy, prompt loading, and runtime availability checks as additional gates.
+- Do not accept `workflowId`. Both tools operate on the current active dynamic workflow.
+
+### SOL-02: Stage read contract
+- `workflow_get_stage` accepts only `stageId`.
+- Return `id`, `description`, `prompt`, `model.thinking`, `initial`, and `final` as JSON.
+- Reject an unknown stage without changing workflow state.
+
+### SOL-03: Stage edit contract
+- `workflow_edit_stage` requires `stageId`, `description`, `prompt`, and `model.thinking` in one closed object.
+- Replace only `description`, `prompt`, and `model.thinking`.
+- Preserve `id`, `initial`, `final`, `triggers`, transitions, workflow fields, route, status, source, and restoration settings.
+- Reject stage deletion, partial edits, unknown fields, unknown stages, catalog workflows, and completed workflows.
+
+### SOL-04: Runtime and session state
+- Append a `stage_edited` workflow-state entry containing the normalized replacement fields.
+- Replay `stage_edited` entries against the preceding `created` snapshot and reject entries without an active dynamic snapshot.
+- Apply an edited active stage's thinking level before persistence and roll it back when persistence fails.
+- Persist a non-active stage edit without changing the current stage's runtime thinking. Apply that thinking level when a later transition enters the edited stage.
+- Publish the revised runtime state before the next provider-context projection. The next request contains the revised active-stage prompt and description.
+- Do not run stage-entry triggers because editing does not enter a stage.
+
+### SOL-05: Tool presentation and prompts
+- Render stage references and YAML content through the existing workflow presentation path in compact and expanded modes.
+- Persist presentation details so the main screen and subagent session screen render the same content.
+- Tell the model in the `workflow_edit_stage` description to inspect incorrect stage fields with `workflow_get_stage` and edit in place instead of replacing the workflow.
+
+### SOL-06: Validation
+- Cover tool schemas, availability, active and non-active edits, catalog rejection, completed workflow rejection, runtime application, rollback, session replay, provider context, and TUI presentation.
+- Run workflow tests, package behavior tests, strict type checks, formatting checks, and extension loading checks.
+
+## Overengineering and Overspecification Considerations
+- The graph, route, triggers, workflow identity, and catalog files remain outside the edit contract.
+- One replay event stores only editable fields instead of another complete workflow snapshot.
+- The implementation reuses workflow availability, model application, session replay, prompt loading, and TUI rendering code.
+
+## Open Questions
+
+None.
+
+## References
+- REF-01: `pi-package/extensions/workflow/index.ts` - tool registration, availability checks, runtime application, and persistence.
+- REF-02: `pi-package/extensions/workflow/workflow.ts` - immutable stage replacement and session replay.
+- REF-03: `pi-package/extensions/workflow/tool-rendering.ts` - compact and expanded stage presentation.
+- REF-04: `docs/extensions/workflow.md` - user-facing workflow extension behavior.

--- a/pi-package/extensions/workflow/availability.test.ts
+++ b/pi-package/extensions/workflow/availability.test.ts
@@ -3,10 +3,13 @@ import {
 	resolveWorkflowAvailability,
 	WORKFLOW_ACTIVATE_TOOL,
 	WORKFLOW_CREATE_TOOL,
+	WORKFLOW_EDIT_STAGE_TOOL,
+	WORKFLOW_GET_STAGE_TOOL,
 	WORKFLOW_TRANSITION_TOOL,
 } from "./availability";
 import {
 	activateWorkflow,
+	completeWorkflow,
 	createWorkflow,
 	validateWorkflowDefinition,
 	type WorkflowDefinition,
@@ -58,6 +61,51 @@ describe("workflow availability", () => {
 		expect(toolNames(result)).toEqual([WORKFLOW_CREATE_TOOL]);
 		expect(result.activationOptions).toEqual([]);
 		expect(result.projectedState).toBeUndefined();
+	});
+
+	/**
+	 * Proves stage inspection and editing exist only while the current workflow is active.
+	 * Input and expected output: one active dynamic workflow exposes get and edit; completing it removes both.
+	 * Edge case: the completed snapshot remains projected for rework while stage tools stay unavailable.
+	 * Dependencies: pure availability resolution and workflow completion state.
+	 */
+	test("exposes stage tools only for an active workflow", () => {
+		const active = createWorkflow(workflow("dynamic"));
+		const activeResult = resolveWorkflowAvailability({
+			catalog: [],
+			catalogValid: true,
+			policy: { kind: "resolved", policy: undefined },
+			state: active,
+		});
+		const completedResult = resolveWorkflowAvailability({
+			catalog: [],
+			catalogValid: true,
+			policy: { kind: "resolved", policy: undefined },
+			state: completeWorkflow(active),
+		});
+		const catalogWorkflow = workflow("catalog");
+		const catalogResult = resolveWorkflowAvailability({
+			catalog: [catalogWorkflow],
+			catalogValid: true,
+			policy: { kind: "resolved", policy: undefined },
+			state: activateWorkflow(catalogWorkflow),
+		});
+
+		expect(toolNames(activeResult)).toEqual([
+			"workflow_create",
+			"workflow_edit_stage",
+			"workflow_get_stage",
+			"workflow_transition",
+		]);
+		expect(toolNames(completedResult)).toEqual([
+			"workflow_create",
+			"workflow_transition",
+		]);
+		expect(toolNames(catalogResult)).toEqual([
+			"workflow_create",
+			"workflow_transition",
+		]);
+		expect(completedResult.projectedState?.status).toBe("completed");
 	});
 
 	/**
@@ -169,6 +217,8 @@ describe("workflow availability", () => {
 		expect(dynamicResult.projectedState).toBe(dynamicState);
 		expect(toolNames(dynamicResult)).toEqual([
 			WORKFLOW_CREATE_TOOL,
+			WORKFLOW_EDIT_STAGE_TOOL,
+			WORKFLOW_GET_STAGE_TOOL,
 			WORKFLOW_TRANSITION_TOOL,
 		]);
 	});
@@ -194,7 +244,11 @@ describe("workflow availability", () => {
 			state: dynamicState,
 		});
 
-		expect(toolNames(catalogFailure)).toEqual([WORKFLOW_TRANSITION_TOOL]);
+		expect(toolNames(catalogFailure)).toEqual([
+			WORKFLOW_EDIT_STAGE_TOOL,
+			WORKFLOW_GET_STAGE_TOOL,
+			WORKFLOW_TRANSITION_TOOL,
+		]);
 		expect(catalogFailure.projectedState).toBe(dynamicState);
 		expect(toolNames(policyFailure)).toEqual([]);
 		expect(policyFailure.projectedState).toBeUndefined();

--- a/pi-package/extensions/workflow/availability.ts
+++ b/pi-package/extensions/workflow/availability.ts
@@ -7,11 +7,15 @@ import type { WorkflowDefinition, WorkflowState } from "./workflow.ts";
 
 export const WORKFLOW_CREATE_TOOL = "workflow_create";
 export const WORKFLOW_ACTIVATE_TOOL = "workflow_activate";
+export const WORKFLOW_GET_STAGE_TOOL = "workflow_get_stage";
+export const WORKFLOW_EDIT_STAGE_TOOL = "workflow_edit_stage";
 export const WORKFLOW_TRANSITION_TOOL = "workflow_transition";
 
 export type WorkflowToolName =
 	| typeof WORKFLOW_CREATE_TOOL
 	| typeof WORKFLOW_ACTIVATE_TOOL
+	| typeof WORKFLOW_GET_STAGE_TOOL
+	| typeof WORKFLOW_EDIT_STAGE_TOOL
 	| typeof WORKFLOW_TRANSITION_TOOL;
 
 /** Inputs required to resolve workflow capabilities without using Pi runtime state. */
@@ -65,6 +69,13 @@ export function resolveWorkflowAvailability(
 	}
 	if (activationOptions.length > 0) {
 		availableToolNames.add(WORKFLOW_ACTIVATE_TOOL);
+	}
+	if (
+		projectedState?.source === "dynamic" &&
+		projectedState.status === "active"
+	) {
+		availableToolNames.add(WORKFLOW_GET_STAGE_TOOL);
+		availableToolNames.add(WORKFLOW_EDIT_STAGE_TOOL);
 	}
 	if (projectedState !== undefined || allowedCatalog.length > 0) {
 		availableToolNames.add(WORKFLOW_TRANSITION_TOOL);

--- a/pi-package/extensions/workflow/config.test.ts
+++ b/pi-package/extensions/workflow/config.test.ts
@@ -156,6 +156,11 @@ describe("workflow prompt configuration", () => {
 		);
 		await writeFile(join(bundled, "create-description.md"), " create \n");
 		await writeFile(join(bundled, "activate-description.md"), " activate \n");
+		await writeFile(join(bundled, "get-stage-description.md"), " get stage \n");
+		await writeFile(
+			join(bundled, "edit-stage-description.md"),
+			" edit stage \n",
+		);
 		await writeFile(
 			join(bundled, "transition-description.md"),
 			" transition \n",
@@ -171,6 +176,8 @@ describe("workflow prompt configuration", () => {
 			extensionDescription: "guidelines",
 			createDescription: "custom creation",
 			activateDescription: "activate",
+			getStageDescription: "get stage",
+			editStageDescription: "edit stage",
 			transitionDescription: "transition",
 		});
 	});
@@ -191,6 +198,8 @@ describe("workflow prompt configuration", () => {
 			"extension-description.md",
 			"create-description.md",
 			"activate-description.md",
+			"get-stage-description.md",
+			"edit-stage-description.md",
 			"transition-description.md",
 		]) {
 			await writeFile(join(bundled, file), "default");
@@ -216,6 +225,8 @@ describe("workflow prompt configuration", () => {
 			"extension-description.md",
 			"create-description.md",
 			"activate-description.md",
+			"get-stage-description.md",
+			"edit-stage-description.md",
 			"transition-description.md",
 		]) {
 			await writeFile(join(bundled, file), "default");

--- a/pi-package/extensions/workflow/config.ts
+++ b/pi-package/extensions/workflow/config.ts
@@ -18,6 +18,8 @@ export interface WorkflowPrompts {
 	readonly extensionDescription: string;
 	readonly createDescription: string;
 	readonly activateDescription: string;
+	readonly getStageDescription: string;
+	readonly editStageDescription: string;
 	readonly transitionDescription: string;
 }
 
@@ -25,6 +27,8 @@ const CONFIG_KEYS = new Set([
 	"extensionDescriptionPromptFile",
 	"createDescriptionPromptFile",
 	"activateDescriptionPromptFile",
+	"getStageDescriptionPromptFile",
+	"editStageDescriptionPromptFile",
 	"transitionDescriptionPromptFile",
 ]);
 
@@ -138,6 +142,16 @@ export async function loadWorkflowPrompts(
 				config["activateDescriptionPromptFile"] ??
 					join(bundledDirectory, "activate-description.md"),
 				"activateDescriptionPromptFile",
+			),
+			getStageDescription: await readPrompt(
+				config["getStageDescriptionPromptFile"] ??
+					join(bundledDirectory, "get-stage-description.md"),
+				"getStageDescriptionPromptFile",
+			),
+			editStageDescription: await readPrompt(
+				config["editStageDescriptionPromptFile"] ??
+					join(bundledDirectory, "edit-stage-description.md"),
+				"editStageDescriptionPromptFile",
 			),
 			transitionDescription: await readPrompt(
 				config["transitionDescriptionPromptFile"] ??

--- a/pi-package/extensions/workflow/context.test.ts
+++ b/pi-package/extensions/workflow/context.test.ts
@@ -11,6 +11,8 @@ const prompts = {
 	extensionDescription: "Use <stages> & choose safely.",
 	createDescription: "create",
 	activateDescription: "activate",
+	getStageDescription: "get stage",
+	editStageDescription: "edit stage",
 	transitionDescription: "transition",
 };
 

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -461,11 +461,13 @@ afterEach(async () => {
 
 describe("workflow extension lifecycle", () => {
 	/** Proves configured definitions exist before lifecycle policy resolution. */
-	test("registers the three sequential workflow tools during initialization", async () => {
+	test("registers the five sequential workflow tools during initialization", async () => {
 		await createSuite(validYaml());
 		const fake = await createFakePi();
 		expect(fake.tools.map(({ name }) => name)).toEqual([
 			"workflow_activate",
+			"workflow_get_stage",
+			"workflow_edit_stage",
 			"workflow_transition",
 			"workflow_create",
 		]);
@@ -474,7 +476,45 @@ describe("workflow extension lifecycle", () => {
 		).toBe(true);
 		await runLifecycle(fake, "session_start");
 		await runLifecycle(fake, "session_tree");
-		expect(fake.tools).toHaveLength(3);
+		expect(fake.tools).toHaveLength(5);
+	});
+
+	/**
+	 * Proves both stage tools have closed schemas without a workflow identifier or immutable stage fields.
+	 * Input and expected output: get accepts only stageId; edit requires stageId, description, prompt, and thinking.
+	 * Edge cases: extended thinking is valid, while partial edits, workflowId, id, initial, final, triggers, and model.id are rejected.
+	 * Dependencies: registered TypeBox schemas only.
+	 */
+	test("exposes closed stage get and edit schemas", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+		const getSchema = get.parameters as Parameters<typeof Check>[0];
+		const editSchema = edit.parameters as Parameters<typeof Check>[0];
+		const validEdit = {
+			stageId: "start",
+			description: "Revised start",
+			prompt: "Use the revised requirements.",
+			model: { thinking: "xhigh" },
+		};
+
+		expect(Check(getSchema, { stageId: "start" })).toBe(true);
+		expect(Check(getSchema, { stageId: "start", workflowId: "other" })).toBe(
+			false,
+		);
+		expect(Check(editSchema, validEdit)).toBe(true);
+		for (const invalid of [
+			{ ...validEdit, workflowId: "other" },
+			{ ...validEdit, id: "replacement" },
+			{ ...validEdit, initial: true },
+			{ ...validEdit, final: true },
+			{ ...validEdit, triggers: [] },
+			{ ...validEdit, model: { thinking: "high", id: "openai/model" } },
+			{ stageId: "start", description: "Partial" },
+		] as const) {
+			expect(Check(editSchema, invalid)).toBe(false);
+		}
 	});
 
 	/**
@@ -678,6 +718,8 @@ describe("workflow extension lifecycle", () => {
 		});
 		expect(fake.activeTools).toEqual([
 			"read",
+			"workflow_get_stage",
+			"workflow_edit_stage",
 			"workflow_transition",
 			"workflow_create",
 		]);
@@ -699,6 +741,243 @@ describe("workflow extension lifecycle", () => {
 			'<active_workflow id="dynamic-delivery" active_stage_id="done"',
 		);
 		expect(content).not.toContain("<workflow_activation_options");
+	});
+
+	/**
+	 * Proves registered stage tools reject direct calls until a workflow is active.
+	 * Input and expected output: no saved state hides both tools and both executions fail with the same active-workflow error.
+	 * Edge case: registered definitions remain callable in the test despite availability filtering.
+	 * Dependencies: lifecycle reconciliation and execution-time state checks.
+	 */
+	test("requires an active workflow for stage tools", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+
+		expect(fake.activeTools).not.toContain("workflow_get_stage");
+		expect(fake.activeTools).not.toContain("workflow_edit_stage");
+		await expect(get.execute("get", { stageId: "start" })).rejects.toThrow(
+			"no workflow is active",
+		);
+		await expect(
+			edit.execute("edit", {
+				stageId: "start",
+				description: "Start",
+				prompt: "Start only after activation.",
+				model: { thinking: "medium" },
+			}),
+		).rejects.toThrow("no workflow is active");
+	});
+
+	/**
+	 * Proves catalog workflows never expose or execute stage inspection and editing.
+	 * Input and expected output: activating one catalog workflow keeps both tools hidden and direct calls reject it.
+	 * Edge case: workflow_transition remains available for the same active catalog workflow.
+	 * Dependencies: workflow source tracking, availability filtering, and execution-time source checks.
+	 */
+	test("rejects stage tools for catalog workflows", async () => {
+		await createSuite(validYaml());
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		await requireTool(fake, "workflow_activate").execute("activate", {
+			workflowId: "delivery",
+		});
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+
+		expect(fake.activeTools).not.toContain("workflow_get_stage");
+		expect(fake.activeTools).not.toContain("workflow_edit_stage");
+		expect(fake.activeTools).toContain("workflow_transition");
+		await expect(get.execute("get", { stageId: "start" })).rejects.toThrow(
+			"workflow_create",
+		);
+		await expect(
+			edit.execute("edit", {
+				stageId: "start",
+				description: "Catalog stage",
+				prompt: "Catalog stages cannot be edited.",
+				model: { thinking: "medium" },
+			}),
+		).rejects.toThrow("workflow_create");
+	});
+
+	/**
+	 * Proves stage tools read and change active and non-active stages in only the current active workflow.
+	 * Input and expected output: dynamic creation exposes both tools; edits persist and appear in the next provider context.
+	 * Edge cases: editing a non-active stage does not change current thinking, while editing the active stage applies thinking immediately.
+	 * Dependencies: workflow availability, session persistence, provider-context projection, and model runtime application.
+	 */
+	test("gets and edits stages in the current active workflow", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		const create = requireTool(fake, "workflow_create");
+		await create.execute("create", createArguments());
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+		const transition = requireTool(fake, "workflow_transition");
+
+		expect(fake.activeTools).toEqual(
+			expect.arrayContaining(["workflow_get_stage", "workflow_edit_stage"]),
+		);
+		const initial = (await get.execute("get-start", {
+			stageId: "start",
+		})) as { content: Array<{ type: string; text: string }> };
+		expect(JSON.parse(initial.content[0]?.text ?? "null")).toEqual({
+			id: "start",
+			description: "Start",
+			prompt: "Start dynamic work",
+			model: { thinking: "medium" },
+			initial: true,
+			final: false,
+		});
+
+		await edit.execute("edit-done", {
+			stageId: "done",
+			description: "Revised done",
+			prompt: "Use the revised final-stage requirements.",
+			model: { thinking: "high" },
+		});
+		expect(fake.thinkingLevel).toBe("medium");
+		const revisedDone = (await get.execute("get-done", {
+			stageId: "done",
+		})) as { content: Array<{ type: string; text: string }> };
+		expect(JSON.parse(revisedDone.content[0]?.text ?? "null")).toMatchObject({
+			id: "done",
+			description: "Revised done",
+			prompt: "Use the revised final-stage requirements.",
+			model: { thinking: "high" },
+			initial: false,
+			final: true,
+		});
+
+		await transition.execute("transition", { stageId: "done" });
+		expect(fake.thinkingLevel).toBe("high");
+		await edit.execute("edit-active", {
+			stageId: "done",
+			description: "Correct final stage",
+			prompt: "Follow the corrected requirements now.",
+			model: { thinking: "low" },
+		});
+		expect(fake.thinkingLevel).toBe("low");
+		expect(
+			fake.appended.map(({ data }) => (data as { kind: string }).kind),
+		).toEqual(["created", "stage_edited", "transitioned", "stage_edited"]);
+		const context = await runContext(fake, []);
+		const content = String(
+			(context as { messages: Array<{ content: unknown }> }).messages[0]
+				?.content,
+		);
+		expect(content).toContain("Correct final stage");
+		expect(content).toContain("Follow the corrected requirements now.");
+	});
+
+	/**
+	 * Proves stage edits survive session replay and are unavailable once the workflow is completed.
+	 * Input and expected output: replaying created and stage_edited entries returns revised stage content; settlement hides both tools.
+	 * Edge case: direct calls against a completed saved snapshot fail instead of reading or changing it.
+	 * Dependencies: session entry replay, agent settlement, and active-tool reconciliation.
+	 */
+	test("replays stage edits and hides stage tools after completion", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		await requireTool(fake, "workflow_create").execute(
+			"create",
+			createArguments(),
+		);
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+		await edit.execute("edit", {
+			stageId: "done",
+			description: "Saved revision",
+			prompt: "Replay these corrected requirements.",
+			model: { thinking: "high" },
+		});
+		const branch = fake.appended.map(({ customType, data }) => ({
+			type: "custom",
+			customType,
+			data,
+		}));
+		await runLifecycle(fake, "session_tree", branch);
+		const replayed = (await get.execute("get-replayed", {
+			stageId: "done",
+		})) as { content: Array<{ text: string }> };
+		expect(JSON.parse(replayed.content[0]?.text ?? "null")).toMatchObject({
+			description: "Saved revision",
+			prompt: "Replay these corrected requirements.",
+			model: { thinking: "high" },
+		});
+
+		await requireTool(fake, "workflow_transition").execute("done", {
+			stageId: "done",
+		});
+		await runAgentSettled(fake);
+		expect(fake.activeTools).not.toContain("workflow_get_stage");
+		expect(fake.activeTools).not.toContain("workflow_edit_stage");
+		await expect(
+			get.execute("completed-get", { stageId: "done" }),
+		).rejects.toThrow("no workflow is active");
+		await expect(
+			edit.execute("completed-edit", {
+				stageId: "done",
+				description: "Disallowed",
+				prompt: "Do not edit a completed workflow.",
+				model: { thinking: "medium" },
+			}),
+		).rejects.toThrow("no workflow is active");
+	});
+
+	/**
+	 * Proves invalid or unpersisted edits leave the active snapshot and runtime settings unchanged.
+	 * Input and expected output: unknown stages reject without append; append failure rolls back active-stage thinking.
+	 * Edge case: get and edit share the same unknown-stage diagnostic.
+	 * Dependencies: exact tool validation and atomic workflow model persistence.
+	 */
+	test("preserves active state when stage editing fails", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		await requireTool(fake, "workflow_create").execute(
+			"create",
+			createArguments(),
+		);
+		const get = requireTool(fake, "workflow_get_stage");
+		const edit = requireTool(fake, "workflow_edit_stage");
+		const appendedBeforeFailure = fake.appended.length;
+		await expect(
+			get.execute("missing-get", { stageId: "missing" }),
+		).rejects.toThrow("stage missing");
+		await expect(
+			edit.execute("missing-edit", {
+				stageId: "missing",
+				description: "Missing",
+				prompt: "This stage does not exist.",
+				model: { thinking: "high" },
+			}),
+		).rejects.toThrow("stage missing");
+		expect(fake.appended).toHaveLength(appendedBeforeFailure);
+
+		fake.appendError = new Error("append failed");
+		await expect(
+			edit.execute("failed-edit", {
+				stageId: "start",
+				description: "Unpersisted revision",
+				prompt: "This change must roll back.",
+				model: { thinking: "high" },
+			}),
+		).rejects.toThrow("append failed");
+		expect(fake.thinkingLevel).toBe("medium");
+		const current = (await get.execute("get-current", {
+			stageId: "start",
+		})) as { content: Array<{ text: string }> };
+		expect(JSON.parse(current.content[0]?.text ?? "null")).toMatchObject({
+			description: "Start",
+			prompt: "Start dynamic work",
+			model: { thinking: "medium" },
+		});
 	});
 
 	/**
@@ -1356,11 +1635,8 @@ describe("workflow extension lifecycle", () => {
 		await createSuite(validYaml());
 		const fake = await createFakePi();
 		await runLifecycle(fake, "session_start");
-		const activate = fake.tools[0];
-		const transition = fake.tools[1];
-		if (activate === undefined || transition === undefined) {
-			throw new Error("tools missing");
-		}
+		const activate = requireTool(fake, "workflow_activate");
+		const transition = requireTool(fake, "workflow_transition");
 		expect(
 			await activate.execute("call", { workflowId: "delivery" }),
 		).toMatchObject({
@@ -1381,11 +1657,8 @@ describe("workflow extension lifecycle", () => {
 		await createSuite(validYaml());
 		const fake = await createFakePi();
 		await runLifecycle(fake, "session_start");
-		const activate = fake.tools[0];
-		const transition = fake.tools[1];
-		if (activate === undefined || transition === undefined) {
-			throw new Error("tools missing");
-		}
+		const activate = requireTool(fake, "workflow_activate");
+		const transition = requireTool(fake, "workflow_transition");
 		await activate.execute("call", { workflowId: "delivery" });
 		await transition.execute("call", { stageId: "done" });
 		const entriesBeforeReactivation = [...fake.appended];

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -13,6 +13,7 @@ import {
 import { getSuiteExtensionDir } from "../../shared/agent-suite-storage";
 import {
 	isReasoningLevel,
+	REASONING_LEVELS,
 	type ReasoningLevel,
 } from "../../shared/reasoning-levels";
 import {
@@ -36,6 +37,8 @@ import {
 	resolveWorkflowAvailability,
 	WORKFLOW_ACTIVATE_TOOL,
 	WORKFLOW_CREATE_TOOL,
+	WORKFLOW_EDIT_STAGE_TOOL,
+	WORKFLOW_GET_STAGE_TOOL,
 	WORKFLOW_TRANSITION_TOOL,
 	type WorkflowAvailability,
 	type WorkflowToolName,
@@ -64,6 +67,7 @@ import {
 	renderWorkflowActivateCall,
 	renderWorkflowCreateCall,
 	renderWorkflowResult,
+	renderWorkflowStageCall,
 	renderWorkflowTransitionCall,
 	type WorkflowToolPresentationDetails,
 } from "./tool-rendering.ts";
@@ -71,6 +75,7 @@ import {
 	activateWorkflow,
 	completeWorkflow,
 	createWorkflow,
+	editWorkflowStage,
 	replayWorkflowStateWithWarnings,
 	transitionWorkflow,
 	validateCreatedWorkflowDefinition,
@@ -85,6 +90,8 @@ const WORKFLOW_STATE_ENTRY = "workflow-state";
 const WORKFLOW_TOOL_NAMES: ReadonlySet<string> = new Set([
 	WORKFLOW_CREATE_TOOL,
 	WORKFLOW_ACTIVATE_TOOL,
+	WORKFLOW_GET_STAGE_TOOL,
+	WORKFLOW_EDIT_STAGE_TOOL,
 	WORKFLOW_TRANSITION_TOOL,
 ]);
 const SUCCESS_RESULT = {
@@ -175,6 +182,39 @@ Completion criteria:
 					"Whether this stage may complete workflow. At least one stage must be true",
 			}),
 		),
+	},
+	{ additionalProperties: false },
+);
+
+/** Closed thinking-only model shape exposed to workflow_edit_stage validation. */
+const WORKFLOW_EDIT_STAGE_MODEL_SCHEMA = Type.Object(
+	{
+		thinking: StringEnum(REASONING_LEVELS, {
+			description: "Thinking level applied when this stage is active",
+		}),
+	},
+	{ additionalProperties: false },
+);
+
+/** Closed workflow_edit_stage boundary without immutable stage fields. */
+const WORKFLOW_EDIT_STAGE_SCHEMA = Type.Object(
+	{
+		stageId: technicalIdentifierSchema({
+			description: "Existing stage ID in current active workflow",
+			minLength: 1,
+			maxLength: 32,
+		}),
+		description: singleLineTextSchema({
+			description: "Replacement short single-line summary of stage outcome",
+			minLength: 1,
+			maxLength: 128,
+		}),
+		prompt: Type.String({
+			description: "Replacement instructions for this stage",
+			minLength: 10,
+			maxLength: 8192,
+		}),
+		model: WORKFLOW_EDIT_STAGE_MODEL_SCHEMA,
 	},
 	{ additionalProperties: false },
 );
@@ -988,6 +1028,8 @@ async function loadPromptsForInitialization(
 /** Registers all sequential definitions through the package presentation registry. */
 function registerWorkflowTools(options: RegisterWorkflowToolsOptions): void {
 	registerWorkflowActivateTool(options);
+	registerWorkflowGetStageTool(options);
+	registerWorkflowEditStageTool(options);
 	registerWorkflowTransitionTool(options);
 	registerWorkflowCreateTool(options);
 }
@@ -1144,6 +1186,180 @@ function registerWorkflowActivateTool(
 			return SUCCESS_RESULT;
 		},
 	});
+}
+
+/** Registers stage inspection for the current active dynamic workflow. */
+function registerWorkflowGetStageTool(
+	options: RegisterWorkflowToolsOptions,
+): void {
+	const { pi, prompts, getCatalog, getState } = options;
+	registerPackageTool(pi, {
+		name: WORKFLOW_GET_STAGE_TOOL,
+		label: "Get workflow stage",
+		description: prompts.getStageDescription,
+		parameters: Type.Object(
+			{
+				stageId: technicalIdentifierSchema({
+					description: "Existing stage ID in current active workflow",
+					minLength: 1,
+					maxLength: 32,
+				}),
+			},
+			{ additionalProperties: false },
+		),
+		executionMode: "sequential",
+		renderCall(args, theme, context) {
+			primeWorkflowRenderState(
+				context,
+				createWorkflowPresentationDetails(
+					WORKFLOW_GET_STAGE_TOOL,
+					args,
+					getCatalog(),
+					getState(),
+				),
+			);
+			return renderWorkflowStageCall(
+				WORKFLOW_GET_STAGE_TOOL,
+				args,
+				theme,
+				context,
+			);
+		},
+		renderResult: renderWorkflowResult,
+		async execute(...[_toolCallId, params]) {
+			const stageId = readExactStringArgument(params, "stageId");
+			const current = requireEditableWorkflow(options, WORKFLOW_GET_STAGE_TOOL);
+			const stage = current.workflow.stages.find(({ id }) => id === stageId);
+			if (stage === undefined) {
+				throw new Error(`stage ${stageId} does not exist in active workflow`);
+			}
+			return {
+				content: [
+					{
+						type: "text" as const,
+						text: JSON.stringify({
+							id: stage.id,
+							description: stage.description,
+							prompt: stage.prompt,
+							model: { thinking: stage.model?.thinking },
+							initial: stage.initial,
+							final: stage.final,
+						}),
+					},
+				],
+				details: {},
+			};
+		},
+	});
+}
+
+/** Registers atomic stage replacement for the current active dynamic workflow. */
+function registerWorkflowEditStageTool(
+	options: RegisterWorkflowToolsOptions,
+): void {
+	const { pi, prompts, runtime, getCatalog, getState, setState } = options;
+	registerPackageTool(pi, {
+		name: WORKFLOW_EDIT_STAGE_TOOL,
+		label: "Edit workflow stage",
+		description: prompts.editStageDescription,
+		parameters: WORKFLOW_EDIT_STAGE_SCHEMA,
+		executionMode: "sequential",
+		renderCall(args, theme, context) {
+			primeWorkflowRenderState(
+				context,
+				createWorkflowPresentationDetails(
+					WORKFLOW_EDIT_STAGE_TOOL,
+					args,
+					getCatalog(),
+					getState(),
+				),
+			);
+			return renderWorkflowStageCall(
+				WORKFLOW_EDIT_STAGE_TOOL,
+				args,
+				theme,
+				context,
+			);
+		},
+		renderResult: renderWorkflowResult,
+		async execute(...[_toolCallId, params]) {
+			const current = requireEditableWorkflow(
+				options,
+				WORKFLOW_EDIT_STAGE_TOOL,
+			);
+			const candidate = editWorkflowStage(
+				current,
+				params,
+				WORKFLOW_EDIT_STAGE_TOOL,
+			);
+			const stageId = readStringArgumentField(params, "stageId");
+			const stage = candidate.workflow.stages.find(({ id }) => id === stageId);
+			const thinking = stage?.model?.thinking;
+			if (stage === undefined || thinking === undefined) {
+				throw new Error(`stage ${stageId} does not exist in active workflow`);
+			}
+			const data = {
+				kind: "stage_edited",
+				stageId,
+				description: stage.description,
+				prompt: stage.prompt,
+				model: { thinking },
+			};
+			let persisted = candidate;
+			if (current.route.at(-1) === stageId) {
+				persisted = await commitWorkflowStateChange(
+					pi,
+					runtime,
+					candidate,
+					data,
+				);
+			} else {
+				pi.appendEntry(WORKFLOW_STATE_ENTRY, data);
+			}
+			setState(persisted);
+			return SUCCESS_RESULT;
+		},
+	});
+}
+
+/** Returns the current active dynamic workflow after standard capability checks. */
+function requireEditableWorkflow(
+	options: RegisterWorkflowToolsOptions,
+	toolName: typeof WORKFLOW_GET_STAGE_TOOL | typeof WORKFLOW_EDIT_STAGE_TOOL,
+): WorkflowState {
+	const current = options.getState();
+	if (current === undefined || current.status !== "active") {
+		throw new Error("no workflow is active");
+	}
+	if (current.source !== "dynamic") {
+		throw new Error(
+			"only workflows created through workflow_create can be inspected or edited",
+		);
+	}
+	const policy = options.getPolicy();
+	if (policy.kind === "error") {
+		throw new Error(policy.issue);
+	}
+	const availability = options.resolveAvailability();
+	if (
+		availability.projectedState !== current ||
+		!availability.availableToolNames.has(toolName)
+	) {
+		throw new Error(`workflow ${current.workflow.id} is not available`);
+	}
+	return current;
+}
+
+/** Reads one required string field after a domain validator accepted the object. */
+function readStringArgumentField(value: unknown, key: string): string {
+	const candidate =
+		typeof value === "object" && value !== null
+			? Reflect.get(value, key)
+			: undefined;
+	if (typeof candidate !== "string") {
+		throw new Error(`${key} must be a string`);
+	}
+	return candidate;
 }
 
 /** Registers transition behavior and its source-to-target presentation. */

--- a/pi-package/extensions/workflow/prompts/edit-stage-description.md
+++ b/pi-package/extensions/workflow/prompts/edit-stage-description.md
@@ -1,0 +1,6 @@
+**DESCRIPTION**: Replace stage parameters of current active workflow
+
+**RULES**:
+1. Use this tool to edit stage parameters instead of replacing whole workflow
+2. Read stage with workflow_get_stage before editing it
+3. Preserve returned values that do not need correction

--- a/pi-package/extensions/workflow/prompts/get-stage-description.md
+++ b/pi-package/extensions/workflow/prompts/get-stage-description.md
@@ -1,0 +1,5 @@
+**DESCRIPTION**: Read one stage from current active workflow
+
+**USE WHEN**:
+1. Current stage data is needed before deciding how to edit it
+2. Existing values are needed to build a complete workflow_edit_stage call

--- a/pi-package/extensions/workflow/tool-rendering.test.ts
+++ b/pi-package/extensions/workflow/tool-rendering.test.ts
@@ -168,7 +168,12 @@ async function applyToolResultHandlers(
 /** Executes one workflow tool through the same start/result event boundaries as Pi. */
 async function executeTool(
 	fixture: WorkflowRenderingFixture,
-	name: "workflow_activate" | "workflow_transition" | "workflow_create",
+	name:
+		| "workflow_activate"
+		| "workflow_get_stage"
+		| "workflow_edit_stage"
+		| "workflow_transition"
+		| "workflow_create",
 	args: Record<string, unknown>,
 ): Promise<ExecutedTool> {
 	const definition = fixture.tools.find((candidate) => candidate.name === name);
@@ -219,7 +224,12 @@ async function executeTool(
 /** Resolves the renderer used by the subagent session screen. */
 function resolveSessionDefinition(
 	fixture: WorkflowRenderingFixture,
-	name: "workflow_activate" | "workflow_transition" | "workflow_create",
+	name:
+		| "workflow_activate"
+		| "workflow_get_stage"
+		| "workflow_edit_stage"
+		| "workflow_transition"
+		| "workflow_create",
 ): ToolDefinition {
 	const resolution = createToolPresentationRegistry(
 		"/tmp",
@@ -468,6 +478,100 @@ describe("workflow semantic tool rendering", () => {
 		]);
 		expect(activeRejected.result.join("\n")).toContain("Error:");
 		expect(sessionRejected).toEqual(activeRejected);
+	});
+
+	/**
+	 * Proves stage inspection and editing use the same semantic rows in active and reconstructed session screens.
+	 * Input and expected output: get shows the saved stage; edit shows replacement fields in collapsed and expanded modes.
+	 * Edge case: successful TUI result rows hide model-visible get JSON and internal edit success JSON.
+	 * Dependencies: presentation events, package registry reconstruction, dynamic workflow state, and YAML rendering.
+	 */
+	test("renders stage get and edit identically in active and subagent screens", async () => {
+		await createWorkflowSuite();
+		const fixture = await createFixture();
+		await executeTool(
+			fixture,
+			"workflow_create",
+			createArguments("dynamic-delivery", "Dynamic delivery process"),
+		);
+		const get = await executeTool(fixture, "workflow_get_stage", {
+			stageId: "implementation",
+		});
+		const edit = await executeTool(fixture, "workflow_edit_stage", {
+			stageId: "implementation",
+			description: "Revised implementation",
+			prompt: "Follow the corrected implementation requirements.",
+			model: { thinking: "high" },
+		});
+
+		for (const execution of [get, edit]) {
+			const toolName = execution.definition.name as
+				| "workflow_get_stage"
+				| "workflow_edit_stage";
+			const active = renderCompletedTool(execution.definition, execution);
+			const session = renderCompletedTool(
+				resolveSessionDefinition(fixture, toolName),
+				execution,
+			);
+			expect(session).toEqual(active);
+			expect(active.result).toEqual([]);
+			expect(active.call.at(-1)).toBe(
+				`Content: ${keyText("app.tools.expand")} to show`,
+			);
+
+			const activeExpanded = renderCompletedTool(
+				execution.definition,
+				execution,
+				PLAIN_THEME,
+				100,
+				true,
+			);
+			const sessionExpanded = renderCompletedTool(
+				resolveSessionDefinition(fixture, toolName),
+				execution,
+				PLAIN_THEME,
+				100,
+				true,
+			);
+			expect(sessionExpanded).toEqual(activeExpanded);
+			expect(activeExpanded.result).toEqual([]);
+			expect(activeExpanded.call).toContain("--- Stage ---");
+			expect(activeExpanded.call).toContain("--- Content ---");
+		}
+
+		expect(renderCompletedTool(get.definition, get).call).toContain(
+			"Stage: implementation · Implementation stage",
+		);
+		expect(renderCompletedTool(edit.definition, edit).call).toContain(
+			"Stage: implementation · Revised implementation",
+		);
+		expect(
+			renderCompletedTool(
+				get.definition,
+				get,
+				PLAIN_THEME,
+				100,
+				true,
+			).call.join("\n"),
+		).toContain("prompt: Implement the change");
+		expect(
+			renderCompletedTool(
+				edit.definition,
+				edit,
+				PLAIN_THEME,
+				100,
+				true,
+			).call.join("\n"),
+		).toContain("prompt: Follow the corrected implementation requirements.");
+		expect(get.result.content).toEqual([
+			{
+				type: "text",
+				text: '{"id":"implementation","description":"Implementation stage","prompt":"Implement the change","model":{"thinking":"medium"},"initial":true,"final":false}',
+			},
+		]);
+		expect(edit.result.content).toEqual([
+			{ type: "text", text: '{"success":true}' },
+		]);
 	});
 
 	/** Proves the transition snapshot keeps the source stage after state mutation. */

--- a/pi-package/extensions/workflow/tool-rendering.ts
+++ b/pi-package/extensions/workflow/tool-rendering.ts
@@ -44,6 +44,16 @@ interface WorkflowContent {
 	readonly transitions: readonly unknown[];
 }
 
+/** Contains the stage fields exposed by get and accepted by edit. */
+interface WorkflowStageContent {
+	readonly id: string;
+	readonly description: string;
+	readonly prompt: string;
+	readonly model: Readonly<Record<string, unknown>>;
+	readonly initial?: boolean;
+	readonly final?: boolean;
+}
+
 /** Persists creation identity supplied before validation or state replacement. */
 interface WorkflowCreatePresentation {
 	readonly presentationKind: typeof PRESENTATION_KIND;
@@ -67,10 +77,19 @@ interface WorkflowTransitionPresentation {
 	readonly to: WorkflowPresentationReference;
 }
 
+/** Persists one stage and its model-visible editable content. */
+interface WorkflowStagePresentation {
+	readonly presentationKind: typeof PRESENTATION_KIND;
+	readonly toolName: "workflow_get_stage" | "workflow_edit_stage";
+	readonly stage: WorkflowPresentationReference;
+	readonly content?: WorkflowStageContent;
+}
+
 export type WorkflowToolPresentationDetails =
 	| WorkflowCreatePresentation
 	| WorkflowActivatePresentation
-	| WorkflowTransitionPresentation;
+	| WorkflowTransitionPresentation
+	| WorkflowStagePresentation;
 
 /** Stores presentation evidence shared by one call/result renderer pair. */
 interface WorkflowRenderState {
@@ -107,6 +126,9 @@ export function createWorkflowPresentationDetails(
 	}
 	if (toolName === "workflow_transition") {
 		return createWorkflowTransitionPresentation(args, state);
+	}
+	if (toolName === "workflow_get_stage" || toolName === "workflow_edit_stage") {
+		return createWorkflowStagePresentation(toolName, args, state);
 	}
 	return undefined;
 }
@@ -178,6 +200,77 @@ function createWorkflowTransitionPresentation(
 	};
 }
 
+/** Captures stage content from saved state for get or replacement arguments for edit. */
+function createWorkflowStagePresentation(
+	toolName: "workflow_get_stage" | "workflow_edit_stage",
+	args: unknown,
+	state: WorkflowState | undefined,
+): WorkflowStagePresentation | undefined {
+	const stageId = readInputString(args, "stageId");
+	if (stageId === undefined) {
+		return undefined;
+	}
+	const savedStage = state?.workflow.stages.find(({ id }) => id === stageId);
+	const description =
+		toolName === "workflow_edit_stage"
+			? readInputString(args, "description")
+			: savedStage?.description;
+	let content: WorkflowStageContent | undefined;
+	if (toolName === "workflow_edit_stage") {
+		content = createEditedStageContent(
+			args,
+			savedStage?.initial,
+			savedStage?.final,
+		);
+	} else if (savedStage !== undefined) {
+		content = {
+			id: savedStage.id,
+			description: savedStage.description,
+			prompt: savedStage.prompt,
+			model: { thinking: savedStage.model?.thinking },
+			initial: savedStage.initial,
+			final: savedStage.final,
+		};
+	}
+	return {
+		presentationKind: PRESENTATION_KIND,
+		toolName,
+		stage: createReference(stageId, description),
+		...(content === undefined ? {} : { content }),
+	};
+}
+
+/** Reads the closed editable stage fields without inventing immutable flags. */
+function createEditedStageContent(
+	args: unknown,
+	initial: boolean | undefined,
+	final: boolean | undefined,
+): WorkflowStageContent | undefined {
+	if (!isRecord(args) || !isRecord(args["model"])) {
+		return undefined;
+	}
+	const id = readInputString(args, "stageId");
+	const description = readInputString(args, "description");
+	const prompt = readInputString(args, "prompt");
+	const thinking = readInputString(args["model"], "thinking");
+	if (
+		id === undefined ||
+		description === undefined ||
+		prompt === undefined ||
+		thinking === undefined
+	) {
+		return undefined;
+	}
+	return {
+		id,
+		description,
+		prompt,
+		model: { thinking },
+		...(initial === undefined ? {} : { initial }),
+		...(final === undefined ? {} : { final }),
+	};
+}
+
 /** Keeps live pending calls semantic until persisted result evidence is available. */
 export function primeWorkflowRenderState(
 	context: WorkflowToolRenderContext,
@@ -234,10 +327,14 @@ export function renderWorkflowActivateCall(
 
 /** Shares bounded workflow-reference rows between create and activate calls. */
 function renderWorkflowReferenceCall(options: {
-	readonly toolName: "workflow_create" | "workflow_activate";
+	readonly toolName:
+		| "workflow_create"
+		| "workflow_activate"
+		| "workflow_get_stage"
+		| "workflow_edit_stage";
 	readonly workflow: WorkflowPresentationReference | undefined;
 	readonly stage: WorkflowPresentationReference | undefined;
-	readonly content?: WorkflowContent | undefined;
+	readonly content?: WorkflowContent | WorkflowStageContent | undefined;
 	readonly theme: Theme;
 	readonly context: WorkflowToolRenderContext;
 }): Component {
@@ -307,6 +404,27 @@ export function renderWorkflowTransitionCall(
 	});
 }
 
+/** Renders one stage inspection or edit with bounded semantic content. */
+export function renderWorkflowStageCall(
+	toolName: "workflow_get_stage" | "workflow_edit_stage",
+	args: unknown,
+	theme: Theme,
+	context: WorkflowToolRenderContext,
+): Component {
+	const presentation = readStagePresentation(context, toolName);
+	const fallback = createWorkflowStagePresentation(toolName, args, undefined);
+	return renderWorkflowReferenceCall({
+		toolName,
+		workflow: undefined,
+		stage: presentation?.stage ?? fallback?.stage,
+		content:
+			presentation?.content ??
+			(context.argsComplete ? fallback?.content : undefined),
+		theme,
+		context,
+	});
+}
+
 /** Restores persisted evidence and hides successful internal result content. */
 export function renderWorkflowResult(
 	result: AgentToolResult<unknown>,
@@ -344,6 +462,12 @@ function parseWorkflowPresentationDetails(
 	}
 	if (value["toolName"] === "workflow_activate") {
 		return parseWorkflowReferencePresentation(value, "workflow_activate");
+	}
+	if (
+		value["toolName"] === "workflow_get_stage" ||
+		value["toolName"] === "workflow_edit_stage"
+	) {
+		return parseStagePresentation(value, value["toolName"]);
 	}
 	return value["toolName"] === "workflow_transition"
 		? parseTransitionPresentation(value)
@@ -389,6 +513,58 @@ function parseTransitionPresentation(
 	};
 }
 
+/** Parses one persisted stage reference and its optional content. */
+function parseStagePresentation(
+	value: Record<string, unknown>,
+	toolName: "workflow_get_stage" | "workflow_edit_stage",
+): WorkflowStagePresentation | undefined {
+	const stage = parseReference(value["stage"]);
+	const content = parseStageContent(value["content"]);
+	if (
+		stage === undefined ||
+		(value["content"] !== undefined && content === undefined)
+	) {
+		return undefined;
+	}
+	return {
+		presentationKind: PRESENTATION_KIND,
+		toolName,
+		stage,
+		...(content === undefined ? {} : { content }),
+	};
+}
+
+/** Parses persisted stage content before rendering it as YAML. */
+function parseStageContent(value: unknown): WorkflowStageContent | undefined {
+	if (!isRecord(value) || !isRecord(value["model"])) {
+		return undefined;
+	}
+	const id = value["id"];
+	const description = value["description"];
+	const prompt = value["prompt"];
+	const thinking = value["model"]["thinking"];
+	const initial = value["initial"];
+	const final = value["final"];
+	if (
+		!isNonEmptyString(id) ||
+		!isNonEmptyString(description) ||
+		!isNonEmptyString(prompt) ||
+		!isNonEmptyString(thinking) ||
+		(initial !== undefined && typeof initial !== "boolean") ||
+		(final !== undefined && typeof final !== "boolean")
+	) {
+		return undefined;
+	}
+	return {
+		id,
+		description,
+		prompt,
+		model: { thinking },
+		...(initial === undefined ? {} : { initial }),
+		...(final === undefined ? {} : { final }),
+	};
+}
+
 /** Reads creation evidence from the shared row state. */
 function readCreatePresentation(
 	context: WorkflowToolRenderContext,
@@ -419,6 +595,15 @@ function readTransitionPresentation(
 		: undefined;
 }
 
+/** Reads stage evidence from the shared row state. */
+function readStagePresentation(
+	context: WorkflowToolRenderContext,
+	toolName: "workflow_get_stage" | "workflow_edit_stage",
+): WorkflowStagePresentation | undefined {
+	const presentation = (context.state as WorkflowRenderState).presentation;
+	return presentation?.toolName === toolName ? presentation : undefined;
+}
+
 /** Renders one standalone bright workflow tool name. */
 function renderToolName(toolName: string, width: number, theme: Theme): string {
 	return theme.fg("toolTitle", theme.bold(sliceTextByWidth(toolName, width)));
@@ -426,7 +611,7 @@ function renderToolName(toolName: string, width: number, theme: Theme): string {
 
 /** Renders catalog-shaped workflow YAML or its configurable expansion hint. */
 function renderWorkflowContent(options: {
-	readonly content: WorkflowContent;
+	readonly content: WorkflowContent | WorkflowStageContent;
 	readonly expanded: boolean;
 	readonly width: number;
 	readonly theme: Theme;
@@ -548,7 +733,7 @@ function parseReference(
 
 /** Selects YAML serialization that fits without display-layer line wrapping. */
 function serializeWorkflowContent(
-	content: WorkflowContent,
+	content: WorkflowContent | WorkflowStageContent,
 	width: number,
 ): readonly string[] {
 	const renderWidth = Math.max(1, Math.floor(width));

--- a/pi-package/extensions/workflow/workflow.test.ts
+++ b/pi-package/extensions/workflow/workflow.test.ts
@@ -674,6 +674,140 @@ describe("workflow state", () => {
 		).toThrow("workflow-state");
 	});
 
+	/**
+	 * Proves a persisted stage edit changes the replayed session snapshot without replacing workflow identity or graph state.
+	 * Input and expected output: one active snapshot followed by a stage_edited entry updates description, prompt, and thinking.
+	 * Edge cases: editing a non-active stage preserves its id, flags, triggers, route, transitions, source, and restoration settings.
+	 * Dependencies: saved workflow validation and ordered custom-entry replay.
+	 */
+	test("replays persisted stage edits into the workflow snapshot", () => {
+		const workflow = validateCreatedWorkflowDefinition(
+			{ id: "dynamic-delivery", ...validCreatedValue() },
+			"workflow_create",
+		);
+		const replayed = replayWorkflowState([
+			{
+				type: "custom",
+				customType: "workflow-state",
+				data: {
+					kind: "created",
+					workflow,
+					route: ["a"],
+					restoration: {
+						modelId: "openai/current-model",
+						thinking: "medium",
+					},
+				},
+			},
+			{
+				type: "custom",
+				customType: "workflow-state",
+				data: {
+					kind: "stage_edited",
+					stageId: "b",
+					description: "Revised B",
+					prompt: "Use the revised requirements.",
+					model: { thinking: "xhigh" },
+				},
+			},
+		]);
+
+		expect(replayed).toMatchObject({
+			source: "dynamic",
+			route: ["a"],
+			status: "active",
+			restoration: {
+				modelId: "openai/current-model",
+				thinking: "medium",
+			},
+		});
+		expect(replayed?.workflow.stages[1]).toEqual({
+			id: "b",
+			description: "Revised B",
+			prompt: "Use the revised requirements.",
+			triggers: [
+				{ type: "local_knowledge_accumulation" },
+				{ type: "global_knowledge_accumulation" },
+				{ type: "local_knowledge_accumulation" },
+			],
+			initial: false,
+			final: false,
+			model: { thinking: "xhigh" },
+		});
+		expect(replayed?.workflow.transitions).toEqual(workflow.transitions);
+	});
+
+	/**
+	 * Proves malformed persisted edits cannot silently corrupt a saved workflow snapshot.
+	 * Input and expected output: an edit before activation and an unknown stage both reject replay.
+	 * Edge cases: immutable flags and extra fields are rejected by the closed entry shape.
+	 * Dependencies: stage edit replay validation only.
+	 */
+	test("rejects invalid persisted stage edits", () => {
+		const catalogWorkflow = validateWorkflowDefinition(
+			"delivery",
+			validValue(),
+			SOURCE,
+		);
+		const dynamicWorkflow = validateCreatedWorkflowDefinition(
+			{ id: "dynamic-delivery", ...validCreatedValue() },
+			"workflow_create",
+		);
+		const edit = {
+			type: "custom",
+			customType: "workflow-state",
+			data: {
+				kind: "stage_edited",
+				stageId: "missing",
+				description: "Revised",
+				prompt: "Use the revised requirements.",
+				model: { thinking: "high" },
+			},
+		};
+		const restoration = {
+			modelId: "openai/current-model",
+			thinking: "medium",
+		};
+		const activation = {
+			type: "custom",
+			customType: "workflow-state",
+			data: {
+				kind: "activated",
+				workflow: catalogWorkflow,
+				route: ["a"],
+				restoration,
+			},
+		};
+		const creation = {
+			type: "custom",
+			customType: "workflow-state",
+			data: {
+				kind: "created",
+				workflow: dynamicWorkflow,
+				route: ["a"],
+				restoration,
+			},
+		};
+
+		expect(() => replayWorkflowState([edit])).toThrow("active snapshot");
+		expect(() =>
+			replayWorkflowState([
+				activation,
+				{ ...edit, data: { ...edit.data, stageId: "b" } },
+			]),
+		).toThrow("workflow_create");
+		expect(() => replayWorkflowState([creation, edit])).toThrow("missing");
+		expect(() =>
+			replayWorkflowState([
+				creation,
+				{
+					...edit,
+					data: { ...edit.data, stageId: "b", initial: true },
+				},
+			]),
+		).toThrow("unsupported key");
+	});
+
 	/** Proves pre-restoration workflow chains are ignored instead of blocking session replay. */
 	test("ignores legacy workflow state chains", () => {
 		const workflow = validateWorkflowDefinition(

--- a/pi-package/extensions/workflow/workflow.ts
+++ b/pi-package/extensions/workflow/workflow.ts
@@ -100,6 +100,7 @@ const CREATED_STAGE_KEYS = new Set([
 	"model",
 ]);
 const CREATED_MODEL_KEYS = new Set(["thinking"]);
+const STAGE_EDIT_KEYS = new Set(["stageId", "description", "prompt", "model"]);
 const TRIGGER_KEYS = new Set(["type"]);
 const TRANSITION_KEYS = new Set(["from", "to", "type"]);
 const SAVED_WORKFLOW_KEYS = new Set(["id", ...ROOT_KEYS]);
@@ -218,6 +219,60 @@ export function transitionWorkflow(
 		status: "active",
 		route: state.route.slice(0, targetIndex + 1),
 	};
+}
+
+/** Replaces only the editable fields of one stage in the current active workflow. */
+export function editWorkflowStage(
+	state: WorkflowState,
+	value: unknown,
+	source: string,
+): WorkflowState {
+	if (state.status !== "active") {
+		throw new Error("no workflow is active");
+	}
+	if (state.source !== "dynamic") {
+		throw new Error(
+			"only workflows created through workflow_create can be inspected or edited",
+		);
+	}
+	try {
+		const root = requireObject(value, "stage edit", STAGE_EDIT_KEYS);
+		const stageId = readTechnicalIdentifier(root, "stageId");
+		const description = readSingleLineText(root, "description");
+		const prompt = readPromptText(root, "prompt");
+		const model = requireObject(
+			Reflect.get(root, "model"),
+			"model",
+			CREATED_MODEL_KEYS,
+		);
+		const thinking = Reflect.get(model, "thinking");
+		if (!isReasoningLevel(thinking)) {
+			throw new Error("model.thinking is invalid");
+		}
+		const stageIndex = state.workflow.stages.findIndex(
+			(stage) => stage.id === stageId,
+		);
+		if (stageIndex < 0) {
+			throw new Error(`stage ${stageId} does not exist in active workflow`);
+		}
+		const stage = state.workflow.stages[stageIndex];
+		if (stage === undefined) {
+			throw new Error(`stage ${stageId} does not exist in active workflow`);
+		}
+		const stages = [...state.workflow.stages];
+		stages[stageIndex] = {
+			...stage,
+			description,
+			prompt,
+			model: { ...stage.model, thinking },
+		};
+		return {
+			...state,
+			workflow: { ...state.workflow, stages },
+		};
+	} catch (error) {
+		throw new Error(`${source}: ${errorMessage(error)}`);
+	}
 }
 
 /** Derives every stage status from route membership and the active route tail. */
@@ -355,6 +410,9 @@ function replayWorkflowStateEntry(
 			...(restoration !== undefined ? { restoration } : {}),
 		};
 	}
+	if (kind === "stage_edited") {
+		return replayWorkflowStageEdit(state, data);
+	}
 	if (kind === "transitioned") {
 		assertExactKeys(data, new Set(["kind", "route"]), "transitioned entry");
 		if (state === undefined) {
@@ -379,7 +437,32 @@ function replayWorkflowStateEntry(
 		return completeWorkflow(completed);
 	}
 	throw new Error(
-		"entry kind must be activated, created, transitioned, or completed",
+		"entry kind must be activated, created, stage_edited, transitioned, or completed",
+	);
+}
+
+/** Applies one persisted edit only to an active dynamic workflow snapshot. */
+function replayWorkflowStageEdit(
+	state: WorkflowState | undefined,
+	data: Record<string, unknown>,
+): WorkflowState {
+	assertExactKeys(
+		data,
+		new Set(["kind", "stageId", "description", "prompt", "model"]),
+		"stage_edited entry",
+	);
+	if (state === undefined) {
+		throw new Error("stage_edited entry has no active snapshot");
+	}
+	return editWorkflowStage(
+		state,
+		{
+			stageId: Reflect.get(data, "stageId"),
+			description: Reflect.get(data, "description"),
+			prompt: Reflect.get(data, "prompt"),
+			model: Reflect.get(data, "model"),
+		},
+		"stage_edited entry",
 	);
 }
 

--- a/pi-package/shared/child-rpc-completion.test.ts
+++ b/pi-package/shared/child-rpc-completion.test.ts
@@ -214,6 +214,32 @@ describe("child RPC prompt completion", () => {
 		});
 	});
 
+	test("accepts a completed over-window answer after successful compaction without retry", () => {
+		// Purpose: successful overflow compaction must not replace an already completed assistant answer with a false failure.
+		// Input and expected output: an over-window stop response and successful non-retrying compaction succeed on agent_settled.
+		// Edge case: Pi sets willRetry false because a completed assistant response cannot be continued.
+		// Dependencies: pure shared completion state and Pi's documented compaction_end result contract.
+		// Arrange
+		const completion = createChildRpcPromptCompletion(BASE_FACTS);
+		const completed = overflowMessage();
+		completion.handleSessionEvent(messageEnd(completed));
+		completion.handleSessionEvent(agentEnd());
+
+		// Act
+		const compactionEnd = completion.handleSessionEvent({
+			type: "compaction_end",
+			reason: "overflow",
+			result: { summary: "compacted" },
+			aborted: false,
+			willRetry: false,
+		});
+		const settled = completion.handleSessionEvent(agentSettled());
+
+		// Assert
+		expect(compactionEnd).toEqual({ kind: "wait" });
+		expect(settled).toEqual({ kind: "success", message: completed });
+	});
+
 	test("accepts a successful post-compaction answer on agent_settled", () => {
 		// Purpose: successful overflow recovery must replace the provisional overflow failure.
 		// Input and expected output: overflow, compaction retry, and recovered answer remain pending until agent_settled succeeds.

--- a/pi-package/shared/child-rpc-completion.ts
+++ b/pi-package/shared/child-rpc-completion.ts
@@ -120,6 +120,10 @@ class ChildRpcPromptCompletionState implements ChildRpcPromptCompletion {
 		if (event["reason"] !== "overflow" || event["willRetry"] === true) {
 			return this.wait();
 		}
+		if (event["result"] !== undefined && event["aborted"] !== true) {
+			this.pendingFailureReason = undefined;
+			return this.wait();
+		}
 
 		this.pendingFailureReason = readEventError(
 			event,

--- a/test/integration/workflow.test.ts
+++ b/test/integration/workflow.test.ts
@@ -111,6 +111,8 @@ test("workflow entry activates a configured workflow and projects its initial st
 	await lifecycle({ type: "session_start" }, context);
 	expect(tools.map(({ name }) => name)).toEqual([
 		"workflow_activate",
+		"workflow_get_stage",
+		"workflow_edit_stage",
 		"workflow_transition",
 		"workflow_create",
 	]);


### PR DESCRIPTION
## Problem
The workflow could be created dynamically, but if one stage had wrong instructions, the only fix was to replace the whole workflow and reset progress. There was no safe way to check one stage and fix only that part.

## Solution
Added two new sequential workflow tools for the active dynamic workflow only:
- `workflow_get_stage` returns one stage (`id`, `description`, `prompt`, `model.thinking`, `initial`, `final`).
- `workflow_edit_stage` updates only `description`, `prompt`, and `model.thinking` on one stage.

The change now includes availability checks, closed schemas, execution-time checks, persistence with a `stage_edited` session entry, session replay handling, and presentation updates so tools, status, and provider context stay consistent. Edits are blocked for catalog workflows, unknown stages, completed workflows, and invalid inputs. Editing an active stage applies thinking immediately; non-active edits are stored and applied when reached.

### Testing
- Added/updated unit and integration tests for availability, prompt config loading, tool schemas, runtime behavior, replay validation, and rendering:
  - `pi-package/extensions/workflow/availability.test.ts`
  - `pi-package/extensions/workflow/index.test.ts`
  - `pi-package/extensions/workflow/tool-rendering.test.ts`
  - `pi-package/extensions/workflow/workflow.test.ts`
  - `pi-package/extensions/workflow/config.test.ts`
  - `pi-package/extensions/workflow/context.test.ts`
  - `test/integration/workflow.test.ts`
- Added feature spec doc: `docs/specs/features/workflow-edit-stage/technical-solution.md` and updated docs: `docs/extensions/workflow.md`.