### PR TITLE
Fix workflow stage semantic rendering in tui

### DIFF
--- a/docs/extensions/workflow.md
+++ b/docs/extensions/workflow.md
@@ -223,13 +223,17 @@ Content: ctrl+o to show
 workflow_activate
 Workflow: delivery · Software delivery
 
-workflow_get_stage
-Stage: implementation · Implement the approved change
-Content: ctrl+o to show
+workflow_get_stage: implementation
+Description: Implement the approved change
+Prompt: Implement and test the change
+Thinking: medium
+Initial: true
+... (1 more line, 5 total, ctrl+o to expand)
 
-workflow_edit_stage
-Stage: implementation · Implement the corrected change
-Content: ctrl+o to show
+workflow_edit_stage: implementation
+Description: Implement the approved change -> Implement the corrected change
+Prompt: Implement and test the change -> Follow the corrected requirements.
+Thinking: medium -> high
 
 workflow_transition
 From: implementation · Implement the approved change
@@ -265,7 +269,7 @@ transitions:
     type: advance
 ```
 
-Collapsed mode wraps references to the available width and shows at most four content rows per reference. Expanded mode shows complete references, creation YAML, and stage YAML for `workflow_get_stage` and `workflow_edit_stage`. A failed call keeps the identity captured before execution and adds `Error: <message>`. Workflow and stage references are stored in result `details`. Expanded creation YAML is reconstructed from the stored tool-call arguments. These two stored sources keep the active screen and subagent session screen consistent.
+Each stage attribute starts a separate semantic row. Collapsed mode normalizes source line breaks inside each attribute to spaces, wraps its value to the available width, and shows at most four content rows before Pi's expansion hint. Expanded mode renders every displayed attribute as a `--- Name ---` section and preserves source line breaks. An expanded `workflow_edit_stage` section contains the old value, a separate `->` row, and the new value. The edit tool shows only changed attributes; an edit with equal values shows `No changes.`. Collapsed attribute labels use Pi's bold `toolTitle` color, values use `toolOutput`, expanded section headers use `muted`, and change arrows use `success`. A failed call keeps the identity captured before execution and adds `Error: <message>`. Workflow and stage presentation data is stored in result `details`. Expanded creation YAML is reconstructed from the stored tool-call arguments. These stored sources keep the active screen and subagent session screen consistent.
 
 ## Provider context
 

--- a/pi-package/extensions/workflow/tool-rendering.test.ts
+++ b/pi-package/extensions/workflow/tool-rendering.test.ts
@@ -504,65 +504,162 @@ describe("workflow semantic tool rendering", () => {
 			model: { thinking: "high" },
 		});
 
-		for (const execution of [get, edit]) {
-			const toolName = execution.definition.name as
-				| "workflow_get_stage"
-				| "workflow_edit_stage";
-			const active = renderCompletedTool(execution.definition, execution);
-			const session = renderCompletedTool(
-				resolveSessionDefinition(fixture, toolName),
-				execution,
-			);
-			expect(session).toEqual(active);
-			expect(active.result).toEqual([]);
-			expect(active.call.at(-1)).toBe(
-				`Content: ${keyText("app.tools.expand")} to show`,
-			);
-
-			const activeExpanded = renderCompletedTool(
-				execution.definition,
-				execution,
-				PLAIN_THEME,
-				100,
-				true,
-			);
-			const sessionExpanded = renderCompletedTool(
-				resolveSessionDefinition(fixture, toolName),
-				execution,
-				PLAIN_THEME,
-				100,
-				true,
-			);
-			expect(sessionExpanded).toEqual(activeExpanded);
-			expect(activeExpanded.result).toEqual([]);
-			expect(activeExpanded.call).toContain("--- Stage ---");
-			expect(activeExpanded.call).toContain("--- Content ---");
-		}
-
-		expect(renderCompletedTool(get.definition, get).call).toContain(
-			"Stage: implementation · Implementation stage",
+		const getCollapsed = renderCompletedTool(
+			get.definition,
+			get,
+			PLAIN_THEME,
+			500,
 		);
-		expect(renderCompletedTool(edit.definition, edit).call).toContain(
-			"Stage: implementation · Revised implementation",
+		const getSessionCollapsed = renderCompletedTool(
+			resolveSessionDefinition(fixture, "workflow_get_stage"),
+			get,
+			PLAIN_THEME,
+			500,
+		);
+		expect(getSessionCollapsed).toEqual(getCollapsed);
+		expect(getCollapsed.call.slice(0, -1)).toEqual([
+			"workflow_get_stage: implementation",
+			"Description: Implementation stage",
+			"Prompt: Implement the change",
+			"Thinking: medium",
+			"Initial: true",
+		]);
+		expect(getCollapsed.call.at(-1)).toMatch(HIDDEN_LINE_HINT);
+		expect(getCollapsed.result).toEqual([]);
+
+		const getExpanded = renderCompletedTool(
+			get.definition,
+			get,
+			PLAIN_THEME,
+			100,
+			true,
 		);
 		expect(
 			renderCompletedTool(
-				get.definition,
+				resolveSessionDefinition(fixture, "workflow_get_stage"),
 				get,
 				PLAIN_THEME,
 				100,
 				true,
-			).call.join("\n"),
-		).toContain("prompt: Implement the change");
+			),
+		).toEqual(getExpanded);
+		expect(getExpanded).toEqual({
+			call: [
+				"workflow_get_stage: implementation",
+				"--- Description ---",
+				"Implementation stage",
+				"--- Prompt ---",
+				"Implement the change",
+				"--- Thinking ---",
+				"medium",
+				"--- Initial ---",
+				"true",
+				"--- Final ---",
+				"false",
+			],
+			result: [],
+		});
+
+		const editCollapsed = renderCompletedTool(
+			edit.definition,
+			edit,
+			PLAIN_THEME,
+			500,
+		);
 		expect(
 			renderCompletedTool(
-				edit.definition,
+				resolveSessionDefinition(fixture, "workflow_edit_stage"),
+				edit,
+				PLAIN_THEME,
+				500,
+			),
+		).toEqual(editCollapsed);
+		expect(editCollapsed).toEqual({
+			call: [
+				"workflow_edit_stage: implementation",
+				"Description: Implementation stage -> Revised implementation",
+				"Prompt: Implement the change -> Follow the corrected implementation requirements.",
+				"Thinking: medium -> high",
+			],
+			result: [],
+		});
+		const styledEdit = renderCompletedTool(
+			edit.definition,
+			edit,
+			MARKED_THEME,
+			500,
+		);
+		expect(styledEdit.call[1]).toBe(
+			"<toolTitle><bold>Description:</bold></toolTitle><toolOutput> Implementation stage </toolOutput><success>-></success><toolOutput> Revised implementation</toolOutput>",
+		);
+		expect(styledEdit.call[2]).toContain(
+			"<toolTitle><bold>Prompt:</bold></toolTitle>",
+		);
+
+		const editExpanded = renderCompletedTool(
+			edit.definition,
+			edit,
+			PLAIN_THEME,
+			100,
+			true,
+		);
+		expect(
+			renderCompletedTool(
+				resolveSessionDefinition(fixture, "workflow_edit_stage"),
 				edit,
 				PLAIN_THEME,
 				100,
 				true,
-			).call.join("\n"),
-		).toContain("prompt: Follow the corrected implementation requirements.");
+			),
+		).toEqual(editExpanded);
+		expect(editExpanded).toEqual({
+			call: [
+				"workflow_edit_stage: implementation",
+				"--- Description ---",
+				"Implementation stage",
+				"->",
+				"Revised implementation",
+				"--- Prompt ---",
+				"Implement the change",
+				"->",
+				"Follow the corrected implementation requirements.",
+				"--- Thinking ---",
+				"medium",
+				"->",
+				"high",
+			],
+			result: [],
+		});
+		const styledExpandedEdit = renderCompletedTool(
+			edit.definition,
+			edit,
+			MARKED_THEME,
+			100,
+			true,
+		);
+		expect(styledExpandedEdit.call[1]).toBe(
+			"<muted>--- Description ---</muted>",
+		);
+		expect(styledExpandedEdit.call[3]).toBe("<success>-></success>");
+
+		const unchanged = await executeTool(fixture, "workflow_edit_stage", {
+			stageId: "implementation",
+			description: "Revised implementation",
+			prompt: "Follow the corrected implementation requirements.",
+			model: { thinking: "high" },
+		});
+		expect(
+			renderCompletedTool(
+				unchanged.definition,
+				unchanged,
+				PLAIN_THEME,
+				100,
+				true,
+			),
+		).toEqual({
+			call: ["workflow_edit_stage: implementation", "No changes."],
+			result: [],
+		});
 		expect(get.result.content).toEqual([
 			{
 				type: "text",
@@ -571,6 +668,80 @@ describe("workflow semantic tool rendering", () => {
 		]);
 		expect(edit.result.content).toEqual([
 			{ type: "text", text: '{"success":true}' },
+		]);
+	});
+
+	/** Proves multiline stage values retain labels and unambiguous edit boundaries. */
+	test("renders multiline stage values as labeled semantic blocks", async () => {
+		await createWorkflowSuite();
+		const fixture = await createFixture();
+		const args = createArguments(
+			"dynamic-delivery",
+			"Dynamic delivery process",
+		);
+		const implementation = (args["stages"] as Record<string, unknown>[])[0];
+		if (implementation === undefined) {
+			throw new Error("implementation stage fixture is missing");
+		}
+		implementation["prompt"] = "Inspect current state.\nImplement the change.";
+		await executeTool(fixture, "workflow_create", args);
+		const get = await executeTool(fixture, "workflow_get_stage", {
+			stageId: "implementation",
+		});
+		const edit = await executeTool(fixture, "workflow_edit_stage", {
+			stageId: "implementation",
+			description: "Implementation stage",
+			prompt: "Read corrected requirements.\nImplement the corrected change.",
+			model: { thinking: "medium" },
+		});
+
+		const getExpanded = renderCompletedTool(
+			get.definition,
+			get,
+			PLAIN_THEME,
+			100,
+			true,
+		);
+		expect(getExpanded.call).toContain("--- Prompt ---");
+		expect(getExpanded.call).toContain("Inspect current state.");
+		expect(getExpanded.call).toContain("Implement the change.");
+
+		const editExpanded = renderCompletedTool(
+			edit.definition,
+			edit,
+			PLAIN_THEME,
+			100,
+			true,
+		);
+		expect(editExpanded.call).toEqual([
+			"workflow_edit_stage: implementation",
+			"--- Prompt ---",
+			"Inspect current state.",
+			"Implement the change.",
+			"->",
+			"Read corrected requirements.",
+			"Implement the corrected change.",
+		]);
+
+		const getCollapsed = renderCompletedTool(
+			get.definition,
+			get,
+			PLAIN_THEME,
+			500,
+		);
+		expect(getCollapsed.call).toContain(
+			"Prompt: Inspect current state. Implement the change.",
+		);
+		expect(getCollapsed.call).not.toContain("  Inspect current state.");
+		const editCollapsed = renderCompletedTool(
+			edit.definition,
+			edit,
+			PLAIN_THEME,
+			500,
+		);
+		expect(editCollapsed.call).toEqual([
+			"workflow_edit_stage: implementation",
+			"Prompt: Inspect current state. Implement the change. -> Read corrected requirements. Implement the corrected change.",
 		]);
 	});
 
@@ -817,6 +988,29 @@ describe("workflow semantic tool rendering", () => {
 			20,
 			true,
 		);
+		const stageGet = await executeTool(fixture, "workflow_get_stage", {
+			stageId: "implementation",
+		});
+		const narrowStageGet = renderCompletedTool(
+			resolveSessionDefinition(fixture, "workflow_get_stage"),
+			stageGet,
+			PLAIN_THEME,
+			20,
+			true,
+		);
+		const stageEdit = await executeTool(fixture, "workflow_edit_stage", {
+			stageId: "implementation",
+			description: "A revised implementation description",
+			prompt: "A revised implementation prompt that wraps",
+			model: { thinking: "high" },
+		});
+		const narrowStageEdit = renderCompletedTool(
+			resolveSessionDefinition(fixture, "workflow_edit_stage"),
+			stageEdit,
+			PLAIN_THEME,
+			20,
+			true,
+		);
 		const contentIndex = expandedCreation.call.indexOf("--- Content ---");
 		const yamlLines = expandedCreation.call.slice(contentIndex + 1);
 		const { description, prompt, stages, transitions } = creationArgs;
@@ -837,6 +1031,8 @@ describe("workflow semantic tool rendering", () => {
 			...rendered.result,
 			...collapsedCreation.call,
 			...expandedCreation.call,
+			...narrowStageGet.call,
+			...narrowStageEdit.call,
 		]) {
 			shell.addChild({ render: () => [line], invalidate: () => {} });
 		}

--- a/pi-package/extensions/workflow/tool-rendering.ts
+++ b/pi-package/extensions/workflow/tool-rendering.ts
@@ -14,6 +14,7 @@ import {
 import { stringify } from "yaml";
 import { sliceTextByWidth } from "../../shared/display-width.ts";
 import { renderLabeledWrappedText } from "../../shared/labeled-wrapped-text.ts";
+import { normalizeCollapsedToolText } from "../../shared/terminal-display-text.ts";
 import {
 	BoundedToolResult,
 	getToolResultText,
@@ -21,6 +22,7 @@ import {
 import type { WorkflowDefinition, WorkflowState } from "./workflow.ts";
 
 const PRESENTATION_KIND = "workflow-tool";
+const STAGE_CHANGE_ARROW = "->";
 /** Matches the standard four-row collapsed content budget used by package tools. */
 const COLLAPSED_REFERENCE_CONTENT_LINE_LIMIT = 4;
 /** Reserves indentation, quotes, and continuation markers around wrapped YAML scalars. */
@@ -77,12 +79,13 @@ interface WorkflowTransitionPresentation {
 	readonly to: WorkflowPresentationReference;
 }
 
-/** Persists one stage and its model-visible editable content. */
+/** Persists one stage and the values needed to render reads or edits. */
 interface WorkflowStagePresentation {
 	readonly presentationKind: typeof PRESENTATION_KIND;
 	readonly toolName: "workflow_get_stage" | "workflow_edit_stage";
 	readonly stage: WorkflowPresentationReference;
 	readonly content?: WorkflowStageContent;
+	readonly editedContent?: WorkflowStageContent;
 }
 
 export type WorkflowToolPresentationDetails =
@@ -211,32 +214,27 @@ function createWorkflowStagePresentation(
 		return undefined;
 	}
 	const savedStage = state?.workflow.stages.find(({ id }) => id === stageId);
-	const description =
+	const content =
+		savedStage === undefined
+			? undefined
+			: {
+					id: savedStage.id,
+					description: savedStage.description,
+					prompt: savedStage.prompt,
+					model: { thinking: savedStage.model?.thinking },
+					initial: savedStage.initial,
+					final: savedStage.final,
+				};
+	const editedContent =
 		toolName === "workflow_edit_stage"
-			? readInputString(args, "description")
-			: savedStage?.description;
-	let content: WorkflowStageContent | undefined;
-	if (toolName === "workflow_edit_stage") {
-		content = createEditedStageContent(
-			args,
-			savedStage?.initial,
-			savedStage?.final,
-		);
-	} else if (savedStage !== undefined) {
-		content = {
-			id: savedStage.id,
-			description: savedStage.description,
-			prompt: savedStage.prompt,
-			model: { thinking: savedStage.model?.thinking },
-			initial: savedStage.initial,
-			final: savedStage.final,
-		};
-	}
+			? createEditedStageContent(args, savedStage?.initial, savedStage?.final)
+			: undefined;
 	return {
 		presentationKind: PRESENTATION_KIND,
 		toolName,
-		stage: createReference(stageId, description),
+		stage: createReference(stageId, savedStage?.description),
 		...(content === undefined ? {} : { content }),
+		...(editedContent === undefined ? {} : { editedContent }),
 	};
 }
 
@@ -413,15 +411,18 @@ export function renderWorkflowStageCall(
 ): Component {
 	const presentation = readStagePresentation(context, toolName);
 	const fallback = createWorkflowStagePresentation(toolName, args, undefined);
-	return renderWorkflowReferenceCall({
-		toolName,
-		workflow: undefined,
-		stage: presentation?.stage ?? fallback?.stage,
-		content:
-			presentation?.content ??
-			(context.argsComplete ? fallback?.content : undefined),
-		theme,
-		context,
+	const resolved = presentation ?? fallback;
+	return new WorkflowRows((width) => {
+		const stageId = resolved?.stage.id;
+		const title = stageId === undefined ? toolName : `${toolName}: ${stageId}`;
+		const attributes =
+			toolName === "workflow_get_stage"
+				? createStageAttributes(resolved?.content)
+				: createStageChanges(resolved?.content, resolved?.editedContent);
+		return [
+			renderToolName(title, width, theme),
+			...renderStageAttributes(attributes, context.expanded, width, theme),
+		];
 	});
 }
 
@@ -520,9 +521,11 @@ function parseStagePresentation(
 ): WorkflowStagePresentation | undefined {
 	const stage = parseReference(value["stage"]);
 	const content = parseStageContent(value["content"]);
+	const editedContent = parseStageContent(value["editedContent"]);
 	if (
 		stage === undefined ||
-		(value["content"] !== undefined && content === undefined)
+		(value["content"] !== undefined && content === undefined) ||
+		(value["editedContent"] !== undefined && editedContent === undefined)
 	) {
 		return undefined;
 	}
@@ -531,6 +534,7 @@ function parseStagePresentation(
 		toolName,
 		stage,
 		...(content === undefined ? {} : { content }),
+		...(editedContent === undefined ? {} : { editedContent }),
 	};
 }
 
@@ -607,6 +611,130 @@ function readStagePresentation(
 /** Renders one standalone bright workflow tool name. */
 function renderToolName(toolName: string, width: number, theme: Theme): string {
 	return theme.fg("toolTitle", theme.bold(sliceTextByWidth(toolName, width)));
+}
+
+interface StageAttributeRow {
+	readonly label: string;
+	readonly value: string;
+	readonly nextValue?: string;
+}
+
+/** Selects every stage field shown by the read tool. */
+function createStageAttributes(
+	content: WorkflowStageContent | undefined,
+): readonly StageAttributeRow[] | undefined {
+	if (content === undefined) {
+		return undefined;
+	}
+	return [
+		{ label: "Description", value: content.description },
+		{ label: "Prompt", value: content.prompt },
+		{ label: "Thinking", value: String(content.model["thinking"]) },
+		...(content.initial === undefined
+			? []
+			: [{ label: "Initial", value: String(content.initial) }]),
+		...(content.final === undefined
+			? []
+			: [{ label: "Final", value: String(content.final) }]),
+	];
+}
+
+/** Selects only editable fields whose captured old and new values differ. */
+function createStageChanges(
+	content: WorkflowStageContent | undefined,
+	editedContent: WorkflowStageContent | undefined,
+): readonly StageAttributeRow[] | undefined {
+	if (content === undefined || editedContent === undefined) {
+		return undefined;
+	}
+	const editableValues: ReadonlyArray<readonly [string, string, string]> = [
+		["Description", content.description, editedContent.description],
+		["Prompt", content.prompt, editedContent.prompt],
+		[
+			"Thinking",
+			String(content.model["thinking"]),
+			String(editedContent.model["thinking"]),
+		],
+	];
+	return editableValues
+		.filter(([, previous, next]) => previous !== next)
+		.map(([label, value, nextValue]) => ({ label, value, nextValue }));
+}
+
+/** Renders one collapsed attribute after normalizing its source line breaks. */
+function renderCollapsedStageAttribute(
+	attribute: StageAttributeRow,
+	width: number,
+	theme: Theme,
+): readonly string[] {
+	const value = normalizeCollapsedToolText(attribute.value);
+	const nextValue =
+		attribute.nextValue === undefined
+			? undefined
+			: normalizeCollapsedToolText(attribute.nextValue);
+	const label = theme.fg("toolTitle", theme.bold(`${attribute.label}:`));
+	const renderedValue =
+		nextValue === undefined
+			? theme.fg("toolOutput", ` ${value}`)
+			: `${theme.fg("toolOutput", ` ${value} `)}${theme.fg("success", STAGE_CHANGE_ARROW)}${theme.fg("toolOutput", ` ${nextValue}`)}`;
+	return new Text(`${label}${renderedValue}`, 0, 0).render(width);
+}
+
+/** Renders one expanded attribute as a standard named section. */
+function renderExpandedStageAttribute(
+	attribute: StageAttributeRow,
+	width: number,
+	theme: Theme,
+): readonly string[] {
+	return [
+		...new Text(theme.fg("muted", `--- ${attribute.label} ---`), 0, 0).render(
+			width,
+		),
+		...new Text(theme.fg("toolOutput", attribute.value), 0, 0).render(width),
+		...(attribute.nextValue === undefined
+			? []
+			: [
+					...new Text(theme.fg("success", STAGE_CHANGE_ARROW), 0, 0).render(
+						width,
+					),
+					...new Text(theme.fg("toolOutput", attribute.nextValue), 0, 0).render(
+						width,
+					),
+				]),
+	];
+}
+
+/** Applies one shared collapsed budget after rendering independent attributes. */
+function renderStageAttributes(
+	attributes: readonly StageAttributeRow[] | undefined,
+	expanded: boolean,
+	width: number,
+	theme: Theme,
+): readonly string[] {
+	if (attributes === undefined) {
+		return [];
+	}
+	if (attributes.length === 0) {
+		return new Text(theme.fg("toolOutput", "No changes."), 0, 0).render(width);
+	}
+	if (expanded) {
+		return attributes.flatMap((attribute) =>
+			renderExpandedStageAttribute(attribute, width, theme),
+		);
+	}
+	return new BoundedToolResult({
+		text: "",
+		theme,
+		isError: false,
+		expanded: false,
+		collapsedContentLineLimit: COLLAPSED_REFERENCE_CONTENT_LINE_LIMIT,
+		showHiddenLineHint: true,
+		showExpandedErrorLabel: false,
+		renderCollapsedLines: (renderWidth) =>
+			attributes.flatMap((attribute) =>
+				renderCollapsedStageAttribute(attribute, renderWidth, theme),
+			),
+	}).render(width);
 }
 
 /** Renders catalog-shaped workflow YAML or its configurable expansion hint. */

--- a/pi-package/shared/tool-presentation/bounded.ts
+++ b/pi-package/shared/tool-presentation/bounded.ts
@@ -21,6 +21,7 @@ interface BoundedToolResultOptions {
 	readonly collapsedContentLineLimit: number;
 	readonly showHiddenLineHint: boolean;
 	readonly showExpandedErrorLabel: boolean;
+	readonly renderCollapsedLines?: (width: number) => readonly string[];
 }
 
 /** Renders one JSON call preview within a visual-line budget. */
@@ -64,14 +65,17 @@ export class BoundedToolResult implements Component {
 			return this.renderExpanded(width);
 		}
 		const color = this.options.isError ? "error" : "toolOutput";
-		const visualLines = new Text(
-			this.options.theme.fg(
-				color,
-				normalizeCollapsedToolText(this.options.text),
-			),
-			0,
-			0,
-		).render(width);
+		// Semantic callers can supply styled rows while this class keeps one shared budget and hint.
+		const visualLines =
+			this.options.renderCollapsedLines?.(width) ??
+			new Text(
+				this.options.theme.fg(
+					color,
+					normalizeCollapsedToolText(this.options.text),
+				),
+				0,
+				0,
+			).render(width);
 		if (
 			!this.options.showHiddenLineHint ||
 			visualLines.length <= this.options.collapsedContentLineLimit


### PR DESCRIPTION
## Problem
When workflow stage tools were shown in the TUI, `workflow_get_stage` and `workflow_edit_stage` looked inconsistent and hard to read. Multiline prompts got weirdly wrapped, edits could show noisy output even when nothing changed, and active/session rendering could drift apart.

## Solution
I made stage rendering semantic and row-based.
- Stage calls now render as `workflow_get_stage: <stage>` / `workflow_edit_stage: <stage>` with explicit attributes.
- Collapsed mode normalizes internal line breaks, wraps values per row, enforces the shared collapsed budget, and keeps a clear "hidden lines" hint.
- Expanded mode now renders each shown attribute as `--- Name ---` blocks and preserves original multiline formatting.
- Edit mode now shows only changed fields, with a standalone arrow row (`->`) between old/new values; unchanged edits render `No changes.`.
- Rendering now uses shared bounded collapse plumbing via a styled collapsed-line callback.

### Changes
- Updated docs for workflow tool output behavior: `docs/extensions/workflow.md`
- Updated workflow stage rendering logic and data model: `pi-package/extensions/workflow/tool-rendering.ts`
- Added explicit rendering tests for collapsed/expanded semantics, styling, multiline blocks, unchanged-edit behavior, and narrow-width wrapping: `pi-package/extensions/workflow/tool-rendering.test.ts`
- Extended bounded renderer support for semantic collapsed rows: `pi-package/shared/tool-presentation/bounded.ts`

### Testing
- Updated `workflow semantic tool rendering` tests now cover:
  - get/edit stage collapsed output shape and expansion parity
  - styled attribute output in both themes
  - multiline value rendering and normalization behavior
  - `No changes.` path for identical edit input
  - narrow-width wrapped expanded get/edit stage references