### PR TITLE
Move model-facing prompts to persistent message journal

### DIFF
--- a/docs/extensions/mcp-wrapper.md
+++ b/docs/extensions/mcp-wrapper.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The MCP wrapper extension registers configured MCP server tools as Pi tools.
+The MCP wrapper extension registers configured MCP server tools as Pi tools. Pi sends each active generated tool's description and parameter schema through the provider tool payload.
 
 ## Configuration file
 
@@ -96,7 +96,7 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `env` | No | Object with string values | `{}` | Environment variables for the server process. Values are literal strings. Configured values override inherited environment variables with the same name. |
 | `cwd` | No | String | Not set by the extension | Working directory for the server process. |
 | `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
-| `additionalInstructions` | No | String | Not set | Local instructions shown only when a tool from this server is final-active. JSON `\n` escapes represent newlines. |
+| `additionalInstructions` | No | String | Not set | Local instructions persisted for the model when an eager server starts active or its deferred toolset is activated. JSON `\n` escapes represent newlines. |
 
 `streamableHttp` server parameters:
 
@@ -106,7 +106,7 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 | `url` | Yes | Non-empty string | None | MCP server URL. |
 | `headers` | No | Object with string values | `{}` | HTTP headers sent to the MCP server. Values are literal strings. |
 | `onDemand` | No | Object with `name` and `description` | Not set | Defers this server as one named toolset. See [On-demand toolsets](#on-demand-toolsets). |
-| `additionalInstructions` | No | String | Not set | Local instructions shown only when a tool from this server is final-active. JSON `\n` escapes represent newlines. |
+| `additionalInstructions` | No | String | Not set | Local instructions persisted for the model when an eager server starts active or its deferred toolset is activated. JSON `\n` escapes represent newlines. |
 
 ## Config rules
 
@@ -115,7 +115,11 @@ Each `mcpServers` entry must be either a `stdio` server or a `streamableHttp` se
 - Commands, arguments, environment values, headers, and URLs are used as written.
 - `additionalInstructions` is omitted when absent, empty, or whitespace-only. Nonblank text is preserved as written, including surrounding whitespace and newlines.
 - When both server-provided MCP instructions and `additionalInstructions` exist, server-provided text comes first, followed by one blank line and local text.
-- Local instructions are included only when at least one generated Pi tool from that server remains in the runtime's final active tool set. Registration alone is not sufficient.
+- At session initialization, server instructions are persisted in one hidden `mcp-instructions` replacement only for servers with at least one generated Pi tool in the runtime's final active tool set. Registration alone is not sufficient.
+- A deferred server's instructions are included in the first successful `activate_toolset` result. An idempotent activation does not repeat them.
+- Session restoration derives the effective instruction set from the latest hidden replacement and later successful `activate_toolset` results. It publishes a replacement when the exact rendered server-block set differs from the active generated MCP servers.
+- When no generated MCP server remains active, `<mcp_instructions />` replaces stale instruction blocks in the provider-visible segment. No empty record is added when the segment already contains no MCP instructions.
+- MCP instructions do not modify the system prompt.
 - Changing only `additionalInstructions` does not invalidate cached MCP metadata or trigger discovery; the text is read from configuration on the next startup.
 - Changing only `onDemand.name` or `onDemand.description` does not invalidate cached MCP metadata.
 
@@ -136,7 +140,7 @@ A server without `onDemand` is eager: its loaded tools are available under the n
 
 `activate_toolset` is available only if it is allowed for the current agent and a loaded, still-deferred toolset has at least one tool allowed for that agent. Activation is exact and case-sensitive. It exposes only that agent's allowed tools, is idempotent for an active toolset, and leaves the toolset deferred when activation fails. It disappears after the final eligible toolset is activated. Activation state is local to the pi session and active history branch; main and subagent sessions do not share it. A resumed branch restores its last valid activation snapshot; stale names from changed configuration are warned about and ignored.
 
-The activation result gives the model the status and complete list of currently available tool names, without tool parameters or descriptions. Main-agent and subagent screens render the status followed by comma-separated tool names. Collapsed rendering shows at most two wrapped content lines, adds an ellipsis when content is hidden, and reports the exact number of hidden lines; expanded rendering shows the complete wrapped list without truncation.
+The activation result gives the model the status and complete list of currently available tool names, without tool parameters or descriptions. On the first successful activation, the same persisted tool result also contains the activated servers' MCP instructions. Main-agent and subagent screens render the status followed by comma-separated tool names. Collapsed rendering shows at most two wrapped content lines, adds an ellipsis when content is hidden, and reports the exact number of hidden lines; expanded rendering shows the complete wrapped list without truncation.
 
 Activation uses already loaded MCP metadata. It does not create a separate MCP connection; normal MCP tool execution retains connection readiness and routing behavior.
 

--- a/docs/extensions/system-prompt.md
+++ b/docs/extensions/system-prompt.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-`system-prompt` replaces pi's base system prompt with a Markdown template. The template can include runtime values such as the current date, working directory, active tool text, deferred-toolset triggers, and loaded project context.
+`system-prompt` replaces pi's base system prompt with a Markdown template. The template can include runtime values such as the current date, working directory, tool guidelines, deferred-toolset triggers, and loaded project context. Tool names, descriptions, and parameter schemas reach the model through the provider tool payload instead of the template.
 
 ## Configuration
 
@@ -38,9 +38,8 @@ Supported variables:
 | --- | --- |
 | `{{date}}` | Local date in `YYYY-MM-DD` format. |
 | `{{cwd}}` | Current working directory with `/` path separators. |
-| `{{tools}}` | Active tools that have prompt text, formatted as `- name: text`. If no matching tools are available, inserts `(none)`. |
 | `{{toolsets}}` | Eligible deferred toolsets as `<toolsets>` XML, one `<toolset name="…" description="…"/>` per entry. It is empty when none are eligible. Attribute values XML-escape `&`, `<`, `>`, `"`, and `'`. |
-| `{{toolGuidelines}}` | Prompt guidelines supplied by active tools or extensions, one bullet per guideline. |
+| `{{toolGuidelines}}` | Prompt guidelines supplied by active tools or extensions, one bullet per normalized guideline. Surrounding whitespace is removed and the first occurrence of a duplicate is retained. |
 | `{{appendSystemPrompt}}` | Text passed through pi append-system-prompt inputs. |
 | `{{contextFiles}}` | Loaded context files inside `<project_specific_instructions>` XML-style blocks. |
 | `{{skills}}` | Loaded skills formatted by pi when the `read` tool is active. |
@@ -55,10 +54,7 @@ You are an expert coding assistant.
 Available toolsets:
 {{toolsets}}
 
-Available tools:
-{{tools}}
-
-Guidelines:
+Tool guidelines:
 {{toolGuidelines}}
 
 Additional instructions:

--- a/docs/extensions/workflow.md
+++ b/docs/extensions/workflow.md
@@ -106,7 +106,7 @@ Optional prompt overrides belong in `~/.pi/agent/agent-suite/workflow/config.jso
 
 Each configured path must be absolute and reference a readable file with non-empty content after trimming. Unknown fields and invalid files reject the prompt configuration atomically.
 
-`extensionDescriptionPromptFile` supplies universal active-workflow guidance. The other files replace the Pi tool description for the corresponding tool. Pi includes descriptions only for active tools, so tool-specific rules are not duplicated in `<workflow_guidelines>`.
+`extensionDescriptionPromptFile` supplies one `promptGuidelines` contribution on each workflow tool. The system prompt formatter normalizes duplicate contributions, so the guidance appears once while any workflow tool is active. The other files replace the Pi tool description for the corresponding tool.
 
 ## Tools
 
@@ -206,7 +206,7 @@ Workflow: TuiBrainstorming · Generate and discuss TUI concepts
 
 The row contains the workflow ID and active stage description. It never includes stage IDs or transitions. The shared separator and the complete Workflow row use Pi's dim color. Repeated spaces and terminal layout whitespace, including tabs and line breaks, collapse to one space before display. A trailing `.` is removed. The row is clipped to the terminal width and ends with `…` when content is hidden.
 
-A completed workflow is still retained for rework, but its provider context uses `<completed_workflow>` and omits `<active_stage_guidelines>` until rework makes the workflow active again.
+A completed workflow is still retained for rework. Its latest journal record uses `<workflow_completed>` and contains no completed-stage prompt. Rework appends a new `<workflow_stage_activated>` record.
 
 Creation, activation, stage editing, transition, session start, and branch changes replace the row with the saved active state. Changing the selected agent or its workflow allowlist does not hide this row or the saved active workflow. The agent's tool policy still controls provider-context availability. A branch without saved active workflow state removes only the `Workflow` row; other shared panel rows remain visible.
 
@@ -277,30 +277,28 @@ The extension computes tool availability independently:
 - `workflow_create` requires a valid catalog, including a valid empty catalog;
 - `workflow_activate` requires at least one allowed activation option;
 - `workflow_get_stage` and `workflow_edit_stage` require an active dynamic workflow created through `workflow_create`;
-- `workflow_transition` requires a projected active state or at least one allowed catalog workflow.
+- `workflow_transition` requires a saved workflow state or at least one allowed catalog workflow.
 
 The agent's `tools` policy remains a second gate. The extension never restores a tool removed by that policy.
 
-`<workflow_guidelines>` contains only universal workflow rules. Context is projected while at least one workflow tool is active. The current active workflow also remains projected when the extension temporarily suppresses the last workflow tool granted by the agent policy. A policy reset that removes that tool permission stops the projection without deleting the saved workflow snapshot. `<workflow_activation_options>` is included only when `workflow_activate` is active and at least one option exists. An empty or self-closing activation-options element is not emitted.
+Workflow state entries remain authoritative for runtime reconstruction. Model-facing workflow data uses hidden, persistent messages with `customType: "workflow"`, `display: false`, and `deliverAs: "steer"`. During a tool loop, steering inserts the record into the next provider request. When Pi is idle, the same call persists the record without starting a turn. The extension does not register a `context` handler and does not append a transient workflow snapshot before provider calls.
 
-An active workflow projects shared workflow guidance before the current stage guidance:
+The journal is append-only:
+- Activation appends `<workflow_activated>` with root guidance, stage descriptions, and the complete transition graph. The same message then appends `<workflow_stage_activated guidelines="inline">` for the initial stage.
+- First entry into a stage appends its prompt with `guidelines="inline"`.
+- Repeated entry into a known unchanged stage uses `guidelines="reuse"` and does not repeat the prompt.
+- Every stage activation includes current outgoing `<available_transitions>`. Route-dependent `rework` options are recalculated for each entry.
+- `workflow_edit_stage` appends `<workflow_stage_updated>` with the complete replacement description and prompt.
+- `agent_settled` appends `<workflow_completed>` with available rework transitions and no completed-stage prompt. Settlement runs after the active agent loop ends, so the completion record reaches the next user-triggered provider request.
+- An empty transition set is represented by `<available_transitions />`.
 
-```xml
-<active_workflow id="delivery" active_stage_id="implementation">
-  <guidelines>
-Follow these guidelines throughout the workflow.
-  </guidelines>
-  <active_stage_guidelines>
-Implement only the approved scope.
-Follow the project testing rules.
-  </active_stage_guidelines>
-  ...
-</active_workflow>
-```
+Activation availability uses separate `<workflow_activation_options>` records. The extension publishes one at session initialization and after policy, catalog, or workflow changes only when the rendered options change. `<workflow_activation_options />` explicitly replaces an older non-empty list.
 
-The root workflow prompt is projected in `<guidelines>` for every active stage and omitted when absent. Only the active stage prompt is projected in `<active_stage_guidelines>`; a transition replaces it on the next context request. A completed workflow uses `<completed_workflow completed_stage_id="...">` and projects no stage prompt.
+After `session_compact`, the extension resets journal deduplication for the new provider-visible segment. It appends one `<workflow_checkpoint>` when workflow state exists, then publishes `<workflow_activation_options>` or `<workflow_activation_options />`. Without workflow state, it publishes activation options without a checkpoint. A repair checkpoint outside compaction preserves activation-options deduplication. Other stage definitions become unknown. The first later entry into another stage therefore uses `guidelines="inline"`.
 
-Catalog activation options are filtered through `workflows`. The current active state remains projectable and transitionable under every resolved policy, regardless of whether it came from catalog activation or `workflow_create`.
+New `activated` and `created` workflow-state snapshots require `journalVersion: 1`. State without this field belongs to the old format, is ignored with a warning, and produces no repair checkpoint. On session start and branch navigation, the extension scans `custom_message` workflow entries after the latest `compaction` or `branch_summary` entry. Every lifecycle record carries a SHA-256 revision of the normalized workflow definition. Current-format compatibility requires matching workflow ID, status, route-tail stage, and definition revision. A current-format state without a compatible lifecycle record receives one checkpoint.
+
+Catalog activation options are filtered through `workflows`. A resolved policy can change new activation options without deleting or blocking the saved workflow state.
 
 ## Session snapshots
 

--- a/docs/specs/issues/tool-prompt-cache-duplication/technical-solution.md
+++ b/docs/specs/issues/tool-prompt-cache-duplication/technical-solution.md
@@ -1,0 +1,105 @@
+# Technical Solution: Tool and Workflow Prompt Cache Duplication
+
+## Problem Statement
+- PRB-01: The bundled system prompt repeats active tool names and prompt snippets even though the provider tool payload already contains each active tool's name, description, and parameter schema.
+- PRB-02: MCP server instructions are appended through `before_agent_start`. The append occurs after system-prompt replacement and repeats the instruction text on each model request.
+- PRB-03: The workflow extension appends a transient snapshot through the `context` event before every model request. The snapshot repeats extension guidance, activation options, workflow metadata, the full transition graph, and active-stage guidance.
+- PRB-04: Transient workflow messages are absent from persisted session history. The next request inserts assistant and tool-result messages at the previous transient suffix position, so the provider cannot reuse that suffix as a stable prompt prefix.
+- PRB-05: Moving mutable workflow state into the system prompt would invalidate the system-prompt prefix after activation, transition, edit, completion, policy change, or compaction.
+- PRB-06: `sendMessage` with `triggerTurn: false` during tool execution writes to persisted agent state but not to the active loop's copied `currentContext`. The model does not receive the journal record until a later user-triggered run.
+- PRB-07: Pi persists model-facing custom messages as `custom_message` session entries. Reading them as nested `message` entries prevents restore deduplication and can append duplicate activation options.
+- PRB-08: Deferred MCP instructions persist inside the first successful `activate_toolset` result. Checking only standalone `mcp-instructions` messages during restoration appends a duplicate copy.
+- PRB-09: Removing one or all MCP servers can leave their earlier instruction blocks visible. Coverage of retained servers does not prove that the persisted instruction set has no stale servers.
+- PRB-10: Compaction without workflow state emits no checkpoint. Without a separate segment reset, activation-options deduplication suppresses availability in the new provider-visible segment.
+- PRB-11: Workflow ID, status, and route-tail stage do not identify the model-visible workflow definition. A persisted stage edit without its journal record requires restoration repair. Treating old revisionless lifecycle records as missing records creates repeated checkpoints during branch navigation.
+
+## Proposed Solution
+
+### SOL-01: Provider tool payload ownership
+- Keep tool names, descriptions, JSON Schema, and parameter descriptions in Pi tool definitions.
+- Treat the provider tool payload as the authoritative model-facing tool catalog.
+- Keep `promptSnippet` for Pi and custom templates that consume it outside the bundled system prompt.
+- Cover the provider boundary with a real Pi `before_provider_request` integration test. The test compares `pi.getActiveTools()` with provider tool names and checks tool and parameter descriptions.
+
+### SOL-02: Bundled system-prompt cleanup
+- Remove `{{tools}}` from `SUPPORTED_TEMPLATE_VARIABLES`, `buildTemplateValues`, and the bundled `system.md` template.
+- Retain `{{toolGuidelines}}` for behavioral instructions that do not belong in provider tool metadata.
+- Normalize each guideline with `trim()`, discard empty values, and retain the first occurrence of each duplicate.
+- Publish workflow extension guidance through each workflow tool's `promptGuidelines`. Deduplication renders the shared guidance once when one or more workflow tools are active.
+
+### SOL-03: Persistent MCP instructions
+- Remove MCP system-prompt mutation from `before_agent_start`.
+- At `session_start`, derive the effective post-boundary instruction set from the latest hidden replacement plus later successful `activate_toolset` results. Persist a hidden replacement when its exact rendered server blocks differ from the active generated MCP servers.
+- Add the activated server's rendered MCP instructions to the first successful `activate_toolset` result through the shared `Toolset.activationContext` contract.
+- Omit `activationContext` from idempotent activation results so repeated activation does not duplicate instruction text.
+- Persist `<mcp_instructions />` when no generated MCP server remains active but the provider-visible segment contains one or more instruction blocks. The self-closing record replaces all earlier MCP instructions in that segment.
+- After `session_compact`, persist the non-empty instruction set for active generated MCP tools because pre-compaction records no longer belong to the provider-visible context segment.
+- Compare exact rendered server-block sets during restoration. Matching requires both complete active-server coverage and no stale server block.
+
+### SOL-04: Append-only workflow journal
+- Remove the workflow `context` handler and its transient full snapshot.
+- Persist model-facing workflow records with `customType: "workflow"`, `display: false`, and `deliverAs: "steer"`.
+- Do not set `triggerTurn: false`. During an active tool loop, that option writes only to session state because the loop's `currentContext` is already a separate message array. `deliverAs: "steer"` adds the record to the next provider request in the active loop and persists it without starting a new turn when Pi is idle.
+- Keep `workflow-state` custom entries as the authoritative runtime reconstruction data. Workflow journal messages provide model instructions and do not replace state replay.
+- Append one activation message containing `<workflow_activated>` and the initial `<workflow_stage_activated guidelines="inline">` record.
+- Append `<workflow_stage_activated>` on each transition. Use `guidelines="inline"` for a stage whose definition is unknown in the provider-visible context segment and `guidelines="reuse"` for a known unchanged definition.
+- Include only route-allowed outgoing edges in each `<available_transitions>` block. Emit `<available_transitions />` when no outgoing edge is allowed.
+- Append `<workflow_stage_updated>` with the replacement stage description, initial or final flags, and stage guidance after `workflow_edit_stage` persists.
+- Append `<workflow_completed>` with rework transitions and no completed-stage prompt after `agent_settled` persists completion. Because settlement occurs after the active agent loop ends, the record is available to the next user-triggered provider request rather than the response that finishes the final stage.
+
+### SOL-05: Workflow activation options
+- Keep activation availability separate from workflow lifecycle records.
+- Persist `<workflow_activation_options>` after session initialization and after workflow or policy changes when its rendered value changes.
+- Reset activation-options deduplication at every `session_compact`, including compaction without active or completed workflow state, then publish availability for the new provider-visible segment. A repair checkpoint outside compaction preserves activation-options deduplication.
+- Persist `<workflow_activation_options />` when no catalog workflow is available. This record replaces an older non-empty option list.
+- Filter options through workflow policy and final active-tool reconciliation. A hidden or disallowed `workflow_activate` tool produces an empty options record.
+
+### SOL-06: Compaction and restoration
+- After `session_compact`, append one `<workflow_checkpoint>` for the replayed workflow state.
+- An active checkpoint contains workflow ID, `status="active"`, active stage ID, root guidance, active-stage guidance, and route-allowed transitions.
+- A completed checkpoint contains workflow ID, `status="completed"`, completed stage ID, root guidance, and rework transitions. It contains no stage prompt.
+- Reset known stage definitions at compaction. Only the active stage definition remains known for an active checkpoint.
+- Re-publish workflow activation options after the checkpoint because the pre-compaction availability record is outside the provider-visible context segment.
+- During `session_start` and `session_tree`, scan `custom_message` workflow entries after the latest `compaction` or `branch_summary` boundary.
+- Require `journalVersion: 1` in new `activated` and `created` workflow-state snapshots. Ignore an older root snapshot without this field, report the existing old-format warning, and append no repair checkpoint.
+- Add a SHA-256 workflow-definition revision to every lifecycle record. The revision covers the normalized workflow snapshot, including stage edits.
+- Append a checkpoint when current-format replayed `workflow-state` has no compatible workflow lifecycle record. Compatibility requires matching workflow ID, status, route-tail stage, and workflow-definition revision.
+- Track the route-tail stage separately from an edited stage ID. Editing an inactive stage must not make that stage the restored active stage.
+
+### SOL-07: Failure and ordering boundaries
+- Persist `workflow-state` before publishing the corresponding workflow journal record.
+- Apply workflow model settings before state persistence, preserving the existing rollback behavior when state persistence fails.
+- Publish no activation, transition, edit, or completion journal record when state persistence fails.
+- Repair a missing journal record from persisted workflow state on the next session start or branch navigation.
+- Keep stage triggers after state persistence and in-memory state entry. Trigger failure does not invalidate the persisted workflow operation.
+
+### SOL-08: Validation
+- Run `bun run test` for behavior tests.
+- Run `bun run typecheck` for strict TypeScript checks.
+- Run `bun run check` for Biome formatting and lint checks.
+- Run `bun run verify` for the full suite.
+- Keep real Pi integration coverage for provider tool payloads, package loading, main-agent workflow policy, child workflow policy, and workflow message visibility in the provider request immediately after a workflow tool call.
+- Unit tests inspect persisted workflow records directly. They do not simulate provider calls by returning the latest journal message from a test helper.
+
+## Overengineering and Overspecification Considerations
+- The solution uses Pi's existing tool payload, custom messages, tool results, state entries, and lifecycle events. It adds no storage service, cache, provider adapter, or model request.
+- `Toolset.activationContext` is provider-neutral. The shared toolset runtime does not depend on MCP-specific types.
+- Workflow state replay remains unchanged as the runtime authority. The journal adds only model-facing deltas and repair checkpoints.
+- Compaction repair is limited to one workflow checkpoint, one activation-options replacement, and one MCP instruction replacement for the exact active-server set.
+
+## Open Questions
+
+No unresolved design questions remain for this solution.
+
+## References
+- REF-01: `pi-package/extensions/system-prompt/index.ts` - bundled template variables and guideline deduplication.
+- REF-02: `pi-package/extensions/system-prompt/prompts/system.md` - bundled system-prompt structure.
+- REF-03: `pi-package/shared/toolsets/contracts.ts` - shared activation-context contract.
+- REF-04: `pi-package/shared/toolsets/runtime.ts` - first-activation result persistence.
+- REF-05: `pi-package/extensions/mcp-wrapper/index.ts` - MCP instruction selection, persistence, activation, and compaction recovery.
+- REF-06: `pi-package/extensions/workflow/context.ts` - workflow journal rendering, deduplication, restoration, and checkpoints.
+- REF-07: `pi-package/extensions/workflow/index.ts` - workflow lifecycle, tool commits, policy changes, and journal publication.
+- REF-08: `test/integration/runtime-package-loading.test.ts` - real Pi provider and workflow policy contracts.
+- REF-09: `docs/extensions/system-prompt.md` - system-prompt user contract.
+- REF-10: `docs/extensions/mcp-wrapper.md` - MCP wrapper user contract.
+- REF-11: `docs/extensions/workflow.md` - workflow journal user contract.

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -65,6 +65,12 @@ interface NotificationRecord {
 
 interface ExtensionApiFake extends ExtensionAPI {
 	readonly activeToolHistory: string[][];
+	readonly messages: Array<{
+		readonly customType: string;
+		readonly content: string;
+		readonly display: boolean;
+		readonly details: unknown;
+	}>;
 	readonly commands: Array<
 		Omit<RegisteredCommand, "name" | "sourceInfo"> & { readonly name: string }
 	>;
@@ -103,10 +109,12 @@ function createExtensionApiFake(
 	const handlers: RegisteredHandler[] = [];
 	const tools: ToolDefinition[] = [];
 	const activeToolHistory: string[][] = [];
+	const messages: ExtensionApiFake["messages"] = [];
 	let activeTools: readonly string[] = [];
 
 	return {
 		activeToolHistory,
+		messages,
 		commands,
 		handlers,
 		tools,
@@ -149,6 +157,14 @@ function createExtensionApiFake(
 			return undefined;
 		},
 		setThinkingLevel(): void {},
+		sendMessage(message: Parameters<ExtensionAPI["sendMessage"]>[0]): void {
+			messages.push({
+				customType: message.customType,
+				content: String(message.content),
+				display: message.display,
+				details: message.details,
+			});
+		},
 		appendEntry(): void {},
 		getSessionHistory() {
 			return [];
@@ -184,6 +200,21 @@ async function runSessionStart(
 					statuses.push({ key, text });
 				},
 			},
+		} as unknown as ExtensionContext);
+	}
+}
+
+async function runSessionCompact(
+	pi: ExtensionApiFake,
+	sessionManager: SessionManager,
+): Promise<void> {
+	const handlers = pi.handlers.filter(
+		(handler) => handler.eventName === "session_compact",
+	);
+	expect(handlers.length).toBeGreaterThan(0);
+	for (const handler of handlers) {
+		await handler.handler({ type: "session_compact" }, {
+			sessionManager,
 		} as unknown as ExtensionContext);
 	}
 }
@@ -249,6 +280,18 @@ async function resolvesWithin(
 			setTimeout(() => resolve(false), milliseconds),
 		),
 	])) as boolean;
+}
+
+function sessionManagerFromMessages(
+	messages: ExtensionApiFake["messages"],
+): SessionManager {
+	return {
+		getBranch: () =>
+			messages.map((message) => ({
+				type: "custom_message",
+				...message,
+			})),
+	} as unknown as SessionManager;
 }
 
 async function runBeforeAgentStart(
@@ -454,9 +497,9 @@ describe("mcp-wrapper extension", () => {
 
 	test("publishes loaded eager and deferred MCP catalogs through composition", async () => {
 		// Purpose: loaded metadata must register every definition while only eager tools start active.
-		// Input and expected output: eager and deferred servers load; activation exposes the deferred tool and instructions.
-		// Edge case: activation uses the already loaded catalog without another discovery or connection step.
-		// Dependencies: shared toolset runtime, composition, MCP manager routing, and instruction filtering.
+		// Input and expected output: eager instructions persist at startup; activation exposes the deferred tool and its instructions in the result.
+		// Edge case: activation uses the loaded catalog without another discovery or repeated instruction record.
+		// Dependencies: shared toolset runtime, composition, MCP manager routing, and persistent custom messages.
 		const pi = createExtensionApiFake();
 		let discoveryCalls = 0;
 		const manager = {
@@ -522,10 +565,19 @@ describe("mcp-wrapper extension", () => {
 			"deferred_search",
 		]);
 		expect(pi.getActiveTools()).toEqual(["activate_toolset", "eager_read"]);
-		expect(await runBeforeAgentStart(pi)).toContain("Use eager files.");
-		expect(await runBeforeAgentStart(pi)).not.toContain(
-			"Use deferred search carefully.",
-		);
+		expect(await runBeforeAgentStart(pi)).toBe("Base prompt");
+		expect(pi.messages).toEqual([
+			{
+				customType: "mcp-instructions",
+				content:
+					'<mcp_instructions>\n  <server name="eager">\nUse eager files.\n  </server>\n</mcp_instructions>',
+				display: false,
+				details: {
+					version: 1,
+					serverKeys: ["eager"],
+				},
+			},
+		]);
 		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([
 			{
 				name: "search-suite",
@@ -534,10 +586,20 @@ describe("mcp-wrapper extension", () => {
 			},
 		]);
 
+		const restoredSessionManager = {
+			getBranch: () =>
+				pi.messages.map((message) => ({
+					type: "custom_message",
+					...message,
+				})),
+		} as unknown as SessionManager;
+		await runSessionStart(pi, [], [], restoredSessionManager);
+		expect(pi.messages).toHaveLength(1);
+
 		const activation = pi.tools.find(
 			(tool) => tool.name === "activate_toolset",
 		);
-		await activation?.execute(
+		const activationResult = await activation?.execute(
 			"activate-1",
 			{ name: "search-suite" },
 			undefined,
@@ -545,11 +607,45 @@ describe("mcp-wrapper extension", () => {
 			{} as ExtensionContext,
 		);
 
-		expect(discoveryCalls).toBe(1);
+		expect(discoveryCalls).toBe(2);
 		expect(pi.getActiveTools()).toEqual(["eager_read", "deferred_search"]);
-		expect(await runBeforeAgentStart(pi)).toContain(
-			"Use deferred search carefully.",
-		);
+		expect(activationResult?.content).toEqual([
+			{
+				type: "text",
+				text: expect.stringContaining("Use deferred search carefully."),
+			},
+		]);
+		expect(await runBeforeAgentStart(pi)).toBe("Base prompt");
+		expect(pi.messages).toHaveLength(1);
+
+		const activatedSessionManager = {
+			getBranch: () => [
+				...pi.messages.map((message) => ({
+					type: "custom_message",
+					...message,
+				})),
+				{
+					type: "message",
+					message: {
+						role: "toolResult",
+						toolName: "activate_toolset",
+						isError: false,
+						content: activationResult?.content,
+						details: activationResult?.details,
+					},
+				},
+			],
+		} as unknown as SessionManager;
+		await runSessionStart(pi, [], [], activatedSessionManager);
+		expect(pi.messages).toHaveLength(1);
+
+		const compactedSessionManager = {
+			getBranch: () => [{ type: "compaction" }],
+		} as unknown as SessionManager;
+		await runSessionCompact(pi, compactedSessionManager);
+		expect(pi.messages).toHaveLength(2);
+		expect(pi.messages[1]?.content).toContain("Use eager files.");
+		expect(pi.messages[1]?.content).toContain("Use deferred search carefully.");
 	});
 
 	test("restores resumed activation after cacheless live discovery finalizes the catalog", async () => {
@@ -623,9 +719,8 @@ describe("mcp-wrapper extension", () => {
 
 		expect(pi.getActiveTools()).toEqual(["deferred_search"]);
 		expect(getToolsetRuntime(pi).getVisibleToolsets()).toEqual([]);
-		expect(await runBeforeAgentStart(pi)).toContain(
-			"Use deferred search carefully.",
-		);
+		expect(pi.messages[0]?.content).toContain("Use deferred search carefully.");
+		expect(await runBeforeAgentStart(pi)).toBe("Base prompt");
 		expect(
 			notifications.some(({ message }) => message.includes("stale activated")),
 		).toBe(false);
@@ -990,9 +1085,8 @@ describe("mcp-wrapper extension", () => {
 			FILES_READ_TOOL_NAME,
 		]);
 		expect(pi.getActiveTools()).toEqual([FILES_READ_TOOL_NAME]);
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
-			"Use cached file instructions.",
-		);
+		expect(pi.messages[0]?.content).toContain("Use cached file instructions.");
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
 
 	test("registers a manual MCP cache refresh command", async () => {
@@ -1485,10 +1579,8 @@ describe("mcp-wrapper extension", () => {
 		});
 
 		await runSessionStart(pi);
-		pi.setActiveTools([FILES_READ_TOOL_NAME]);
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
-			"Use this server for files.",
-		);
+		expect(pi.messages[0]?.content).toContain("Use this server for files.");
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 
 		await runSessionShutdown(pi);
 
@@ -2021,20 +2113,19 @@ describe("mcp-wrapper extension", () => {
 			createManager: () => managerWithCleanup(manager),
 		});
 
-		await runSessionStart(pi);
 		getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", [
 			"docs_server_search",
 		]);
+		await runSessionStart(pi);
 
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe(`Base prompt
-
-<mcp_instructions>
+		expect(pi.messages[0]?.content).toBe(`<mcp_instructions>
   <server name="docs&amp;server">
 Use this server. Do not call &lt;private>.
 
 Local docs guidance.
   </server>
 </mcp_instructions>`);
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
 
 	test("renders local MCP instructions for an eligible server without protocol instructions", async () => {
@@ -2085,10 +2176,7 @@ Local docs guidance.
 		});
 
 		await runSessionStart(pi);
-		pi.setActiveTools(["alpha_read", "beta_search"]);
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe(`Base prompt
-
-<mcp_instructions>
+		expect(pi.messages[0]?.content).toBe(`<mcp_instructions>
   <server name="alpha">
 Alpha local guidance.
   </server>
@@ -2096,6 +2184,7 @@ Alpha local guidance.
 Beta local guidance.
   </server>
 </mcp_instructions>`);
+		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
 
 	test("omits MCP initialize instructions when no registered MCP tool is active", async () => {
@@ -2140,26 +2229,35 @@ Beta local guidance.
 			createManager: () => managerWithCleanup(manager),
 		});
 
-		await runSessionStart(pi);
 		getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", []);
+		await runSessionStart(pi);
 
+		expect(pi.messages).toEqual([]);
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
 
-	test("clears MCP initialize instructions when a later startup registers no tools", async () => {
+	test("replaces MCP instructions when configured servers are removed", async () => {
+		// Purpose: restoration must replace stale instructions rather than only proving coverage for active servers.
+		// Input and expected output: files plus search becomes files only, then an explicit empty replacement.
+		// Edge case: retained files instructions must not hide stale search instructions in an older aggregate record.
+		// Dependencies: live discovery, session restoration, and MCP instruction replacement semantics.
 		const pi = createExtensionApiFake();
-		let enabled = true;
+		let configuredServers: Array<"files" | "search"> = ["files", "search"];
 		const manager = {
 			discoverServers: async () => ({
-				serverToolLists: [
-					{
-						serverKey: "files",
-						tools: [{ name: "read", inputSchema: { type: "object" } }],
-					},
-				],
-				serverInstructions: [
-					{ serverKey: "files", instructions: "Use this server for files." },
-				],
+				serverToolLists: configuredServers.map((serverKey) => ({
+					serverKey,
+					tools: [
+						{
+							name: serverKey === "files" ? "read" : "lookup",
+							inputSchema: { type: "object" },
+						},
+					],
+				})),
+				serverInstructions: configuredServers.map((serverKey) => ({
+					serverKey,
+					instructions: `Use this server for ${serverKey}.`,
+				})),
 				failures: [],
 			}),
 			callTool: async () => ({ content: [] }),
@@ -2169,7 +2267,7 @@ Beta local guidance.
 			readConfig: async () => ({
 				kind: "valid",
 				config: {
-					enabled,
+					enabled: configuredServers.length > 0,
 					timeouts: {
 						startupSeconds: 30,
 						listToolsSeconds: 15,
@@ -2177,31 +2275,48 @@ Beta local guidance.
 						maxTotalSeconds: 180,
 					},
 					widgetLineBudget: 5,
-					mcpServers: enabled
-						? {
-								files: {
-									type: "stdio",
-									command: "node",
-									args: [],
-									env: {},
-									additionalInstructions: "Files local guidance.",
-								},
-							}
-						: {},
+					mcpServers: {
+						...(configuredServers.includes("files")
+							? {
+									files: {
+										type: "stdio" as const,
+										command: "node",
+										args: [],
+										env: {},
+									},
+								}
+							: {}),
+						...(configuredServers.includes("search")
+							? {
+									search: {
+										type: "stdio" as const,
+										command: "node",
+										args: [],
+										env: {},
+									},
+								}
+							: {}),
+					},
 				},
 			}),
 			createManager: () => managerWithCleanup(manager),
 		});
 
 		await runSessionStart(pi);
-		pi.setActiveTools([FILES_READ_TOOL_NAME]);
-		expect(await runBeforeAgentStart(pi, "Base prompt")).toContain(
-			"<mcp_instructions>",
-		);
+		expect(pi.messages).toHaveLength(1);
+		expect(pi.messages[0]?.content).toContain('name="files"');
+		expect(pi.messages[0]?.content).toContain('name="search"');
 
-		enabled = false;
-		await runSessionStart(pi);
+		configuredServers = ["files"];
+		await runSessionStart(pi, [], [], sessionManagerFromMessages(pi.messages));
+		expect(pi.messages).toHaveLength(2);
+		expect(pi.messages[1]?.content).toContain('name="files"');
+		expect(pi.messages[1]?.content).not.toContain('name="search"');
 
+		configuredServers = [];
+		await runSessionStart(pi, [], [], sessionManagerFromMessages(pi.messages));
+		expect(pi.messages).toHaveLength(3);
+		expect(pi.messages[2]?.content).toBe("<mcp_instructions />");
 		expect(await runBeforeAgentStart(pi, "Base prompt")).toBe("Base prompt");
 	});
 

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -114,41 +114,7 @@ export default async function mcpWrapper(
 		registeredToolDefinitions,
 		toolsetRuntime,
 	});
-	registerMcpInstructionPromptHandler(pi, () => state.serverInstructionRecords);
-
 	await preloadedStatePromise;
-}
-
-interface BeforeAgentStartEventLike {
-	readonly systemPrompt: string;
-}
-
-/** Adds instructions only for MCP servers that own at least one active generated tool. */
-function registerMcpInstructionPromptHandler(
-	pi: ExtensionAPI,
-	getServerInstructionRecords: () => readonly ServerInstructionRecord[],
-): void {
-	pi.on("before_agent_start", (event) => {
-		const serverInstructionRecords = getServerInstructionRecords();
-		if (serverInstructionRecords.length === 0) {
-			return undefined;
-		}
-
-		const activeToolNames = new Set(pi.getActiveTools());
-		const visibleServerInstructions = serverInstructionRecords.filter(
-			(serverInstructions) =>
-				serverInstructions.registeredPiToolNames.some((toolName) =>
-					activeToolNames.has(toolName),
-				),
-		);
-		if (visibleServerInstructions.length === 0) {
-			return undefined;
-		}
-
-		return {
-			systemPrompt: `${(event as BeforeAgentStartEventLike).systemPrompt}\n\n${renderMcpInstructions(visibleServerInstructions)}`,
-		};
-	});
 }
 
 interface SessionStartContextLike {
@@ -250,6 +216,19 @@ function registerMcpSessionLifecycleHandlers(options: {
 		);
 		options.state.activeManager = result.manager;
 		options.state.serverInstructionRecords = result.serverInstructionRecords;
+		persistActiveServerInstructions(
+			options.pi,
+			result.serverInstructionRecords,
+			ctx.sessionManager.getBranch(),
+		);
+	});
+
+	options.pi.on("session_compact", (_event, ctx) => {
+		persistActiveServerInstructions(
+			options.pi,
+			options.state.serverInstructionRecords,
+			ctx.sessionManager.getBranch(),
+		);
 	});
 
 	options.pi.on("session_shutdown", async () => {
@@ -265,23 +244,31 @@ function buildMcpToolsets(
 	servers: ValidMcpWrapperConfig["mcpServers"],
 	serverToolLists: readonly McpServerToolList[],
 	catalogTools: readonly PiToolCatalogEntry[],
+	serverInstructionRecords: readonly ServerInstructionRecord[] = [],
 ): readonly Toolset[] {
 	const loadedServerKeys = new Set(
 		serverToolLists.map((serverToolList) => serverToolList.serverKey),
 	);
 	const toolNamesByServer = groupCatalogToolNamesByServer(catalogTools);
+	const instructionsByServer = new Map(
+		serverInstructionRecords.map((record) => [record.serverKey, record]),
+	);
 
 	return Object.entries(servers).flatMap(([serverKey, server]) => {
 		if (server.onDemand === undefined || !loadedServerKeys.has(serverKey)) {
 			return [];
 		}
 		const toolNames = toolNamesByServer.get(serverKey) ?? [];
+		const instructions = instructionsByServer.get(serverKey);
 		return [
 			{
 				providerId: MCP_TOOLSET_PROVIDER_ID,
 				name: server.onDemand.name,
 				description: server.onDemand.description,
 				toolNames,
+				...(instructions === undefined
+					? {}
+					: { activationContext: renderMcpInstructions([instructions]) }),
 				// MCP metadata and definitions are already loaded; normal tool execution owns connection readiness.
 				activate: async () => toolNames,
 			},
@@ -464,21 +451,20 @@ async function handleSessionStart(
 	}
 
 	const catalog = buildPiToolCatalog(startup.serverToolLists);
+	const serverInstructionRecords = buildActiveServerInstructions(
+		startup.serverInstructions,
+		configResult.config.mcpServers,
+		catalog.tools,
+	);
 	registerStartupCatalog({
 		options,
 		startup,
 		catalog,
 		config: configResult.config,
+		serverInstructionRecords,
 	});
 
-	return {
-		manager,
-		serverInstructionRecords: buildActiveServerInstructions(
-			startup.serverInstructions,
-			configResult.config.mcpServers,
-			catalog.tools,
-		),
-	};
+	return { manager, serverInstructionRecords };
 }
 
 /** Publishes one startup catalog through normal registration and shared runtime presentation. */
@@ -487,11 +473,13 @@ function registerStartupCatalog({
 	startup,
 	catalog,
 	config,
+	serverInstructionRecords,
 }: {
 	readonly options: HandleSessionStartOptions;
 	readonly startup: StartupMetadata;
 	readonly catalog: PiToolCatalog;
 	readonly config: ValidMcpWrapperConfig;
+	readonly serverInstructionRecords: readonly ServerInstructionRecord[];
 }): void {
 	reportStatuses(options.ctx, startup, catalog.rejected);
 	registerCatalogTools({
@@ -504,7 +492,12 @@ function registerStartupCatalog({
 	});
 	replaceRuntimeCatalog(
 		options,
-		buildMcpToolsets(config.mcpServers, startup.serverToolLists, catalog.tools),
+		buildMcpToolsets(
+			config.mcpServers,
+			startup.serverToolLists,
+			catalog.tools,
+			serverInstructionRecords,
+		),
 		catalog.tools.map((entry) => entry.definition.name),
 	);
 	reportStartupDiagnostics(options.ctx, {
@@ -959,12 +952,140 @@ function renderMcpInstructions(
 ): string {
 	return [
 		"<mcp_instructions>",
-		...serverInstructions.map(
-			(instructions) =>
-				`  <server name="${escapeMcpInstructionAttribute(instructions.serverKey)}">\n${escapeMcpInstructionText(instructions.instructions)}\n  </server>`,
-		),
+		...serverInstructions.map(renderMcpServerInstruction),
 		"</mcp_instructions>",
 	].join("\n");
+}
+
+function renderMcpServerInstruction(instructions: ServerInstructions): string {
+	return `  <server name="${escapeMcpInstructionAttribute(instructions.serverKey)}">\n${escapeMcpInstructionText(instructions.instructions)}\n  </server>`;
+}
+
+/** Persists instructions for servers whose generated tools are active after startup restoration. */
+function persistActiveServerInstructions(
+	pi: ExtensionAPI,
+	records: readonly ServerInstructionRecord[],
+	branch: readonly unknown[],
+): void {
+	const activeToolNames = new Set(pi.getActiveTools());
+	const visible = records.filter((record) =>
+		record.registeredPiToolNames.some((name) => activeToolNames.has(name)),
+	);
+	const content =
+		visible.length === 0
+			? "<mcp_instructions />"
+			: renderMcpInstructions(visible);
+	if (hasCurrentMcpInstructions(branch, visible)) {
+		return;
+	}
+	pi.sendMessage(
+		{
+			customType: "mcp-instructions",
+			content,
+			display: false,
+			details: {
+				version: 1,
+				serverKeys: visible.map(({ serverKey }) => serverKey),
+			},
+		},
+		{ deliverAs: "steer" },
+	);
+}
+
+/** Checks instruction coverage in replacements and successful activation results after the latest context boundary. */
+function hasCurrentMcpInstructions(
+	branch: readonly unknown[],
+	records: readonly ServerInstructionRecord[],
+): boolean {
+	const expectedBlocks = new Set(records.map(renderMcpServerInstruction));
+	const currentBlocks = readEffectiveMcpInstructionBlocks(branch);
+	return (
+		currentBlocks.size === expectedBlocks.size &&
+		[...expectedBlocks].every((block) => currentBlocks.has(block))
+	);
+}
+
+interface McpInstructionCarrier {
+	readonly kind: "activation" | "replacement";
+	readonly content: string;
+}
+
+function readCurrentMcpInstructionCarriers(
+	branch: readonly unknown[],
+): McpInstructionCarrier[] {
+	const carriers: McpInstructionCarrier[] = [];
+	for (let index = branch.length - 1; index >= 0; index -= 1) {
+		const entry = branch[index];
+		if (!isRecord(entry)) {
+			continue;
+		}
+		if (entry["type"] === "compaction" || entry["type"] === "branch_summary") {
+			break;
+		}
+		const carrier = readMcpInstructionCarrier(entry);
+		if (carrier !== undefined) {
+			carriers.push(carrier);
+		}
+	}
+	return carriers;
+}
+
+function readEffectiveMcpInstructionBlocks(
+	branch: readonly unknown[],
+): Set<string> {
+	const blocks = new Set<string>();
+	for (const carrier of readCurrentMcpInstructionCarriers(branch)) {
+		for (const block of extractMcpInstructionBlocks(carrier.content)) {
+			blocks.add(block);
+		}
+		if (carrier.kind === "replacement") {
+			break;
+		}
+	}
+	return blocks;
+}
+
+function extractMcpInstructionBlocks(content: string): readonly string[] {
+	return (
+		content.match(/ {2}<server name="[^"]*">\n[\s\S]*?\n {2}<\/server>/g) ?? []
+	);
+}
+
+function readMcpInstructionCarrier(
+	entry: Record<string, unknown>,
+): McpInstructionCarrier | undefined {
+	if (
+		entry["type"] === "custom_message" &&
+		entry["customType"] === "mcp-instructions" &&
+		typeof entry["content"] === "string"
+	) {
+		return { kind: "replacement", content: entry["content"] };
+	}
+	if (entry["type"] !== "message") {
+		return undefined;
+	}
+	const message = entry["message"];
+	if (
+		!isRecord(message) ||
+		message["role"] !== "toolResult" ||
+		message["toolName"] !== "activate_toolset" ||
+		message["isError"] !== false ||
+		!Array.isArray(message["content"])
+	) {
+		return undefined;
+	}
+	const content = message["content"]
+		.filter(
+			(part): part is { readonly type: "text"; readonly text: string } =>
+				isRecord(part) &&
+				part["type"] === "text" &&
+				typeof part["text"] === "string",
+		)
+		.map(({ text }) => text)
+		.join("\n");
+	return content.includes("<mcp_instructions")
+		? { kind: "activation", content }
+		: undefined;
 }
 
 function escapeMcpInstructionText(value: string): string {
@@ -1076,6 +1197,10 @@ function formatRejectedTool(rejected: RejectedPiToolRoute): string {
 
 function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildStatusKey(serverKey: string): string {

--- a/pi-package/extensions/system-prompt/index.test.ts
+++ b/pi-package/extensions/system-prompt/index.test.ts
@@ -207,6 +207,7 @@ function createBeforeAgentStartEvent(
 			promptGuidelines: [
 				"Use read before editing files.",
 				"  ",
+				"  Use read before editing files.  ",
 				"Use bash only when command output is needed.",
 			],
 			appendSystemPrompt: "Append text",
@@ -246,7 +247,7 @@ describe("system-prompt", () => {
 	test("renders only requested dynamic variables from the Markdown template", async () => {
 		// Purpose: a template must own all static prose while variables inject only runtime values.
 		// Input and expected output: a custom template references every supported variable plus one unknown placeholder.
-		// Edge case: tools without prompt snippets, blank tool guidelines, and unknown placeholders are omitted.
+		// Edge case: blank and normalized duplicate tool guidelines plus unknown placeholders are omitted.
 		// Dependencies: this test uses isolated temp config/template files and in-memory pi lifecycle fakes.
 		await withIsolatedAgentDir(async ({ suiteDir }) => {
 			const templateFile = join(suiteDir, "template.md");
@@ -256,8 +257,6 @@ describe("system-prompt", () => {
 					"Static header",
 					"Date: {{date}}",
 					"CWD: {{cwd}}",
-					"Tools:",
-					"{{tools}}",
 					"Tool guidelines:",
 					"{{toolGuidelines}}",
 					"Append:",
@@ -294,10 +293,9 @@ describe("system-prompt", () => {
 			expect(prompt).toContain("Static header");
 			expect(prompt).toMatch(DATE_LINE_PATTERN);
 			expect(prompt).toContain("CWD: /tmp/project");
-			expect(prompt).toContain("- read: Read file contents");
-			expect(prompt).toContain("- bash: Execute shell commands");
-			expect(prompt).not.toContain("hidden");
-			expect(prompt).toContain("- Use read before editing files.");
+			expect(prompt.match(/- Use read before editing files\./g)).toHaveLength(
+				1,
+			);
 			expect(prompt).toContain(
 				"- Use bash only when command output is needed.",
 			);
@@ -479,9 +477,9 @@ describe("system-prompt", () => {
 		});
 	});
 
-	test("places bundled toolsets between skills and active tools", async () => {
+	test("places bundled toolsets between skills and tool guidelines", async () => {
 		// Purpose: the bundled template must expose the deferred catalog at the approved structural location.
-		// Input and expected output: the bundled template renders one eligible toolset beside populated skills and active tools.
+		// Input and expected output: the bundled template renders one eligible toolset between populated skills and guidelines.
 		// Edge case: placement is asserted by required section boundaries rather than mutable prompt prose.
 		// Dependencies: bundled template loading plus the shared runtime/composition lifecycle.
 		await withIsolatedAgentDir(async () => {
@@ -511,7 +509,7 @@ describe("system-prompt", () => {
 			expect(prompt.indexOf("<toolsets>")).toBeGreaterThan(
 				prompt.indexOf("</skills>"),
 			);
-			expect(prompt.indexOf("<tools>")).toBeGreaterThan(
+			expect(prompt.indexOf("<tool_guidelines>")).toBeGreaterThan(
 				prompt.indexOf("<toolsets>"),
 			);
 		});

--- a/pi-package/extensions/system-prompt/index.ts
+++ b/pi-package/extensions/system-prompt/index.ts
@@ -24,7 +24,6 @@ const CONFIG_KEYS = [ENABLED_CONFIG_KEY, TEMPLATE_FILE_CONFIG_KEY] as const;
 const SUPPORTED_TEMPLATE_VARIABLES = [
 	"date",
 	"cwd",
-	"tools",
 	"toolGuidelines",
 	"appendSystemPrompt",
 	"contextFiles",
@@ -256,7 +255,6 @@ function buildTemplateValues(
 	return {
 		date: getLocalDate(),
 		cwd: options.cwd.replace(/\\/g, "/"),
-		tools: formatTools(options),
 		toolGuidelines: formatToolGuidelines(options),
 		appendSystemPrompt: options.appendSystemPrompt ?? "",
 		contextFiles: formatContextFiles(options),
@@ -265,26 +263,12 @@ function buildTemplateValues(
 	};
 }
 
-/** Formats visible active tools as the one-line prompt snippets exposed by pi. */
-function formatTools(options: BuildSystemPromptOptions): string {
-	const tools = options.selectedTools ?? [...DEFAULT_SELECTED_TOOLS];
-	const visibleTools = tools.filter((name) =>
-		Boolean(options.toolSnippets?.[name]),
-	);
-	if (visibleTools.length === 0) {
-		return "(none)";
-	}
-
-	return visibleTools
-		.map((name) => `- ${name}: ${options.toolSnippets?.[name] ?? ""}`)
-		.join("\n");
-}
-
 /** Formats only dynamic promptGuidelines supplied by active tools or extensions. */
 function formatToolGuidelines(options: BuildSystemPromptOptions): string {
-	return (options.promptGuidelines ?? [])
+	const normalized = (options.promptGuidelines ?? [])
 		.map((guideline) => guideline.trim())
-		.filter((guideline) => guideline.length > 0)
+		.filter((guideline) => guideline.length > 0);
+	return [...new Set(normalized)]
 		.map((guideline) => `- ${guideline}`)
 		.join("\n");
 }

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -230,12 +230,6 @@ Skills guidelines:
 
 {{toolsets}}
 
-<tools>
-<available>
-{{tools}}
-</available>
-
-<guidelines>
+<tool_guidelines>
 {{toolGuidelines}}
-</guidelines>
-</tools>
+</tool_guidelines>

--- a/pi-package/extensions/workflow/context.test.ts
+++ b/pi-package/extensions/workflow/context.test.ts
@@ -1,170 +1,255 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { projectWorkflowContext } from "./context";
+import { WorkflowJournal, type WorkflowJournalRecord } from "./context";
 import {
-	activateWorkflow,
+	completeWorkflow,
+	createWorkflow,
+	editWorkflowStage,
 	transitionWorkflow,
-	validateWorkflowDefinition,
+	validateCreatedWorkflowDefinition,
 } from "./workflow";
 
-const prompts = {
-	extensionDescription: "Use <stages> & choose safely.",
-	createDescription: "create",
-	activateDescription: "activate",
-	getStageDescription: "get stage",
-	editStageDescription: "edit stage",
-	transitionDescription: "transition",
-};
-
-/** Creates a graph whose text and identifiers prove XML text and attribute escaping. */
-function workflow(
-	id = "delivery",
-	prompt: unknown = "Follow <global> & stay safe.",
-): ReturnType<typeof validateWorkflowDefinition> {
-	return validateWorkflowDefinition(
-		id,
+function workflow() {
+	return validateCreatedWorkflowDefinition(
 		{
+			id: "delivery",
 			description: "Build & review",
-			prompt,
+			prompt: "Follow <global> & stay safe.",
 			stages: [
 				{
-					id: "start",
-					description: 'Start "now"',
-					prompt: "Start <carefully>",
+					id: "implementation",
+					description: 'Implement "now"',
+					prompt: "Implement <carefully>",
+					model: { thinking: "medium" },
 					initial: true,
 				},
 				{
-					id: "done",
-					description: "Done",
+					id: "review",
+					description: "Review result",
 					prompt: "Review & finish",
+					model: { thinking: "medium" },
 					final: true,
 				},
 			],
 			transitions: [
-				{ from: "start", to: "done", type: "advance" },
-				{ from: "done", to: "start", type: "rework" },
+				{ from: "implementation", to: "review", type: "advance" },
+				{ from: "review", to: "implementation", type: "rework" },
 			],
 		},
-		"fixture.yaml",
+		"fixture",
 	);
 }
 
-/** Reads content only from the custom message produced by the projection boundary. */
-function customContent(message: AgentMessage | undefined): string {
-	if (message?.role !== "custom") {
-		throw new Error("expected a custom workflow message");
-	}
-	return String(message.content);
+function createJournal(): {
+	readonly journal: WorkflowJournal;
+	readonly records: WorkflowJournalRecord[];
+} {
+	const records: WorkflowJournalRecord[] = [];
+	return {
+		journal: new WorkflowJournal((record) => records.push(record)),
+		records,
+	};
 }
 
-describe("workflow context projection", () => {
-	/** Proves prior chained messages are preserved and exactly one hidden transient message is appended. */
-	test("projects activation options before activation", () => {
-		const prior = [
-			{ role: "user", content: "keep me", timestamp: 1 },
-		] as AgentMessage[];
-		const projected = projectWorkflowContext(
-			prior,
-			prompts,
-			[workflow()],
-			undefined,
-		);
-		expect(projected).toHaveLength(2);
-		expect(projected[0]).toBe(prior[0]);
-		expect(projected[1]).toMatchObject({
-			role: "custom",
+describe("workflow journal", () => {
+	test("publishes activation and the initial stage definition in one hidden record", () => {
+		// Purpose: workflow activation must establish the complete graph and current-stage instructions once.
+		// Input and expected output: a dynamic workflow emits workflow_activated followed by an inline initial-stage activation.
+		// Edge case: XML-sensitive configured text is escaped and the inactive-stage prompt is not exposed.
+		// Dependencies: validated workflow state and the journal publisher callback.
+		const { journal, records } = createJournal();
+		journal.activate(createWorkflow(workflow()));
+
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({
 			customType: "workflow",
 			display: false,
+			details: {
+				version: 1,
+				kind: "activation",
+				workflowId: "delivery",
+				stageId: "implementation",
+			},
 		});
-		const content = customContent(projected[1]);
-		expect(content).toContain("Use &lt;stages&gt; &amp; choose safely.");
+		const content = records[0]?.content ?? "";
+		expect(content.indexOf("<workflow_activated")).toBeLessThan(
+			content.indexOf("<workflow_stage_activated"),
+		);
+		expect(content).toContain('id="delivery" source="dynamic"');
+		expect(content).toContain("Follow &lt;global&gt; &amp; stay safe.");
 		expect(content).toContain(
+			'id="implementation" description="Implement &quot;now&quot;" initial="true"',
+		);
+		expect(content).toContain('guidelines="inline"');
+		expect(content).toContain("Implement &lt;carefully&gt;");
+		expect(content).not.toContain("Review &amp; finish");
+	});
+
+	test("reuses known stage definitions while repeating route-dependent transitions", () => {
+		// Purpose: repeated stage entry must preserve activation history without repeating stage prompts.
+		// Input and expected output: first review entry is inline, then rework and advance entries reuse known definitions.
+		// Edge case: every activation still carries its current outgoing transition.
+		// Dependencies: immutable workflow transitions and journal-local known-stage tracking.
+		const { journal, records } = createJournal();
+		let state = createWorkflow(workflow());
+		journal.activate(state);
+		state = transitionWorkflow(state, "review");
+		journal.enterStage(state);
+		state = transitionWorkflow(state, "implementation");
+		journal.enterStage(state);
+		state = transitionWorkflow(state, "review");
+		journal.enterStage(state);
+
+		expect(records[1]?.content).toContain(
+			'<workflow_stage_activated workflow_id="delivery" stage_id="review" guidelines="inline">',
+		);
+		expect(records[1]?.content).toContain("Review &amp; finish");
+		expect(records[2]?.content).toContain('guidelines="reuse"');
+		expect(records[2]?.content).toContain(
+			'<transition to="review" type="advance" />',
+		);
+		expect(records[3]?.content).toContain('guidelines="reuse"');
+		expect(records[3]?.content).toContain(
+			'<transition to="implementation" type="rework" />',
+		);
+	});
+
+	test("publishes complete edited stage definitions and completion records", () => {
+		// Purpose: edits and completion must replace model-visible stage data without snapshot repetition.
+		// Input and expected output: one active-stage edit emits a complete update, then final completion emits rework options.
+		// Edge case: completion carries no completed-stage prompt.
+		// Dependencies: dynamic stage editing, transition validation, and workflow completion.
+		const { journal, records } = createJournal();
+		let state = createWorkflow(workflow());
+		journal.activate(state);
+		state = editWorkflowStage(
+			state,
+			{
+				stageId: "implementation",
+				description: "Implement corrected change",
+				prompt: "Use corrected <requirements>.",
+				model: { thinking: "high" },
+			},
+			"test",
+		);
+		journal.updateStage(state, "implementation");
+		state = transitionWorkflow(state, "review");
+		journal.enterStage(state);
+		const completed = completeWorkflow(state);
+		journal.complete(completed);
+
+		expect(records[1]?.content).toContain(
+			'<workflow_stage_updated workflow_id="delivery" stage_id="implementation" active="true">',
+		);
+		expect(records[1]?.content).toContain(
+			'<stage_definition description="Implement corrected change" initial="true">',
+		);
+		expect(records[1]?.content).toContain(
+			"Use corrected &lt;requirements&gt;.",
+		);
+		expect(records[3]?.content).toContain(
+			'<workflow_completed id="delivery" completed_stage_id="review">',
+		);
+		expect(records[3]?.content).toContain(
+			'<transition to="implementation" type="rework" />',
+		);
+		expect(records[3]?.content).not.toContain("Review &amp; finish");
+	});
+
+	test("restores the active stage after an inactive stage update", () => {
+		// Purpose: an inactive-stage definition update must not replace the lifecycle active-stage marker.
+		// Input and expected output: activation plus an inactive review edit restores as compatible with implementation still active.
+		// Edge case: the edited stage ID differs from the route tail.
+		// Dependencies: journal metadata restoration and dynamic stage editing.
+		const { journal, records } = createJournal();
+		let state = createWorkflow(workflow());
+		journal.activate(state);
+		state = editWorkflowStage(
+			state,
+			{
+				stageId: "review",
+				description: "Revised review",
+				prompt: "Use revised review.",
+				model: { thinking: "high" },
+			},
+			"test",
+		);
+		journal.updateStage(state, "review");
+		const restored = new WorkflowJournal(() => {});
+		restored.restore(
+			records.map((message) => ({
+				type: "custom_message",
+				...message,
+			})),
+		);
+
+		expect(restored.isCurrent(state)).toBe(true);
+	});
+
+	test("rejects restoration that omits the latest stage definition edit", () => {
+		// Purpose: restoration repair must detect state that is newer than the latest model-facing workflow record.
+		// Input and expected output: activation records followed by an unrecorded stage edit are incompatible with edited state.
+		// Edge case: workflow ID, status, and route-tail stage remain unchanged across the edit.
+		// Dependencies: workflow-definition revision metadata and journal restoration.
+		const { journal, records } = createJournal();
+		let state = createWorkflow(workflow());
+		journal.activate(state);
+		state = editWorkflowStage(
+			state,
+			{
+				stageId: "implementation",
+				description: "Unrecorded correction",
+				prompt: "Use the corrected definition.",
+				model: { thinking: "high" },
+			},
+			"test",
+		);
+		const restored = new WorkflowJournal(() => {});
+		restored.restore(
+			records.map((message) => ({
+				type: "custom_message",
+				...message,
+			})),
+		);
+
+		expect(restored.isCurrent(state)).toBe(false);
+	});
+
+	test("preserves activation-option deduplication during repair checkpoints", () => {
+		// Purpose: branch repair must not republish unchanged catalog availability in the same context segment.
+		// Input and expected output: equal options before and after a checkpoint produce one options record.
+		// Edge case: checkpoint still publishes the complete active workflow state.
+		// Dependencies: checkpoint lifecycle rendering and activation-options deduplication.
+		const { journal, records } = createJournal();
+		const state = createWorkflow(workflow());
+		journal.activationOptions([workflow()]);
+		journal.checkpoint(state);
+		journal.activationOptions([workflow()]);
+
+		expect(records).toHaveLength(2);
+		expect(records[0]?.content).toContain("<workflow_activation_options>");
+		expect(records[1]?.content).toContain("<workflow_checkpoint");
+	});
+
+	test("resets known stages at checkpoints and deduplicates activation options", () => {
+		// Purpose: compaction repair must inline current instructions and availability must change only when its rendered value changes.
+		// Input and expected output: one active checkpoint is followed by one options record despite two equivalent publications.
+		// Edge case: an empty options list emits the explicit self-closing replacement record.
+		// Dependencies: checkpoint rendering, known-stage reset, and ordered catalog options.
+		const { journal, records } = createJournal();
+		const state = createWorkflow(workflow());
+		journal.checkpoint(state);
+		journal.activationOptions([workflow()]);
+		journal.activationOptions([workflow()]);
+		journal.activationOptions([]);
+
+		expect(records[0]?.content).toContain(
+			'<workflow_checkpoint id="delivery" status="active" active_stage_id="implementation">',
+		);
+		expect(records[0]?.content).toContain("<active_stage_guidelines>");
+		expect(records[1]?.content).toContain(
 			'<workflow id="delivery" description="Build &amp; review" />',
 		);
-		expect(content).not.toContain("<active_workflow");
-	});
-
-	/**
-	 * Proves active context contains persistent workflow guidance and only the current stage prompt.
-	 * Input and expected output: activation projects both escaped prompts, then transition retains workflow guidance and replaces the stage prompt.
-	 * Edge case: XML metacharacters in both prompts remain element text.
-	 * Dependencies: validated workflow state and context projection.
-	 */
-	test("projects one active snapshot without exposing its route", () => {
-		const activeWorkflow = workflow();
-		const initialContent = customContent(
-			projectWorkflowContext(
-				[],
-				prompts,
-				[],
-				activateWorkflow(activeWorkflow),
-			)[0],
-		);
-		expect(initialContent).toContain(
-			"<guidelines>\nFollow &lt;global&gt; &amp; stay safe.\n  </guidelines>\n  <active_stage_guidelines>\nStart &lt;carefully&gt;\n  </active_stage_guidelines>",
-		);
-
-		const state = transitionWorkflow(activateWorkflow(activeWorkflow), "done");
-		const other = workflow("other");
-		const projected = projectWorkflowContext([], prompts, [other], state);
-		const content = customContent(projected[0]);
-		expect(content).toContain(
-			'<workflow id="other" description="Build &amp; review" />',
-		);
-		expect(content).not.toContain('<workflow id="delivery" description=');
-		expect(content).toContain(
-			'<active_workflow id="delivery" active_stage_id="done">\n  <guidelines>\nFollow &lt;global&gt; &amp; stay safe.\n  </guidelines>\n  <active_stage_guidelines>\nReview &amp; finish\n  </active_stage_guidelines>',
-		);
-		expect(content).not.toContain("Start &lt;carefully&gt;");
-		expect(content).toContain(
-			'id="start" description="Start &quot;now&quot;" status="completed" initial="true"',
-		);
-		expect(content).toContain(
-			'id="done" description="Done" status="in_progress" final="true"',
-		);
-		expect(content).toContain('<transition to="start" type="rework" />');
-		expect(content).not.toContain("<route");
-	});
-
-	/**
-	 * Proves absent workflow guidance emits no empty XML section.
-	 * Input and expected output: a whitespace-only workflow prompt projects the active stage without `<guidelines>`.
-	 * Edge case: normalization happens before projection rather than rendering whitespace.
-	 * Dependencies: workflow validation and context projection.
-	 */
-	test("omits empty workflow guidelines", () => {
-		const activeWorkflow = workflow("empty", " \n\t ");
-		const content = customContent(
-			projectWorkflowContext(
-				[],
-				prompts,
-				[],
-				activateWorkflow(activeWorkflow),
-			)[0],
-		);
-		expect(content).not.toContain("<guidelines>");
-		expect(content).toContain("<active_stage_guidelines>");
-	});
-
-	/**
-	 * Proves empty activation options are omitted while universal guidance and saved state remain projectable.
-	 * Input and expected output: no options first produces guidelines only, then saved state adds active_workflow.
-	 * Edge case: neither context shape contains a self-closing activation element.
-	 * Dependencies: context projection and one validated catalog state.
-	 */
-	test("omits empty activation options", () => {
-		const guidelinesOnly = customContent(
-			projectWorkflowContext([], prompts, [], undefined)[0],
-		);
-		expect(guidelinesOnly).toContain("<workflow_guidelines>");
-		expect(guidelinesOnly).not.toContain("<workflow_activation_options");
-		expect(guidelinesOnly).not.toContain("<active_workflow");
-
-		const state = activateWorkflow(workflow());
-		const savedContent = customContent(
-			projectWorkflowContext([], prompts, [], state)[0],
-		);
-		expect(savedContent).not.toContain("<workflow_activation_options");
-		expect(savedContent).toContain("<active_workflow");
+		expect(records[2]?.content).toBe("<workflow_activation_options />");
+		expect(records).toHaveLength(3);
 	});
 });

--- a/pi-package/extensions/workflow/context.ts
+++ b/pi-package/extensions/workflow/context.ts
@@ -1,58 +1,327 @@
-import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { WorkflowPrompts } from "./config";
+import { createHash } from "node:crypto";
 import {
 	getAvailableTransitions,
-	getStageStatuses,
 	type WorkflowDefinition,
+	type WorkflowStage,
 	type WorkflowState,
+	type WorkflowTransition,
 } from "./workflow";
 
-/** Appends one transient workflow message to the current chained provider context. */
-export function projectWorkflowContext(
-	messages: readonly AgentMessage[],
-	prompts: WorkflowPrompts,
-	activationOptions: readonly WorkflowDefinition[],
-	state: WorkflowState | undefined,
-): AgentMessage[] {
-	const content = renderWorkflowContext(
-		prompts.extensionDescription,
-		activationOptions,
-		state,
-	);
-	return [
-		...messages,
-		{
-			role: "custom",
+export interface WorkflowJournalRecord {
+	readonly customType: "workflow";
+	readonly content: string;
+	readonly display: false;
+	readonly details: Readonly<Record<string, unknown>>;
+}
+
+type WorkflowJournalKind =
+	| "activation"
+	| "stage_activation"
+	| "stage_update"
+	| "completion"
+	| "checkpoint"
+	| "activation_options";
+
+/** Publishes append-only hidden workflow records and tracks definitions known in the current context segment. */
+export class WorkflowJournal {
+	private readonly knownStages = new Set<string>();
+	private currentWorkflowId: string | undefined;
+	private currentStatus: WorkflowState["status"] | undefined;
+	private currentStageId: string | undefined;
+	private currentWorkflowRevision: string | undefined;
+	private activationOptionsContent: string | undefined;
+
+	public constructor(
+		private readonly publish: (record: WorkflowJournalRecord) => void,
+	) {}
+
+	public activate(state: WorkflowState): void {
+		const stage = requireCurrentStage(state);
+		this.knownStages.clear();
+		this.knownStages.add(stage.id);
+		this.setCurrentState(state);
+		this.publishRecord(
+			renderWorkflowActivation(state, stage),
+			"activation",
+			state,
+			{ stageId: stage.id, guidelines: "inline" },
+		);
+	}
+
+	public enterStage(state: WorkflowState): void {
+		const stage = requireCurrentStage(state);
+		const guidelines = this.knownStages.has(stage.id) ? "reuse" : "inline";
+		this.knownStages.add(stage.id);
+		this.setCurrentState(state);
+		this.publishRecord(
+			renderStageActivation(state, stage, guidelines),
+			"stage_activation",
+			state,
+			{ stageId: stage.id, guidelines },
+		);
+	}
+
+	public updateStage(state: WorkflowState, stageId: string): void {
+		const stage = state.workflow.stages.find(({ id }) => id === stageId);
+		if (stage === undefined) {
+			throw new Error(`workflow stage does not exist: ${stageId}`);
+		}
+		this.knownStages.add(stageId);
+		this.setCurrentState(state);
+		this.publishRecord(renderStageUpdate(state, stage), "stage_update", state, {
+			stageId,
+			active: state.status === "active" && state.route.at(-1) === stageId,
+		});
+	}
+
+	public complete(state: WorkflowState): void {
+		if (state.status !== "completed") {
+			throw new Error("workflow completion record requires completed state");
+		}
+		const stage = requireCurrentStage(state);
+		this.setCurrentState(state);
+		this.publishRecord(
+			renderWorkflowCompletion(state, stage.id),
+			"completion",
+			state,
+			{ stageId: stage.id },
+		);
+	}
+
+	public checkpoint(state: WorkflowState): void {
+		const stage = requireCurrentStage(state);
+		this.knownStages.clear();
+		if (state.status === "active") {
+			this.knownStages.add(stage.id);
+		}
+		this.setCurrentState(state);
+		this.publishRecord(
+			renderWorkflowCheckpoint(state, stage),
+			"checkpoint",
+			state,
+			{ stageId: stage.id },
+		);
+	}
+
+	public activationOptions(workflows: readonly WorkflowDefinition[]): void {
+		const content = renderActivationOptions(workflows);
+		if (content === this.activationOptionsContent) {
+			return;
+		}
+		this.activationOptionsContent = content;
+		this.publish({
 			customType: "workflow",
 			content,
 			display: false,
-			timestamp: Date.now(),
-		},
-	];
+			details: { version: 1, kind: "activation_options" },
+		});
+	}
+
+	/** Clears journal-local state when Pi starts a new provider-visible context segment. */
+	public startContextSegment(): void {
+		this.knownStages.clear();
+		this.currentWorkflowId = undefined;
+		this.currentStatus = undefined;
+		this.currentStageId = undefined;
+		this.currentWorkflowRevision = undefined;
+		this.activationOptionsContent = undefined;
+	}
+
+	/** Rebuilds journal-local deduplication state from the current post-compaction branch segment. */
+	public restore(branch: readonly unknown[]): void {
+		this.startContextSegment();
+		const start = findCurrentContextSegmentStart(branch);
+		for (const entry of branch.slice(start)) {
+			const message = readWorkflowMessage(entry);
+			if (message === undefined) {
+				continue;
+			}
+			this.restoreRecord(message.details, message.content);
+		}
+	}
+
+	/** Returns whether the current context segment already contains a compatible lifecycle record. */
+	public isCurrent(state: WorkflowState): boolean {
+		return (
+			this.currentWorkflowId === state.workflow.id &&
+			this.currentStatus === state.status &&
+			this.currentStageId === state.route.at(-1) &&
+			this.currentWorkflowRevision === getWorkflowRevision(state.workflow)
+		);
+	}
+
+	private restoreRecord(
+		details: Readonly<Record<string, unknown>>,
+		content: string,
+	): void {
+		if (details["version"] !== 1) {
+			return;
+		}
+		const kind = details["kind"];
+		if (kind === "activation_options") {
+			this.activationOptionsContent = content;
+			return;
+		}
+		const workflowId = details["workflowId"];
+		const stageId = details["stageId"];
+		const currentStageId = details["currentStageId"];
+		const status = details["status"];
+		const workflowRevision = details["workflowRevision"];
+		if (
+			typeof workflowId !== "string" ||
+			typeof stageId !== "string" ||
+			typeof currentStageId !== "string" ||
+			typeof workflowRevision !== "string" ||
+			(status !== "active" && status !== "completed")
+		) {
+			return;
+		}
+		if (kind === "activation" || kind === "checkpoint") {
+			this.knownStages.clear();
+		}
+		if (
+			kind === "activation" ||
+			(kind === "stage_activation" && details["guidelines"] === "inline") ||
+			kind === "stage_update" ||
+			(kind === "checkpoint" && status === "active")
+		) {
+			this.knownStages.add(stageId);
+		}
+		this.currentWorkflowId = workflowId;
+		this.currentStatus = status;
+		this.currentStageId = currentStageId;
+		this.currentWorkflowRevision = workflowRevision;
+	}
+
+	private setCurrentState(state: WorkflowState): void {
+		this.currentWorkflowId = state.workflow.id;
+		this.currentStatus = state.status;
+		this.currentStageId = state.route.at(-1);
+		this.currentWorkflowRevision = getWorkflowRevision(state.workflow);
+	}
+
+	private publishRecord(
+		content: string,
+		kind: Exclude<WorkflowJournalKind, "activation_options">,
+		state: WorkflowState,
+		metadata: Readonly<Record<string, unknown>> & { readonly stageId: string },
+	): void {
+		this.publish({
+			customType: "workflow",
+			content,
+			display: false,
+			details: {
+				version: 1,
+				kind,
+				workflowId: state.workflow.id,
+				status: state.status,
+				currentStageId: state.route.at(-1),
+				workflowRevision: getWorkflowRevision(state.workflow),
+				...metadata,
+			},
+		});
+	}
 }
 
-/** Renders guidelines, activation options, and the optional saved snapshot. */
-function renderWorkflowContext(
-	guidelines: string,
-	activationOptions: readonly WorkflowDefinition[],
-	state: WorkflowState | undefined,
+function renderWorkflowActivation(
+	state: WorkflowState,
+	stage: WorkflowStage,
 ): string {
-	const sections = [
-		`<workflow_guidelines>\n${escapeXml(guidelines)}\n</workflow_guidelines>`,
-	];
-	if (activationOptions.length > 0) {
-		sections.push(renderActivationOptions(activationOptions));
-	}
-	if (state !== undefined) {
-		sections.push(renderActiveWorkflow(state));
-	}
-	return sections.join("\n\n");
+	const workflow = state.workflow;
+	const stages = workflow.stages.map((item) => {
+		const flags = `${item.initial ? ' initial="true"' : ""}${item.final ? ' final="true"' : ""}`;
+		return `    <stage id="${escapeXml(item.id)}" description="${escapeXml(item.description)}"${flags} />`;
+	});
+	const transitions = workflow.transitions.map(
+		(edge) =>
+			`    <transition from="${escapeXml(edge.from)}" to="${escapeXml(edge.to)}" type="${edge.type}" />`,
+	);
+	return [
+		`<workflow_activated id="${escapeXml(workflow.id)}" source="${state.source}">`,
+		...renderOptionalGuidelines(workflow.prompt, "guidelines", "  "),
+		"  <stages>",
+		...stages,
+		"  </stages>",
+		"  <transitions>",
+		...transitions,
+		"  </transitions>",
+		"</workflow_activated>",
+		"",
+		renderStageActivation(state, stage, "inline"),
+	].join("\n");
 }
 
-/** Renders the non-empty activation options supplied by availability resolution. */
+function renderStageActivation(
+	state: WorkflowState,
+	stage: WorkflowStage,
+	guidelines: "inline" | "reuse",
+): string {
+	return [
+		`<workflow_stage_activated workflow_id="${escapeXml(state.workflow.id)}" stage_id="${escapeXml(stage.id)}" guidelines="${guidelines}">`,
+		...(guidelines === "inline"
+			? [
+					"  <stage_guidelines>",
+					escapeXml(stage.prompt),
+					"  </stage_guidelines>",
+				]
+			: []),
+		...renderAvailableTransitions(getAvailableTransitions(state), "  "),
+		"</workflow_stage_activated>",
+	].join("\n");
+}
+
+function renderStageUpdate(state: WorkflowState, stage: WorkflowStage): string {
+	const active = state.status === "active" && state.route.at(-1) === stage.id;
+	const flags = `${stage.initial ? ' initial="true"' : ""}${stage.final ? ' final="true"' : ""}`;
+	return [
+		`<workflow_stage_updated workflow_id="${escapeXml(state.workflow.id)}" stage_id="${escapeXml(stage.id)}" active="${active}">`,
+		`  <stage_definition description="${escapeXml(stage.description)}"${flags}>`,
+		"    <stage_guidelines>",
+		escapeXml(stage.prompt),
+		"    </stage_guidelines>",
+		"  </stage_definition>",
+		"</workflow_stage_updated>",
+	].join("\n");
+}
+
+function renderWorkflowCompletion(
+	state: WorkflowState,
+	stageId: string,
+): string {
+	return [
+		`<workflow_completed id="${escapeXml(state.workflow.id)}" completed_stage_id="${escapeXml(stageId)}">`,
+		...renderAvailableTransitions(getAvailableTransitions(state), "  "),
+		"</workflow_completed>",
+	].join("\n");
+}
+
+function renderWorkflowCheckpoint(
+	state: WorkflowState,
+	stage: WorkflowStage,
+): string {
+	const stageAttribute =
+		state.status === "active" ? "active_stage_id" : "completed_stage_id";
+	return [
+		`<workflow_checkpoint id="${escapeXml(state.workflow.id)}" status="${state.status}" ${stageAttribute}="${escapeXml(stage.id)}">`,
+		...renderOptionalGuidelines(state.workflow.prompt, "guidelines", "  "),
+		...(state.status === "active"
+			? [
+					"  <active_stage_guidelines>",
+					escapeXml(stage.prompt),
+					"  </active_stage_guidelines>",
+				]
+			: []),
+		...renderAvailableTransitions(getAvailableTransitions(state), "  "),
+		"</workflow_checkpoint>",
+	].join("\n");
+}
+
 function renderActivationOptions(
 	workflows: readonly WorkflowDefinition[],
 ): string {
+	if (workflows.length === 0) {
+		return "<workflow_activation_options />";
+	}
 	return [
 		"<workflow_activation_options>",
 		...workflows.map(
@@ -63,74 +332,77 @@ function renderActivationOptions(
 	].join("\n");
 }
 
-/** Renders the saved definition with route-derived statuses and allowed transitions. */
-function renderActiveWorkflow(state: WorkflowState): string {
-	const statuses = getStageStatuses(state);
-	const activeStageId = state.route.at(-1);
-	if (activeStageId === undefined) {
-		throw new Error("active workflow route must be non-empty");
-	}
-	const activeStage = state.workflow.stages.find(
-		(stage) => stage.id === activeStageId,
-	);
-	if (activeStage === undefined) {
-		throw new Error("active workflow stage must exist");
-	}
-	const stages = state.workflow.stages.map((stage) => {
-		const flags = [
-			stage.initial ? ' initial="true"' : "",
-			stage.final ? ' final="true"' : "",
-		].join("");
-		return `    <stage id="${escapeXml(stage.id)}" description="${escapeXml(stage.description)}" status="${statuses.get(stage.id)}"${flags} />`;
-	});
-	const transitions = state.workflow.transitions.map(
-		(edge) =>
-			`    <transition from="${escapeXml(edge.from)}" to="${escapeXml(edge.to)}" type="${edge.type}" />`,
-	);
-	const available = getAvailableTransitions(state).map(
-		(edge) =>
-			`    <transition to="${escapeXml(edge.to)}" type="${edge.type}" />`,
-	);
-	const workflowTag =
-		state.status === "completed" ? "completed_workflow" : "active_workflow";
-	const stageAttribute =
-		state.status === "completed" ? "completed_stage_id" : "active_stage_id";
-	const stageGuidelines =
-		state.status === "active"
-			? [
-					"  <active_stage_guidelines>",
-					escapeXml(activeStage.prompt),
-					"  </active_stage_guidelines>",
-				]
-			: [];
-	return [
-		`<${workflowTag} id="${escapeXml(state.workflow.id)}" ${stageAttribute}="${escapeXml(activeStageId)}">`,
-		...(state.workflow.prompt === undefined
-			? []
-			: [
-					"  <guidelines>",
-					escapeXml(state.workflow.prompt),
-					"  </guidelines>",
-				]),
-		...stageGuidelines,
-		"  <stages>",
-		...stages,
-		"  </stages>",
-		"  <transitions>",
-		...transitions,
-		"  </transitions>",
-		...(available.length === 0
-			? ["  <available_transitions />"]
-			: [
-					"  <available_transitions>",
-					...available,
-					"  </available_transitions>",
-				]),
-		`</${workflowTag}>`,
-	].join("\n");
+function renderOptionalGuidelines(
+	prompt: string | undefined,
+	tag: string,
+	indent: string,
+): readonly string[] {
+	return prompt === undefined
+		? []
+		: [`${indent}<${tag}>`, escapeXml(prompt), `${indent}</${tag}>`];
 }
 
-/** Escapes configured and workflow text before placing it in XML text or attributes. */
+function renderAvailableTransitions(
+	transitions: readonly WorkflowTransition[],
+	indent: string,
+): readonly string[] {
+	if (transitions.length === 0) {
+		return [`${indent}<available_transitions />`];
+	}
+	return [
+		`${indent}<available_transitions>`,
+		...transitions.map(
+			(edge) =>
+				`${indent}  <transition to="${escapeXml(edge.to)}" type="${edge.type}" />`,
+		),
+		`${indent}</available_transitions>`,
+	];
+}
+
+function requireCurrentStage(state: WorkflowState): WorkflowStage {
+	const stageId = state.route.at(-1);
+	const stage = state.workflow.stages.find(({ id }) => id === stageId);
+	if (stage === undefined) {
+		throw new Error("active workflow stage must exist");
+	}
+	return stage;
+}
+
+function findCurrentContextSegmentStart(branch: readonly unknown[]): number {
+	for (let index = branch.length - 1; index >= 0; index -= 1) {
+		const entry = branch[index];
+		if (
+			isRecord(entry) &&
+			(entry["type"] === "compaction" || entry["type"] === "branch_summary")
+		) {
+			return index + 1;
+		}
+	}
+	return 0;
+}
+
+function readWorkflowMessage(entry: unknown):
+	| {
+			readonly content: string;
+			readonly details: Readonly<Record<string, unknown>>;
+	  }
+	| undefined {
+	if (
+		!isRecord(entry) ||
+		entry["type"] !== "custom_message" ||
+		entry["customType"] !== "workflow" ||
+		typeof entry["content"] !== "string" ||
+		!isRecord(entry["details"])
+	) {
+		return undefined;
+	}
+	return { content: entry["content"], details: entry["details"] };
+}
+
+function getWorkflowRevision(workflow: WorkflowDefinition): string {
+	return createHash("sha256").update(JSON.stringify(workflow)).digest("hex");
+}
+
 function escapeXml(value: string): string {
 	return value
 		.replaceAll("&", "&amp;")
@@ -138,4 +410,8 @@ function escapeXml(value: string): string {
 		.replaceAll(">", "&gt;")
 		.replaceAll('"', "&quot;")
 		.replaceAll("'", "&apos;");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -23,7 +23,11 @@ import {
 	type WorkflowTriggerRunResult,
 } from "../../shared/workflow-trigger-runtime";
 import workflowExtension from "./index";
-import { activateWorkflow, validateWorkflowDefinition } from "./workflow";
+import {
+	activateWorkflow,
+	validateWorkflowDefinition,
+	WORKFLOW_STATE_JOURNAL_VERSION,
+} from "./workflow";
 
 type WidgetFactory = (tui: TUI, theme: Theme) => Component;
 type WidgetContent = string[] | WidgetFactory | undefined;
@@ -31,6 +35,7 @@ type WidgetContent = string[] | WidgetFactory | undefined;
 interface FakeTool {
 	readonly name: string;
 	readonly description: string;
+	readonly promptGuidelines?: readonly string[];
 	readonly executionMode?: string;
 	readonly parameters: unknown;
 	readonly execute: (...args: unknown[]) => Promise<unknown>;
@@ -41,6 +46,13 @@ interface FakePi {
 	readonly listeners: Map<string, Set<(...args: unknown[]) => void>>;
 	readonly tools: FakeTool[];
 	readonly appended: Array<{ customType: string; data: unknown }>;
+	readonly messages: Array<{
+		readonly customType: string;
+		readonly content: string;
+		readonly display: boolean;
+		readonly details: unknown;
+		readonly options: unknown;
+	}>;
 	readonly notifications: Array<{ message: string; type: string | undefined }>;
 	readonly modelSetCalls: Model<Api>[];
 	readonly modelRegistry: ExtensionContext["modelRegistry"];
@@ -243,6 +255,7 @@ function activatedEntry(): unknown {
 			workflow,
 			route: state.route,
 			restoration: { modelId: "openai/current-model", thinking: "medium" },
+			journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 		},
 	};
 }
@@ -269,6 +282,7 @@ async function createFakePi(): Promise<FakePi> {
 		listeners: new Map(),
 		tools: [],
 		appended: [],
+		messages: [],
 		notifications,
 		modelSetCalls: [],
 		modelRegistry: {
@@ -318,6 +332,23 @@ async function createFakePi(): Promise<FakePi> {
 				throw fake.appendError;
 			}
 			fake.appended.push({ customType, data });
+		},
+		sendMessage(
+			message: {
+				customType: string;
+				content: unknown;
+				display: boolean;
+				details?: unknown;
+			},
+			options?: unknown,
+		) {
+			fake.messages.push({
+				customType: message.customType,
+				content: String(message.content),
+				display: message.display,
+				details: message.details,
+				options,
+			});
 		},
 		registerFlag(
 			name: string,
@@ -399,6 +430,15 @@ async function runLifecycle(
 	);
 }
 
+/** Invokes the post-compaction lifecycle handler. */
+async function runSessionCompact(fake: FakePi): Promise<void> {
+	const handler = fake.handlers.get("session_compact");
+	if (handler === undefined) {
+		throw new Error("missing session_compact handler");
+	}
+	await handler({ type: "session_compact" });
+}
+
 /** Invokes the session-level settlement handler without providing a UI context. */
 async function runAgentSettled(fake: FakePi): Promise<void> {
 	const handler = fake.handlers.get("agent_settled");
@@ -424,16 +464,22 @@ function renderLatestStatus(fake: FakePi, width: number): string[] {
 		.map((row) => stripVTControlCharacters(row));
 }
 
-/** Invokes the context handler and returns its optional replacement. */
-async function runContext(
-	fake: FakePi,
-	messages: readonly unknown[],
-): Promise<unknown> {
-	const handler = fake.handlers.get("context");
-	if (handler === undefined) {
-		throw new Error("context handler missing");
-	}
-	return handler({ messages }, {});
+/** Returns content from the latest persisted workflow lifecycle record. */
+function latestWorkflowContent(fake: FakePi): string | undefined {
+	return (
+		[...fake.messages]
+			.reverse()
+			.find(({ details }) => isWorkflowLifecycleDetails(details)) ??
+		fake.messages.at(-1)
+	)?.content;
+}
+
+function isWorkflowLifecycleDetails(details: unknown): boolean {
+	return (
+		typeof details === "object" &&
+		details !== null &&
+		Reflect.get(details, "kind") !== "activation_options"
+	);
 }
 
 afterEach(async () => {
@@ -473,6 +519,15 @@ describe("workflow extension lifecycle", () => {
 		]);
 		expect(
 			fake.tools.every(({ executionMode }) => executionMode === "sequential"),
+		).toBe(true);
+		const workflowGuideline = fake.tools[0]?.promptGuidelines?.[0];
+		expect(workflowGuideline?.length).toBeGreaterThan(0);
+		expect(
+			fake.tools.every(
+				({ promptGuidelines }) =>
+					promptGuidelines?.length === 1 &&
+					promptGuidelines[0] === workflowGuideline,
+			),
 		).toBe(true);
 		await runLifecycle(fake, "session_start");
 		await runLifecycle(fake, "session_tree");
@@ -600,7 +655,7 @@ describe("workflow extension lifecycle", () => {
 	 * Proves a valid empty catalog keeps workflow_create and universal guidance without activation options.
 	 * Input and expected output: no YAML and no saved state leave only workflow_create active and project guidelines only.
 	 * Edge case: workflow_activate and workflow_transition are system-suppressed independently.
-	 * Dependencies: lifecycle reconciliation, prompt loading, and provider-context projection.
+	 * Dependencies: lifecycle reconciliation, prompt loading, and activation-options journaling.
 	 */
 	test("keeps creation active for an empty catalog", async () => {
 		await createSuite();
@@ -608,14 +663,9 @@ describe("workflow extension lifecycle", () => {
 		await runLifecycle(fake, "session_start");
 
 		expect(fake.activeTools).toEqual(["read", "workflow_create"]);
-		const context = await runContext(fake, []);
-		const content = String(
-			(context as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
-		expect(content).toContain("<workflow_guidelines>");
-		expect(content).not.toContain("<workflow_activation_options");
-		expect(content).not.toContain("<active_workflow");
+		const content = latestWorkflowContent(fake);
+		expect(content).toBe("<workflow_activation_options />");
+		expect(fake.handlers.has("context")).toBe(false);
 	});
 
 	/**
@@ -673,7 +723,7 @@ describe("workflow extension lifecycle", () => {
 			readonly data: Record<string, unknown>;
 		};
 		const activatedData = activated.data;
-		const { restoration: _restoration, ...legacyData } = activatedData;
+		const { journalVersion: _journalVersion, ...legacyData } = activatedData;
 		const legacyBranch = [
 			{ ...activated, data: legacyData },
 			{
@@ -694,6 +744,13 @@ describe("workflow extension lifecycle", () => {
 				type: "warning",
 			},
 		]);
+		expect(
+			fake.messages.some(
+				({ details }) =>
+					isWorkflowLifecycleDetails(details) &&
+					(details as Record<string, unknown>)["kind"] === "checkpoint",
+			),
+		).toBe(false);
 		expect(fake.activeTools).toContain("workflow_activate");
 		expect(fake.activeTools).toContain("workflow_transition");
 	});
@@ -732,13 +789,9 @@ describe("workflow extension lifecycle", () => {
 			fake.appended.map(({ data }) => (data as { kind: string }).kind),
 		).toEqual(["created", "transitioned"]);
 		expect(triggerCalls).toEqual([]);
-		const context = await runContext(fake, []);
-		const content = String(
-			(context as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const content = latestWorkflowContent(fake);
 		expect(content).toContain(
-			'<active_workflow id="dynamic-delivery" active_stage_id="done"',
+			'<workflow_stage_activated workflow_id="dynamic-delivery" stage_id="done"',
 		);
 		expect(content).not.toContain("<workflow_activation_options");
 	});
@@ -805,9 +858,9 @@ describe("workflow extension lifecycle", () => {
 
 	/**
 	 * Proves stage tools read and change active and non-active stages in only the current active workflow.
-	 * Input and expected output: dynamic creation exposes both tools; edits persist and appear in the next provider context.
+	 * Input and expected output: dynamic creation exposes both tools; edits persist in the workflow journal.
 	 * Edge cases: editing a non-active stage does not change current thinking, while editing the active stage applies thinking immediately.
-	 * Dependencies: workflow availability, session persistence, provider-context projection, and model runtime application.
+	 * Dependencies: workflow availability, session persistence, workflow journaling, and model runtime application.
 	 */
 	test("gets and edits stages in the current active workflow", async () => {
 		await createSuite();
@@ -865,11 +918,7 @@ describe("workflow extension lifecycle", () => {
 		expect(
 			fake.appended.map(({ data }) => (data as { kind: string }).kind),
 		).toEqual(["created", "stage_edited", "transitioned", "stage_edited"]);
-		const context = await runContext(fake, []);
-		const content = String(
-			(context as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const content = latestWorkflowContent(fake);
 		expect(content).toContain("Correct final stage");
 		expect(content).toContain("Follow the corrected requirements now.");
 	});
@@ -1154,15 +1203,9 @@ describe("workflow extension lifecycle", () => {
 			create.execute("create", createArguments("new-delivery")),
 		).rejects.toThrow("append failed");
 		fake.appendError = undefined;
-		const retained = String(
-			(
-				(await runContext(fake, [])) as {
-					messages: Array<{ content: unknown }>;
-				}
-			).messages[0]?.content,
-		);
+		const retained = latestWorkflowContent(fake);
 		expect(retained).toContain(
-			'<active_workflow id="delivery" active_stage_id="done"',
+			'<workflow_stage_activated workflow_id="delivery" stage_id="done"',
 		);
 
 		await create.execute("create", createArguments("new-delivery"));
@@ -1171,15 +1214,9 @@ describe("workflow extension lifecycle", () => {
 			create.execute("create", createArguments("new-delivery")),
 		).rejects.toThrow("already active");
 		expect(fake.appended).toEqual(entriesBeforeDuplicate);
-		const replaced = String(
-			(
-				(await runContext(fake, [])) as {
-					messages: Array<{ content: unknown }>;
-				}
-			).messages[0]?.content,
-		);
+		const replaced = latestWorkflowContent(fake);
 		expect(replaced).toContain(
-			'<active_workflow id="new-delivery" active_stage_id="start"',
+			'<workflow_stage_activated workflow_id="new-delivery" stage_id="start"',
 		);
 	});
 
@@ -1258,6 +1295,7 @@ describe("workflow extension lifecycle", () => {
 		expect(fake.thinkingLevel).toBe("xhigh");
 		expect(fake.appended[0]?.data).toMatchObject({
 			kind: "activated",
+			journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 			workflow: {
 				model: { id: "openai/workflow-model", thinking: "high" },
 			},
@@ -1544,7 +1582,7 @@ describe("workflow extension lifecycle", () => {
 	 * Proves completion removes active-stage instructions while retaining the rework route.
 	 * Inputs and expected outputs: a settled final stage projects completed state without active-stage guidance; rework restores active settings and context.
 	 * Edge cases: the completed state must remain available even though the final-stage model has been restored.
-	 * Dependencies: completion persistence, context projection, and route transition application.
+	 * Dependencies: completion persistence, workflow journaling, and route transition application.
 	 */
 	test("projects completion and supports rework", async () => {
 		await createSuite(modelYaml());
@@ -1556,30 +1594,17 @@ describe("workflow extension lifecycle", () => {
 		await transition.execute("transition", { stageId: "done" });
 		await runAgentSettled(fake);
 
-		const completedContext = String(
-			(
-				(await runContext(fake, [])) as {
-					messages: Array<{ content: unknown }>;
-				}
-			).messages[0]?.content,
-		);
-		expect(completedContext).toContain("<completed_workflow");
-		expect(completedContext).not.toContain("<active_workflow");
-		expect(completedContext).not.toContain("<active_stage_guidelines>");
+		const completedContext = latestWorkflowContent(fake);
+		expect(completedContext).toContain("<workflow_completed");
+		expect(completedContext).not.toContain("<stage_guidelines>");
 
 		await transition.execute("rework", { stageId: "start" });
 
 		expect(fake.model?.id).toBe("workflow-model");
 		expect(fake.thinkingLevel).toBe("xhigh");
-		const activeContext = String(
-			(
-				(await runContext(fake, [])) as {
-					messages: Array<{ content: unknown }>;
-				}
-			).messages[0]?.content,
-		);
-		expect(activeContext).toContain("<active_workflow");
-		expect(activeContext).toContain("<active_stage_guidelines>");
+		const activeContext = latestWorkflowContent(fake);
+		expect(activeContext).toContain("<workflow_stage_activated");
+		expect(activeContext).toContain('guidelines="reuse"');
 	});
 
 	/**
@@ -1675,12 +1700,8 @@ describe("workflow extension lifecycle", () => {
 		expect(
 			(transitionedEntry.data as { route: readonly string[] }).route,
 		).toEqual(["start", "done"]);
-		const result = await runContext(fake, []);
-		const content = String(
-			(result as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
-		expect(content).toContain('active_stage_id="done"');
+		const content = latestWorkflowContent(fake);
+		expect(content).toContain('stage_id="done"');
 		expect(content).toContain('<transition to="start" type="rework" />');
 	});
 
@@ -1699,15 +1720,11 @@ describe("workflow extension lifecycle", () => {
 
 		await activate.execute("activate", { workflowId: "delivery" });
 		expect(fake.activeTools).toEqual(["read"]);
-		const context = await runContext(fake, []);
-		const content = String(
-			(context as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const content = latestWorkflowContent(fake);
 		expect(content).toContain(
-			'<active_workflow id="delivery" active_stage_id="start"',
+			'<workflow_stage_activated workflow_id="delivery" stage_id="start"',
 		);
-		expect(content).toContain("<active_stage_guidelines>\nStart work");
+		expect(content).toContain("<stage_guidelines>\nStart work");
 		expect(content).not.toContain("<workflow_activation_options");
 	});
 
@@ -1732,43 +1749,101 @@ describe("workflow extension lifecycle", () => {
 			activate.execute("call", { workflowId: "delivery", extra: true }),
 		).rejects.toThrow();
 		const triggerCalls = captureTriggers(fake);
+		const messageCount = fake.messages.length;
 		fake.appendError = new Error("append failed");
 		await expect(
 			activate.execute("call", { workflowId: "delivery" }),
 		).rejects.toThrow("append failed");
 		expect(triggerCalls).toEqual([]);
+		expect(fake.messages).toHaveLength(messageCount);
 		fake.appendError = undefined;
-		const result = await runContext(fake, []);
-		expect(
-			String(
-				(result as { messages: Array<{ content: unknown }> }).messages[0]
-					?.content,
-			),
-		).not.toContain("<active_workflow");
 	});
 
-	/** Proves either current workflow tool independently enables complete projection. */
-	test("projects while any workflow tool is active", async () => {
+	/** Proves workflow records enter the active tool loop through Pi's steering queue. */
+	test("delivers workflow records to the next provider request", async () => {
+		// Purpose: a journal record published during tool execution must join the active loop context.
+		// Input and expected output: activation uses steer delivery without forcing a separate agent turn.
+		// Edge case: triggerTurn false would persist the message but omit it from the active loop snapshot.
+		// Dependencies: workflow activation and the public sendMessage delivery contract.
 		await createSuite(validYaml());
 		const fake = await createFakePi();
 		await runLifecycle(fake, "session_start");
-		const incoming = [{ role: "user", content: "preserve", timestamp: 1 }];
+		await requireTool(fake, "workflow_activate").execute("activate", {
+			workflowId: "delivery",
+		});
+		const activation = fake.messages.find(({ details }) =>
+			isWorkflowLifecycleDetails(details),
+		);
 
-		for (const activeTools of [
-			["read", "workflow_activate"],
-			["read", "workflow_transition"],
-			["read", "workflow_activate", "workflow_transition"],
-		]) {
-			fake.activeTools = activeTools;
-			const eligible = await runContext(fake, incoming);
-			expect(eligible).toBeDefined();
-			const messages = (eligible as { messages: unknown[] }).messages;
-			expect(messages[0]).toBe(incoming[0]);
-			expect(messages).toHaveLength(2);
-		}
+		expect(activation?.options).toEqual({ deliverAs: "steer" });
+	});
 
-		fake.activeTools = ["read"];
-		expect(await runContext(fake, incoming)).toBeUndefined();
+	/** Proves compaction starts a new activation-options segment without an active workflow. */
+	test("re-publishes activation options after inactive compaction", async () => {
+		// Purpose: every compaction must establish workflow availability in the new provider-visible segment.
+		// Input and expected output: delivery availability is published once at startup and once after inactive compaction.
+		// Edge case: no active or completed workflow exists to produce a checkpoint.
+		// Dependencies: session_compact wiring and activation-options deduplication reset.
+		await createSuite(validYaml());
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		const initialOptions = fake.messages.at(-1)?.content;
+
+		await runSessionCompact(fake);
+
+		expect(fake.messages).toHaveLength(2);
+		expect(fake.messages.at(-1)?.content).toBe(initialOptions);
+	});
+
+	/** Proves compaction creates one checkpoint and forgets definitions outside that checkpoint. */
+	test("checkpoints after compaction and inlines the first later stage entry", async () => {
+		// Purpose: post-compaction history must restore exact active instructions without trusting the summary.
+		// Input and expected output: review compaction emits one checkpoint, then rework inlines implementation guidance again.
+		// Edge case: unchanged activation options are re-published because compaction removed the prior record from provider context.
+		// Dependencies: session_compact wiring, checkpoint rendering, and known-stage reset.
+		await createSuite(validYaml());
+		const fake = await createFakePi();
+		await runLifecycle(fake, "session_start");
+		await requireTool(fake, "workflow_activate").execute("activate", {
+			workflowId: "delivery",
+		});
+		const transition = requireTool(fake, "workflow_transition");
+		await transition.execute("advance", { stageId: "done" });
+		const beforeCompaction = fake.messages.length;
+
+		await runSessionCompact(fake);
+		expect(fake.messages).toHaveLength(beforeCompaction + 2);
+		expect(fake.messages.at(-2)?.content).toContain(
+			'<workflow_checkpoint id="delivery" status="active" active_stage_id="done"',
+		);
+		expect(fake.messages.at(-1)?.content).toBe(
+			"<workflow_activation_options />",
+		);
+
+		await transition.execute("rework", { stageId: "start" });
+		expect(fake.messages.at(-1)?.content).toContain('guidelines="inline"');
+		expect(fake.messages.at(-1)?.content).toContain("Start work");
+	});
+
+	/** Proves restored journal records prevent duplicate legacy-repair checkpoints. */
+	test("deduplicates compatible restore checkpoints", async () => {
+		// Purpose: repeated session restoration must not append the same checkpoint and options again.
+		// Input and expected output: state-only history is repaired once, then the repaired branch produces no new message.
+		// Edge case: the availability record follows the checkpoint in the repaired branch.
+		// Dependencies: workflow-state replay and journal detail restoration.
+		await createSuite(validYaml());
+		const fake = await createFakePi();
+		const stateEntry = activatedEntry();
+		await runLifecycle(fake, "session_start", [stateEntry]);
+		const repairedMessages = fake.messages.map((message) => ({
+			type: "custom_message",
+			...message,
+		}));
+		const messageCount = fake.messages.length;
+
+		await runLifecycle(fake, "session_tree", [stateEntry, ...repairedMessages]);
+
+		expect(fake.messages).toHaveLength(messageCount);
 	});
 
 	/**
@@ -1796,26 +1871,20 @@ describe("workflow extension lifecycle", () => {
 		await transition.execute("finish-delivery", { stageId: "done" });
 
 		setMainWorkflowPolicy(fake, ["review"]);
-		const switchedContext = await runContext(fake, []);
-		const switchedContent = String(
-			(switchedContext as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const switchedContent = latestWorkflowContent(fake);
 		expect(switchedContent).toContain(
-			'<active_workflow id="delivery" active_stage_id="done"',
+			'<workflow_stage_activated workflow_id="delivery" stage_id="done"',
 		);
-		expect(switchedContent).toContain("<workflow_activation_options>");
-		expect(switchedContent).toContain('id="review"');
+		expect(fake.messages.at(-1)?.content).toContain(
+			"<workflow_activation_options>",
+		);
+		expect(fake.messages.at(-1)?.content).toContain('id="review"');
 
 		await transition.execute("reopen-delivery", { stageId: "start" });
 		await activate.execute("activate-review", { workflowId: "review" });
-		const replacedContext = await runContext(fake, []);
-		const replacedContent = String(
-			(replacedContext as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const replacedContent = latestWorkflowContent(fake);
 		expect(replacedContent).toContain(
-			'<active_workflow id="review" active_stage_id="start"',
+			'<workflow_stage_activated workflow_id="review" stage_id="start"',
 		);
 	});
 
@@ -1838,25 +1907,17 @@ describe("workflow extension lifecycle", () => {
 		const transition = requireTool(fake, "workflow_transition");
 		const activate = requireTool(fake, "workflow_activate");
 
-		const initialContext = await runContext(fake, []);
-		const initialContent = String(
-			(initialContext as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const initialContent = latestWorkflowContent(fake);
 		expect(initialContent).toContain(
-			'<active_workflow id="delivery" active_stage_id="start"',
+			'<workflow_checkpoint id="delivery" status="active" active_stage_id="start"',
 		);
-		expect(initialContent).toContain('id="review"');
+		expect(fake.messages.at(-1)?.content).toContain('id="review"');
 
 		await transition.execute("finish-delivery", { stageId: "done" });
 		await activate.execute("activate-review", { workflowId: "review" });
-		const replacedContext = await runContext(fake, []);
-		const replacedContent = String(
-			(replacedContext as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const replacedContent = latestWorkflowContent(fake);
 		expect(replacedContent).toContain(
-			'<active_workflow id="review" active_stage_id="start"',
+			'<workflow_stage_activated workflow_id="review" stage_id="start"',
 		);
 	});
 
@@ -1879,7 +1940,7 @@ describe("workflow extension lifecycle", () => {
 		).rejects.toThrow(expectedIssue);
 
 		expect(fake.activeTools).toEqual(["read"]);
-		expect(await runContext(fake, [])).toBeUndefined();
+		expect(latestWorkflowContent(fake)).toBeUndefined();
 		expect(fake.appended).toEqual([]);
 		const transition = fake.tools.find(
 			({ name }) => name === "workflow_transition",
@@ -1999,25 +2060,17 @@ describe("workflow extension lifecycle", () => {
 		setMainWorkflowPolicy(fake, policy);
 		const transition = requireTool(fake, "workflow_transition");
 
-		const initialContext = await runContext(fake, []);
-		expect(initialContext).toBeDefined();
-		const initialContent = String(
-			(initialContext as { messages: Array<{ content: unknown }> }).messages[0]
-				?.content,
-		);
+		const initialContent = latestWorkflowContent(fake);
+		expect(initialContent).toBeDefined();
 		expect(initialContent).not.toContain("<workflow_activation_options");
 		expect(initialContent).toContain(
-			'<active_workflow id="delivery" active_stage_id="start"',
+			'<workflow_checkpoint id="delivery" status="active" active_stage_id="start"',
 		);
 
 		await transition.execute("finish-delivery", { stageId: "done" });
 		expect(fake.appended).toHaveLength(1);
-		const transitionedContext = await runContext(fake, []);
-		const transitionedContent = String(
-			(transitionedContext as { messages: Array<{ content: unknown }> })
-				.messages[0]?.content,
-		);
-		expect(transitionedContent).toContain('active_stage_id="done"');
+		const transitionedContent = latestWorkflowContent(fake);
+		expect(transitionedContent).toContain('stage_id="done"');
 	});
 
 	test("does not publish workflow status outside TUI mode", async () => {

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -48,7 +48,7 @@ import {
 	loadWorkflowPrompts,
 	type WorkflowPrompts,
 } from "./config";
-import { projectWorkflowContext } from "./context";
+import { WorkflowJournal } from "./context";
 import { readWorkflowPolicyEnvironment } from "./environment";
 import {
 	applyWorkflowModelRestoration,
@@ -79,6 +79,7 @@ import {
 	replayWorkflowStateWithWarnings,
 	transitionWorkflow,
 	validateCreatedWorkflowDefinition,
+	WORKFLOW_STATE_JOURNAL_VERSION,
 	type WorkflowDefinition,
 	type WorkflowRestorationSettings,
 	type WorkflowState,
@@ -311,6 +312,8 @@ interface WorkflowRuntime {
 	currentModel: ExtensionContext["model"];
 	modelRegistry: ExtensionContext["modelRegistry"] | undefined;
 	readonly selfSuppressedNames: Set<string>;
+	readonly journal: WorkflowJournal;
+	journalReady: boolean;
 }
 
 /** Groups runtime registration dependencies without widening the tool boundary. */
@@ -406,6 +409,7 @@ async function setEnteredWorkflowState(
 
 /** Creates the initial mutable workflow state from catalog-wide and prompt loading results. */
 function createWorkflowRuntimeState(
+	pi: ExtensionAPI,
 	catalogResult: Awaited<ReturnType<typeof loadWorkflowCatalog>>,
 	promptError: Error | undefined,
 ): WorkflowRuntime {
@@ -418,6 +422,10 @@ function createWorkflowRuntimeState(
 		currentModel: undefined,
 		modelRegistry: undefined,
 		selfSuppressedNames: new Set<string>(),
+		journal: new WorkflowJournal((record) => {
+			pi.sendMessage(record, { deliverAs: "steer" });
+		}),
+		journalReady: false,
 	};
 }
 
@@ -427,6 +435,18 @@ function publishWorkflowStatus(
 	runtime: WorkflowRuntime,
 ): void {
 	indicator?.publish(runtime.state);
+}
+
+/** Publishes the current model-visible catalog subset after active-tool reconciliation. */
+function publishWorkflowActivationOptions(
+	pi: ExtensionAPI,
+	runtime: WorkflowRuntime,
+	availability: WorkflowAvailability,
+): void {
+	const options = pi.getActiveTools().includes(WORKFLOW_ACTIVATE_TOOL)
+		? availability.activationOptions
+		: [];
+	runtime.journal.activationOptions(options);
 }
 
 /** Reports all skipped catalog workflows in one startup notification. */
@@ -497,7 +517,11 @@ export default async function workflowExtension(
 		catalogPublication.error === undefined
 			? loadedCatalog
 			: { workflows: [], error: catalogPublication.error };
-	const runtime = createWorkflowRuntimeState(catalogResult, promptResult.error);
+	const runtime = createWorkflowRuntimeState(
+		pi,
+		catalogResult,
+		promptResult.error,
+	);
 	const statusHolder: WorkflowStatusHolder = { indicator: undefined };
 	const getPolicy = createWorkflowPolicyReader(pi);
 	const refreshTools = (trigger: ReconciliationTrigger): void => {
@@ -509,6 +533,9 @@ export default async function workflowExtension(
 			trigger,
 		);
 		publishWorkflowStatus(statusHolder.indicator, runtime);
+		if (runtime.journalReady) {
+			publishWorkflowActivationOptions(pi, runtime, availability);
+		}
 	};
 
 	if (promptResult.error === undefined) {
@@ -583,57 +610,20 @@ async function completeSettledWorkflow(
 		}
 		throw error;
 	}
-	runtime.state = completeWorkflow(state);
+	const completed = completeWorkflow(state);
+	runtime.journal.complete(completed);
+	runtime.state = completed;
 	refreshTools("lifecycle");
 }
 
 /** Registers session and model lifecycle synchronization without reapplying manual model changes. */
 function registerWorkflowLifecycle(options: WorkflowLifecycleOptions): void {
-	const {
-		pi,
-		runtime,
-		catalogResult,
-		promptError,
-		getPolicy,
-		refreshTools,
-		statusHolder,
-		warnings,
-	} = options;
+	const { pi, runtime, getPolicy, refreshTools, statusHolder, warnings } =
+		options;
 	let reportedReplayWarningKey: string | undefined;
-	const synchronize = async (ctx: {
-		readonly mode: ExtensionContext["mode"];
-		readonly ui: ExtensionContext["ui"];
-		readonly model: ExtensionContext["model"];
-		readonly modelRegistry: ExtensionContext["modelRegistry"];
-		readonly sessionManager: { getBranch(): readonly unknown[] };
-	}): Promise<void> => {
-		if (ctx.mode === "tui") {
-			statusHolder.indicator ??= installWorkflowStatusIndicator(pi, ctx.ui);
-		}
-		try {
-			const branch = ctx.sessionManager.getBranch();
-			const previousState = runtime.state;
-			synchronizeWorkflowRuntime({
-				pi,
-				branch,
-				runtime,
-				catalogResult,
-				promptError,
-				getPolicy,
-				model: ctx.model,
-				modelRegistry: ctx.modelRegistry,
-			});
-			await synchronizeWorkflowModelRuntime(pi, runtime, branch, previousState);
-		} finally {
-			publishWorkflowStatus(statusHolder.indicator, runtime);
-		}
-	};
-	pi.on("model_select", (event) => {
-		runtime.currentModel = event.model;
-	});
-	pi.on("agent_settled", async () => {
-		await completeSettledWorkflow(pi, runtime, refreshTools);
-	});
+	const synchronize = createWorkflowSynchronizer(options);
+	registerWorkflowRunLifecycle(pi, runtime, refreshTools);
+	registerWorkflowCompaction(pi, runtime, getPolicy);
 	const unsubscribeFromAgentChanges = (
 		pi.events as unknown as WorkflowEventBus
 	).on(MAIN_AGENT_CONTRIBUTION_CHANGE_EVENT, () => {
@@ -663,6 +653,91 @@ function registerWorkflowLifecycle(options: WorkflowLifecycleOptions): void {
 	});
 }
 
+interface WorkflowSynchronizationContext {
+	readonly mode: ExtensionContext["mode"];
+	readonly ui: ExtensionContext["ui"];
+	readonly model: ExtensionContext["model"];
+	readonly modelRegistry: ExtensionContext["modelRegistry"];
+	readonly sessionManager: { getBranch(): readonly unknown[] };
+}
+
+/** Creates the shared session-start and branch-navigation synchronization operation. */
+function createWorkflowSynchronizer(
+	options: WorkflowLifecycleOptions,
+): (ctx: WorkflowSynchronizationContext) => Promise<void> {
+	const { pi, runtime, catalogResult, promptError, getPolicy, statusHolder } =
+		options;
+	return async (ctx) => {
+		if (ctx.mode === "tui") {
+			statusHolder.indicator ??= installWorkflowStatusIndicator(pi, ctx.ui);
+		}
+		try {
+			const branch = ctx.sessionManager.getBranch();
+			const previousState = runtime.state;
+			runtime.journalReady = false;
+			synchronizeWorkflowRuntime({
+				pi,
+				branch,
+				runtime,
+				catalogResult,
+				promptError,
+				getPolicy,
+				model: ctx.model,
+				modelRegistry: ctx.modelRegistry,
+			});
+			await synchronizeWorkflowModelRuntime(pi, runtime, branch, previousState);
+			runtime.journal.restore(branch);
+			if (
+				runtime.state !== undefined &&
+				!runtime.journal.isCurrent(runtime.state)
+			) {
+				runtime.journal.checkpoint(runtime.state);
+			}
+			runtime.journalReady = true;
+			publishWorkflowActivationOptions(
+				pi,
+				runtime,
+				resolveRuntimeAvailability(runtime, getPolicy()),
+			);
+		} finally {
+			publishWorkflowStatus(statusHolder.indicator, runtime);
+		}
+	};
+}
+
+/** Registers model selection and final-stage settlement handlers. */
+function registerWorkflowRunLifecycle(
+	pi: ExtensionAPI,
+	runtime: WorkflowRuntime,
+	refreshTools: (trigger: ReconciliationTrigger) => void,
+): void {
+	pi.on("model_select", (event) => {
+		runtime.currentModel = event.model;
+	});
+	pi.on("agent_settled", async () => {
+		await completeSettledWorkflow(pi, runtime, refreshTools);
+	});
+}
+
+/** Registers the post-compaction workflow checkpoint. */
+function registerWorkflowCompaction(
+	pi: ExtensionAPI,
+	runtime: WorkflowRuntime,
+	getPolicy: () => WorkflowPolicyResolution,
+): void {
+	pi.on("session_compact", () => {
+		runtime.journal.startContextSegment();
+		if (runtime.state !== undefined) {
+			runtime.journal.checkpoint(runtime.state);
+		}
+		publishWorkflowActivationOptions(
+			pi,
+			runtime,
+			resolveRuntimeAvailability(runtime, getPolicy()),
+		);
+	});
+}
+
 /** Reads immutable child transport or the current canonical main-agent metadata. */
 function createWorkflowPolicyReader(
 	pi: ExtensionAPI,
@@ -681,7 +756,7 @@ function createWorkflowPolicyReader(
 		};
 }
 
-/** Registers tools and one filtered context projection over shared runtime state. */
+/** Registers workflow tools over shared runtime state. */
 function registerWorkflowRuntime(
 	options: RegisterWorkflowRuntimeOptions,
 ): void {
@@ -706,28 +781,6 @@ function registerWorkflowRuntime(
 	getAgentRuntimeComposition(pi).publishBaselineToolNames([
 		...WORKFLOW_TOOL_NAMES,
 	]);
-	pi.on("context", (event) => {
-		const activeNames = pi.getActiveTools();
-		const availability = resolveAvailability();
-		// Suppression preserves a tool permission only while an active state remains projectable.
-		const hasSuppressedWorkflowPermission =
-			availability.projectedState !== undefined &&
-			hasAnyWorkflowTool([...runtime.selfSuppressedNames]);
-		if (!hasAnyWorkflowTool(activeNames) && !hasSuppressedWorkflowPermission) {
-			return undefined;
-		}
-		const activationOptions = activeNames.includes(WORKFLOW_ACTIVATE_TOOL)
-			? availability.activationOptions
-			: [];
-		return {
-			messages: projectWorkflowContext(
-				event.messages,
-				prompts,
-				activationOptions,
-				availability.projectedState,
-			),
-		};
-	});
 }
 
 /** Persists row-local UI evidence so live and replayed sessions render identically. */
@@ -979,9 +1032,14 @@ async function commitWorkflowStateChange(
 	);
 	runtime.currentModel = application.currentModel;
 	const persistedData =
-		(kind === "activated" || kind === "created") &&
-		persistedCandidate.restoration !== undefined
-			? { ...data, restoration: persistedCandidate.restoration }
+		kind === "activated" || kind === "created"
+			? {
+					...data,
+					...(persistedCandidate.restoration === undefined
+						? {}
+						: { restoration: persistedCandidate.restoration }),
+					journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
+				}
 			: data;
 	try {
 		pi.appendEntry(WORKFLOW_STATE_ENTRY, persistedData);
@@ -1084,6 +1142,7 @@ async function executeWorkflowCreate(
 		workflow: candidate.workflow,
 		route: candidate.route,
 	});
+	runtime.journal.activate(persisted);
 	await setEnteredWorkflowState(pi, setState, persisted, { ctx, signal });
 	return SUCCESS_RESULT;
 }
@@ -1097,6 +1156,7 @@ function registerWorkflowCreateTool(
 		name: WORKFLOW_CREATE_TOOL,
 		label: "Create workflow",
 		description: prompts.createDescription,
+		promptGuidelines: [prompts.extensionDescription],
 		parameters: WORKFLOW_CREATE_SCHEMA,
 		executionMode: "sequential",
 		renderCall(args, theme, context) {
@@ -1136,6 +1196,7 @@ function registerWorkflowActivateTool(
 		name: WORKFLOW_ACTIVATE_TOOL,
 		label: "Activate workflow",
 		description: prompts.activateDescription,
+		promptGuidelines: [prompts.extensionDescription],
 		parameters: Type.Object(
 			{
 				workflowId: singleLineTextSchema({
@@ -1182,6 +1243,7 @@ function registerWorkflowActivateTool(
 					route: candidate.route,
 				},
 			);
+			runtime.journal.activate(persisted);
 			await setEnteredWorkflowState(pi, setState, persisted, { ctx, signal });
 			return SUCCESS_RESULT;
 		},
@@ -1197,6 +1259,7 @@ function registerWorkflowGetStageTool(
 		name: WORKFLOW_GET_STAGE_TOOL,
 		label: "Get workflow stage",
 		description: prompts.getStageDescription,
+		promptGuidelines: [prompts.extensionDescription],
 		parameters: Type.Object(
 			{
 				stageId: technicalIdentifierSchema({
@@ -1262,6 +1325,7 @@ function registerWorkflowEditStageTool(
 		name: WORKFLOW_EDIT_STAGE_TOOL,
 		label: "Edit workflow stage",
 		description: prompts.editStageDescription,
+		promptGuidelines: [prompts.extensionDescription],
 		parameters: WORKFLOW_EDIT_STAGE_SCHEMA,
 		executionMode: "sequential",
 		renderCall(args, theme, context) {
@@ -1316,6 +1380,7 @@ function registerWorkflowEditStageTool(
 			} else {
 				pi.appendEntry(WORKFLOW_STATE_ENTRY, data);
 			}
+			runtime.journal.updateStage(persisted, stageId);
 			setState(persisted);
 			return SUCCESS_RESULT;
 		},
@@ -1380,6 +1445,7 @@ function registerWorkflowTransitionTool(
 		name: WORKFLOW_TRANSITION_TOOL,
 		label: "Transition workflow",
 		description: prompts.transitionDescription,
+		promptGuidelines: [prompts.extensionDescription],
 		parameters: Type.Object(
 			{
 				stageId: technicalIdentifierSchema({
@@ -1426,6 +1492,7 @@ function registerWorkflowTransitionTool(
 					route: candidate.route,
 				},
 			);
+			runtime.journal.enterStage(persisted);
 			await setEnteredWorkflowState(pi, setState, persisted, { ctx, signal });
 			return SUCCESS_RESULT;
 		},
@@ -1479,7 +1546,7 @@ function reconcileTools(
 		selfSuppressedNames.clear();
 	}
 
-	// Suppression ownership remains separate from final list ownership because context projection uses it.
+	// Suppression ownership remains separate from final list ownership for branch restoration.
 	for (const name of activeNames.filter(isWorkflowToolName)) {
 		if (!availableToolNames.has(name)) {
 			selfSuppressedNames.add(name);
@@ -1505,9 +1572,4 @@ function reconcileTools(
 /** Narrows arbitrary Pi tool names to the workflow-owned finite set. */
 function isWorkflowToolName(name: string): name is WorkflowToolName {
 	return WORKFLOW_TOOL_NAMES.has(name);
-}
-
-/** Enables projection when the current agent can call at least one workflow tool. */
-function hasAnyWorkflowTool(activeNames: readonly string[]): boolean {
-	return activeNames.some(isWorkflowToolName);
 }

--- a/pi-package/extensions/workflow/tool-rendering.test.ts
+++ b/pi-package/extensions/workflow/tool-rendering.test.ts
@@ -114,6 +114,7 @@ async function createFixture(): Promise<WorkflowRenderingFixture> {
 			thinkingLevel = level;
 		},
 		appendEntry(): void {},
+		sendMessage(): void {},
 	} as unknown as ExtensionAPI;
 	const renderingModel = {
 		provider: "test",

--- a/pi-package/extensions/workflow/workflow.test.ts
+++ b/pi-package/extensions/workflow/workflow.test.ts
@@ -8,6 +8,7 @@ import {
 	transitionWorkflow,
 	validateCreatedWorkflowDefinition,
 	validateWorkflowDefinition,
+	WORKFLOW_STATE_JOURNAL_VERSION,
 } from "./workflow";
 
 const SOURCE = "/tmp/workflow.yaml";
@@ -554,6 +555,7 @@ describe("workflow state", () => {
 					workflow,
 					route: ["a"],
 					restoration: { modelId: "openai/current-model", thinking: "medium" },
+					journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 				},
 			},
 			{
@@ -588,6 +590,7 @@ describe("workflow state", () => {
 						modelId: "openai/current-model",
 						thinking: "medium",
 					},
+					journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 				},
 			},
 			{
@@ -668,6 +671,7 @@ describe("workflow state", () => {
 						workflow: dynamicWorkflow,
 						route: ["a"],
 						source: "dynamic",
+						journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 					},
 				},
 			]),
@@ -697,6 +701,7 @@ describe("workflow state", () => {
 						modelId: "openai/current-model",
 						thinking: "medium",
 					},
+					journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 				},
 			},
 			{
@@ -776,6 +781,7 @@ describe("workflow state", () => {
 				workflow: catalogWorkflow,
 				route: ["a"],
 				restoration,
+				journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 			},
 		};
 		const creation = {
@@ -786,6 +792,7 @@ describe("workflow state", () => {
 				workflow: dynamicWorkflow,
 				route: ["a"],
 				restoration,
+				journalVersion: WORKFLOW_STATE_JOURNAL_VERSION,
 			},
 		};
 
@@ -808,8 +815,8 @@ describe("workflow state", () => {
 		).toThrow("unsupported key");
 	});
 
-	/** Proves pre-restoration workflow chains are ignored instead of blocking session replay. */
-	test("ignores legacy workflow state chains", () => {
+	/** Proves workflow chains without the journal contract are ignored instead of repaired. */
+	test("ignores workflow state without a journal contract", () => {
 		const workflow = validateWorkflowDefinition(
 			"delivery",
 			validValue(),
@@ -819,7 +826,15 @@ describe("workflow state", () => {
 			{
 				type: "custom",
 				customType: "workflow-state",
-				data: { kind: "activated", workflow, route: ["a"] },
+				data: {
+					kind: "activated",
+					workflow,
+					route: ["a"],
+					restoration: {
+						modelId: "openai/current-model",
+						thinking: "medium",
+					},
+				},
 			},
 			{
 				type: "custom",

--- a/pi-package/extensions/workflow/workflow.ts
+++ b/pi-package/extensions/workflow/workflow.ts
@@ -106,9 +106,11 @@ const TRANSITION_KEYS = new Set(["from", "to", "type"]);
 const SAVED_WORKFLOW_KEYS = new Set(["id", ...ROOT_KEYS]);
 const SAVED_DYNAMIC_WORKFLOW_KEYS = new Set(CREATED_ROOT_KEYS);
 const RESTORATION_KEYS = new Set(["modelId", "thinking"]);
-const LEGACY_WORKFLOW_STATE_KEYS = new Set(["kind", "workflow", "route"]);
 
-/** Warning emitted when a workflow snapshot predates persisted restoration settings. */
+/** Journal contract required by persisted workflow root snapshots. */
+export const WORKFLOW_STATE_JOURNAL_VERSION = 1;
+
+/** Warning emitted when a workflow snapshot predates the current persisted state contract. */
 export const WORKFLOW_LEGACY_STATE_WARNING =
 	"[workflow] ignored workflow state from an older format; start a new workflow to continue";
 
@@ -374,7 +376,10 @@ function classifyWorkflowReplayAction(
 ): "ignore" | "legacy" | "replay" {
 	const kind = Reflect.get(data, "kind");
 	if (ignoringLegacyState) {
-		return kind === "activated" || kind === "created" ? "replay" : "ignore";
+		if (kind !== "activated" && kind !== "created") {
+			return "ignore";
+		}
+		return isLegacyWorkflowStateData(data) ? "legacy" : "replay";
 	}
 	return isLegacyWorkflowStateData(data) ? "legacy" : "replay";
 }
@@ -392,9 +397,10 @@ function replayWorkflowStateEntry(
 	if (kind === "activated" || kind === "created") {
 		assertExactKeys(
 			data,
-			new Set(["kind", "workflow", "route", "restoration"]),
+			new Set(["kind", "workflow", "route", "restoration", "journalVersion"]),
 			`${kind} entry`,
 		);
+		requireWorkflowJournalVersion(data);
 		const workflow = validateSavedWorkflow(
 			Reflect.get(data, "workflow"),
 			kind === "activated",
@@ -467,6 +473,14 @@ function replayWorkflowStageEdit(
 }
 
 /** Identifies an activation or creation entry from before restoration was persisted. */
+function requireWorkflowJournalVersion(
+	data: Readonly<Record<string, unknown>>,
+): void {
+	if (Reflect.get(data, "journalVersion") !== WORKFLOW_STATE_JOURNAL_VERSION) {
+		throw new Error(`journalVersion must be ${WORKFLOW_STATE_JOURNAL_VERSION}`);
+	}
+}
+
 function isLegacyWorkflowStateData(
 	data: Readonly<Record<string, unknown>>,
 ): boolean {
@@ -474,11 +488,7 @@ function isLegacyWorkflowStateData(
 	if (kind !== "activated" && kind !== "created") {
 		return false;
 	}
-	const keys = Object.keys(data);
-	return (
-		keys.length === LEGACY_WORKFLOW_STATE_KEYS.size &&
-		keys.every((key) => LEGACY_WORKFLOW_STATE_KEYS.has(key))
-	);
+	return !Object.hasOwn(data, "journalVersion");
 }
 
 /** Identifies every entry claiming workflow ownership before outer-shape validation. */

--- a/pi-package/shared/toolsets/contracts.ts
+++ b/pi-package/shared/toolsets/contracts.ts
@@ -3,6 +3,8 @@ export interface Toolset {
 	readonly name: string;
 	readonly description: string;
 	readonly toolNames: readonly string[];
+	/** Model-facing context persisted with the first successful activation result. */
+	readonly activationContext?: string;
 	/** Confirms provider readiness and returns the registered names available for composition. */
 	readonly activate: () => Promise<readonly string[]>;
 }
@@ -17,6 +19,7 @@ export interface ToolsetActivation {
 	readonly name: string;
 	readonly toolNames: readonly string[];
 	readonly alreadyActive: boolean;
+	readonly activationContext?: string;
 }
 
 export interface ToolsetActivationPresentation {

--- a/pi-package/shared/toolsets/runtime.test.ts
+++ b/pi-package/shared/toolsets/runtime.test.ts
@@ -154,6 +154,41 @@ describe("toolset runtime", () => {
 		expect(activeTools).toEqual(["read", "activate_toolset"]);
 	});
 
+	test("persists provider activation context only on first activation", async () => {
+		// Purpose: provider instructions must reach the next model call through the persisted activation result.
+		// Input and expected output: one toolset adds activation context on first activation and omits it on an idempotent retry.
+		// Edge case: the active toolset remains callable through the runtime after its trigger disappears.
+		// Dependencies: activate_toolset result formatting and provider-owned activation metadata.
+		const controls = createFakePi(["files_read", "files_write"]);
+		const runtime = getToolsetRuntime(controls.pi);
+		runtime.replaceProvider("mcp", [
+			{
+				...filesToolset(),
+				activationContext:
+					"<provider_instructions>Use files.</provider_instructions>",
+			},
+		]);
+		getAgentRuntimeComposition(controls.pi).reconcileActiveTools();
+		const activationTool = controls.definitions.get("activate_toolset");
+
+		const first = await activationTool?.execute(
+			"call-context",
+			{ name: "files" },
+			undefined,
+			undefined,
+			{} as never,
+		);
+		const repeated = await runtime.activate("files");
+
+		expect(first?.content).toEqual([
+			{
+				type: "text",
+				text: 'Activated toolset "files".\nAvailable tools:\n- files_read\n- files_write\n\n<provider_instructions>Use files.</provider_instructions>',
+			},
+		]);
+		expect(repeated.activationContext).toBeUndefined();
+	});
+
 	test("activates only allowed tools and removes the final activation trigger", async () => {
 		const { pi, definitions, activeTools } = createFakePi([
 			"read",

--- a/pi-package/shared/toolsets/runtime.ts
+++ b/pi-package/shared/toolsets/runtime.ts
@@ -189,7 +189,14 @@ class ToolsetRuntimeImpl implements ToolsetRuntime {
 			getAgentRuntimeComposition(this.pi).reconcileActiveTools();
 			throw error;
 		}
-		return { name, toolNames, alreadyActive: false };
+		return {
+			name,
+			toolNames,
+			alreadyActive: false,
+			...(toolset.activationContext === undefined
+				? {}
+				: { activationContext: toolset.activationContext }),
+		};
 	}
 
 	public restoreFromBranch(
@@ -338,9 +345,12 @@ function formatActivationContent(activation: ToolsetActivation): string {
 	const status = activation.alreadyActive
 		? `Toolset "${activation.name}" is already active.`
 		: `Activated toolset "${activation.name}".`;
-	return `${status}\nAvailable tools:\n${activation.toolNames
+	const summary = `${status}\nAvailable tools:\n${activation.toolNames
 		.map((name) => `- ${name}`)
 		.join("\n")}`;
+	return activation.activationContext === undefined
+		? summary
+		: `${summary}\n\n${activation.activationContext}`;
 }
 
 function readActivationName(params: unknown): string {

--- a/test/integration/mcp-wrapper-system-prompt.test.ts
+++ b/test/integration/mcp-wrapper-system-prompt.test.ts
@@ -38,16 +38,19 @@ interface RegisteredHandler {
 interface ExtensionApiFake extends ExtensionAPI {
 	readonly handlers: RegisteredHandler[];
 	readonly tools: ToolDefinition[];
+	readonly messages: Array<{ readonly content: string }>;
 }
 
 function createExtensionApiFake(): ExtensionApiFake {
 	const handlers: RegisteredHandler[] = [];
 	const tools: ToolDefinition[] = [];
+	const messages: Array<{ readonly content: string }> = [];
 	let activeTools: readonly string[] = [];
 
 	return {
 		handlers,
 		tools,
+		messages,
 		events: {
 			emit(): void {},
 			on(): () => void {
@@ -86,6 +89,9 @@ function createExtensionApiFake(): ExtensionApiFake {
 			return undefined;
 		},
 		setThinkingLevel(): void {},
+		sendMessage(message: Parameters<ExtensionAPI["sendMessage"]>[0]): void {
+			messages.push({ content: String(message.content) });
+		},
 		appendEntry(): void {},
 		getSessionHistory() {
 			return [];
@@ -243,8 +249,6 @@ describe("mcp-wrapper and system-prompt integration", () => {
 			});
 
 			await runSessionStart(pi);
-			pi.setActiveTools(["fetch_fetch"]);
-
 			expect(
 				await runBeforeAgentStart(pi, projectDir),
 			).toBe(`Suite template for ${projectDir}
@@ -253,15 +257,8 @@ describe("mcp-wrapper and system-prompt integration", () => {
   <project_rule path=".pi/rules/project.md">
 Project rule
   </project_rule>
-</project_rules>
-
-<mcp_instructions>
-  <server name="fetch">
-Use fetch for web pages.
-
-Prefer the fetch tool.
-  </server>
-</mcp_instructions>`);
+</project_rules>`);
+			expect(pi.messages[0]?.content).toContain("Use fetch for web pages.");
 		} finally {
 			await rm(suiteDir, { recursive: true, force: true });
 			await rm(projectDir, { recursive: true, force: true });
@@ -326,9 +323,10 @@ Prefer the fetch tool.
 				createManager: () => manager,
 			});
 
-			await runSessionStart(pi);
 			getAgentRuntimeComposition(pi).setRestrictiveToolNames("test-policy", []);
+			await runSessionStart(pi);
 
+			expect(pi.messages).toEqual([]);
 			expect(await runBeforeAgentStart(pi)).toBe(
 				"Suite template for /tmp/project",
 			);
@@ -345,25 +343,17 @@ Prefer the fetch tool.
 		const cases: ReadonlyArray<{
 			readonly name: string;
 			readonly councilTools: readonly string[] | undefined;
-			readonly expectedPrompt: string;
+			readonly expectedMessageCount: number;
 		}> = [
 			{
 				name: "read-only participant",
 				councilTools: undefined,
-				expectedPrompt: "Suite template for /tmp/project",
+				expectedMessageCount: 0,
 			},
 			{
 				name: "participant with fetch MCP tool",
 				councilTools: ["fetch_fetch"],
-				expectedPrompt: `Suite template for /tmp/project
-
-<mcp_instructions>
-  <server name="fetch">
-Use fetch for web pages.
-
-Prefer the fetch tool.
-  </server>
-</mcp_instructions>`,
+				expectedMessageCount: 1,
 			},
 		];
 
@@ -438,13 +428,16 @@ Prefer the fetch tool.
 					createManager: () => manager,
 				});
 
-				await runSessionStart(pi);
 				getAgentRuntimeComposition(pi).setRestrictiveToolNames(
 					"test-policy",
 					toolNamesFromArgs(toolArgs.args),
 				);
+				await runSessionStart(pi);
 
-				expect(await runBeforeAgentStart(pi)).toBe(testCase.expectedPrompt);
+				expect(pi.messages).toHaveLength(testCase.expectedMessageCount);
+				expect(await runBeforeAgentStart(pi)).toBe(
+					"Suite template for /tmp/project",
+				);
 			} finally {
 				await rm(suiteDir, { recursive: true, force: true });
 			}

--- a/test/integration/runtime-package-loading.test.ts
+++ b/test/integration/runtime-package-loading.test.ts
@@ -165,6 +165,82 @@ function writePromptDumpExtension(directory: string): string {
 	return extensionPath;
 }
 
+/** Writes a debug extension that dumps the final provider tool payload before network access. */
+function writeProviderToolPayloadDumpExtension(directory: string): string {
+	const extensionPath = join(directory, "dump-provider-tools.ts");
+	writeFileSync(
+		extensionPath,
+		[
+			'import { writeFileSync } from "node:fs";',
+			"",
+			"export default function dumpProviderTools(pi) {",
+			...RUNTIME_TEST_PROVIDER_LINES,
+			"\tpi.registerTool({",
+			'\t\tname: "audit_lookup",',
+			'\t\tlabel: "Audit Lookup",',
+			'\t\tdescription: "Find one audit record by query.",',
+			"\t\tparameters: {",
+			'\t\t\ttype: "object",',
+			"\t\t\tproperties: {",
+			'\t\t\t\tquery: { type: "string", description: "Exact audit query." },',
+			"\t\t\t},",
+			'\t\t\trequired: ["query"],',
+			"\t\t\tadditionalProperties: false,",
+			"\t\t},",
+			'\t\texecute: async () => ({ content: [{ type: "text", text: "ok" }] }),',
+			"\t});",
+			'\tpi.on("session_start", () => pi.setActiveTools(["audit_lookup"]));',
+			'\tpi.on("before_provider_request", (event) => {',
+			"\t\tconst dumpFile = process.env.PI_PROVIDER_TOOL_DUMP_FILE;",
+			'\t\tif (dumpFile === undefined) throw new Error("PI_PROVIDER_TOOL_DUMP_FILE is required");',
+			"\t\twriteFileSync(dumpFile, JSON.stringify({ activeTools: pi.getActiveTools(), payload: event.payload }, null, 2));",
+			"\t\tprocess.exit(23);",
+			"\t});",
+			"}",
+		].join("\n"),
+	);
+	return extensionPath;
+}
+
+/** Writes a deterministic provider that activates one workflow and dumps the next request context. */
+function writeWorkflowLoopDumpExtension(directory: string): string {
+	const extensionPath = join(directory, "dump-workflow-loop.ts");
+	writeFileSync(
+		extensionPath,
+		[
+			'import { writeFileSync } from "node:fs";',
+			'import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";',
+			"let calls = 0;",
+			"const usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } };",
+			"export default function dumpWorkflowLoop(pi) {",
+			'\tpi.registerProvider("workflow-loop", {',
+			'\t\tname: "Workflow Loop",',
+			'\t\tapi: "openai-completions",',
+			'\t\tbaseUrl: "http://127.0.0.1:1/v1",',
+			'\t\tapiKey: "test",',
+			'\t\tmodels: [{ id: "fake", name: "Fake", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 128000, maxTokens: 4096 }],',
+			"\t\tstreamSimple(model, context) {",
+			"\t\t\tconst stream = createAssistantMessageEventStream();",
+			"\t\t\tqueueMicrotask(() => {",
+			"\t\t\t\tcalls += 1;",
+			"\t\t\t\tif (calls === 2) {",
+			"\t\t\t\t\twriteFileSync(process.env.PI_WORKFLOW_LOOP_DUMP_FILE, JSON.stringify(context.messages, null, 2));",
+			"\t\t\t\t\tprocess.exit(23);",
+			"\t\t\t\t}",
+			'\t\t\t\tconst output = { role: "assistant", content: [{ type: "toolCall", id: "activate-1", name: "workflow_activate", arguments: { workflowId: "delivery" } }], api: model.api, provider: model.provider, model: model.id, usage, stopReason: "toolUse", timestamp: Date.now() };',
+			'\t\t\t\tstream.push({ type: "start", partial: output });',
+			'\t\t\t\tstream.push({ type: "done", reason: "toolUse", message: output });',
+			"\t\t\t\tstream.end();",
+			"\t\t\t});",
+			"\t\t\treturn stream;",
+			"\t\t},",
+			"\t});",
+			"}",
+		].join("\n"),
+	);
+	return extensionPath;
+}
+
 /** Writes a debug extension that exits from context before any provider request. */
 function writeWorkflowRuntimeDumpExtension(
 	directory: string,
@@ -706,6 +782,142 @@ test("runtime package loading snapshots configured subagent descriptions on the 
 	}
 });
 
+test("provider payload carries active tool definitions without prompt inventory", () => {
+	// Purpose: Pi provider serialization, not system-prompt prose, owns active tool names, descriptions, and parameter schemas.
+	// Input and expected output: one active custom tool appears as the only provider tool with both description levels intact.
+	// Edge case: the process exits from before_provider_request before any network connection.
+	// Dependencies: local Pi CLI, an isolated runtime provider, and a temporary debug extension.
+	const scratchDir = mkdtempSync(join(tmpdir(), "pi-provider-tools-"));
+	const projectDir = mkdtempSync(join(tmpdir(), "pi-provider-tools-project-"));
+	const dumpFile = join(scratchDir, "provider-tools.json");
+	const extensionPath = writeProviderToolPayloadDumpExtension(scratchDir);
+	try {
+		const result = spawnSync(
+			"pi",
+			[
+				"--no-session",
+				"--no-extensions",
+				"--model",
+				RUNTIME_TEST_MODEL,
+				"-p",
+				"-e",
+				extensionPath,
+				"inspect provider tools",
+			],
+			{
+				cwd: projectDir,
+				encoding: "utf8",
+				env: { ...process.env, PI_PROVIDER_TOOL_DUMP_FILE: dumpFile },
+				timeout: 30_000,
+			},
+		);
+		if (result.status !== 23) {
+			throw new Error(`${result.stdout}\n${result.stderr}`);
+		}
+		const dump = JSON.parse(readFileSync(dumpFile, "utf8")) as {
+			readonly activeTools: readonly string[];
+			readonly payload: {
+				readonly tools: readonly {
+					readonly function: {
+						readonly name: string;
+						readonly description: string;
+						readonly parameters: {
+							readonly properties: {
+								readonly query: { readonly description: string };
+							};
+						};
+					};
+				}[];
+			};
+		};
+		expect(dump.activeTools).toEqual(["audit_lookup"]);
+		expect(dump.payload.tools).toHaveLength(1);
+		expect(dump.payload.tools[0]?.function).toMatchObject({
+			name: "audit_lookup",
+			description: "Find one audit record by query.",
+			parameters: {
+				properties: {
+					query: { description: "Exact audit query." },
+				},
+			},
+		});
+	} finally {
+		rmSync(projectDir, { recursive: true, force: true });
+		rmSync(scratchDir, { recursive: true, force: true });
+	}
+});
+
+test("workflow activation reaches the next provider request in the active tool loop", () => {
+	// Purpose: workflow journal records published by a tool must enter the active agent loop rather than only persisted session state.
+	// Input and expected output: a deterministic provider activates delivery, then its second request contains activation and stage records.
+	// Edge case: activation options change from the catalog list to an explicit empty replacement after activation.
+	// Dependencies: real Pi CLI, package loading, sendMessage steer delivery, and an isolated workflow catalog.
+	const scratchDir = mkdtempSync(join(tmpdir(), "pi-workflow-loop-"));
+	const projectDir = mkdtempSync(join(tmpdir(), "pi-workflow-loop-project-"));
+	const suiteDir = mkdtempSync(join(tmpdir(), "pi-workflow-loop-suite-"));
+	const workflowsDir = join(suiteDir, "workflow", "workflows");
+	mkdirSync(workflowsDir, { recursive: true });
+	writeFileSync(
+		join(workflowsDir, "delivery.yaml"),
+		"description: Delivery\nstages:\n  - id: start\n    description: Start\n    prompt: Start live check\n    initial: true\n  - id: done\n    description: Done\n    prompt: Finish live check\n    final: true\ntransitions:\n  - from: start\n    to: done\n    type: advance\n",
+	);
+	const dumpFile = join(scratchDir, "workflow-loop.json");
+	const extensionPath = writeWorkflowLoopDumpExtension(scratchDir);
+	try {
+		const result = spawnSync(
+			"pi",
+			[
+				"--no-session",
+				"--no-extensions",
+				"--model",
+				"workflow-loop/fake",
+				"-p",
+				"-e",
+				join(process.cwd(), "pi-package"),
+				"-e",
+				extensionPath,
+				"activate delivery",
+			],
+			{
+				cwd: projectDir,
+				encoding: "utf8",
+				env: {
+					...process.env,
+					PI_AGENT_SUITE_DIR: suiteDir,
+					PI_WORKFLOW_LOOP_DUMP_FILE: dumpFile,
+				},
+				timeout: 30_000,
+			},
+		);
+		if (result.status !== 23) {
+			throw new Error(`${result.stdout}\n${result.stderr}`);
+		}
+		const dumpedMessages = JSON.parse(readFileSync(dumpFile, "utf8")) as {
+			readonly content: readonly {
+				readonly type: string;
+				readonly text?: string;
+			}[];
+		}[];
+		const context = dumpedMessages
+			.flatMap(({ content }) => content.map(({ text }) => text ?? ""))
+			.join("\n");
+		const activationIndex = context.indexOf(
+			'<workflow_activated id="delivery"',
+		);
+		const stageIndex = context.indexOf(
+			'<workflow_stage_activated workflow_id="delivery" stage_id="start"',
+		);
+		expect(activationIndex).toBeGreaterThanOrEqual(0);
+		expect(stageIndex).toBeGreaterThan(activationIndex);
+		expect(context).toContain("<available_transitions>");
+		expect(context).toContain("<workflow_activation_options />");
+	} finally {
+		rmSync(projectDir, { recursive: true, force: true });
+		rmSync(scratchDir, { recursive: true, force: true });
+		rmSync(suiteDir, { recursive: true, force: true });
+	}
+});
+
 test("runtime package loading applies system-prompt before agent runtime contributions", () => {
 	// Purpose: real package load order must let system-prompt replace only the base prompt and keep selected-agent prompt additions after it.
 	// Input and expected output: suite config points system-prompt to a temp Markdown template, and selected TestAgent still appears later.
@@ -725,7 +937,7 @@ test("runtime package loading applies system-prompt before agent runtime contrib
 	});
 	writeFileSync(
 		customTemplateFile,
-		"Suite system prompt\n\nTools:\n{{tools}}\n\n{{unknown-from-test}}",
+		"Suite system prompt\n\nTool guidelines:\n{{toolGuidelines}}\n\n{{unknown-from-test}}",
 	);
 	writeFileSync(
 		join(agentDir, "agent-suite", "system-prompt", "config.json"),
@@ -1062,11 +1274,9 @@ function verifyWorkflowPolicyCases(cases: readonly WorkflowPolicyCase[]): void {
 				}
 			}
 			if (runtimeCase.projectsWorkflow) {
-				expect(workflowMessages).toHaveLength(1);
-				expect(String(workflowMessages[0]?.content)).toContain(
-					"WORKFLOW_RUNTIME_GUIDELINES",
-				);
-				const workflowContent = String(workflowMessages[0]?.content);
+				expect(workflowMessages.length).toBeGreaterThan(0);
+				expect(runtime.systemPrompt).toContain("WORKFLOW_RUNTIME_GUIDELINES");
+				const workflowContent = String(workflowMessages.at(-1)?.content);
 				if (expectedWorkflowTools.includes("workflow_activate")) {
 					expect(workflowContent).toContain("<workflow_activation_options>");
 					const expectedWorkflowIds = new Set<string>(
@@ -1082,12 +1292,14 @@ function verifyWorkflowPolicyCases(cases: readonly WorkflowPolicyCase[]): void {
 						}
 					}
 				} else {
-					expect(workflowContent).not.toContain("<workflow_activation_options");
+					expect(workflowContent).toBe("<workflow_activation_options />");
 				}
 			} else {
-				expect(workflowMessages).toHaveLength(0);
-				expect(JSON.stringify(runtime.contextMessages)).not.toContain(
-					"<workflow_",
+				expect(runtime.systemPrompt).not.toContain(
+					"WORKFLOW_RUNTIME_GUIDELINES",
+				);
+				expect(workflowMessages.at(-1)?.content).toBe(
+					"<workflow_activation_options />",
 				);
 			}
 		} finally {

--- a/test/integration/workflow.test.ts
+++ b/test/integration/workflow.test.ts
@@ -40,6 +40,10 @@ test("workflow entry activates a configured workflow and projects its initial st
 		execute: (...args: unknown[]) => Promise<unknown>;
 	}> = [];
 	const appended: Array<{ customType: string; data: unknown }> = [];
+	const messages: Array<{
+		readonly content: string;
+		readonly details: unknown;
+	}> = [];
 	let activeTools = ["read"];
 	let thinkingLevel = "medium";
 	const pi = {
@@ -71,6 +75,12 @@ test("workflow entry activates a configured workflow and projects its initial st
 		},
 		appendEntry(customType: string, data: unknown) {
 			appended.push({ customType, data });
+		},
+		sendMessage(message: { content: unknown; details?: unknown }) {
+			messages.push({
+				content: String(message.content),
+				details: message.details,
+			});
 		},
 		events: {
 			emit() {},
@@ -123,18 +133,18 @@ test("workflow entry activates a configured workflow and projects its initial st
 	await activate.execute("call", { workflowId: "delivery" });
 	expect(appended).toHaveLength(1);
 	expect(appended[0]?.customType).toBe("workflow-state");
-	const contextHandler = handlers.get("context");
-	if (contextHandler === undefined) {
-		throw new Error("context handler missing");
-	}
-	const prior = { role: "user", content: "preserve", timestamp: 1 };
-	const result = await contextHandler({ messages: [prior] }, {});
-	const messages = (result as { messages: Array<{ content: unknown }> })
-		.messages;
-	expect(messages[0]).toBe(prior);
-	expect(String(messages[1]?.content)).toContain('active_stage_id="start"');
-	expect(String(messages[1]?.content)).toContain(
-		"<active_stage_guidelines>\nStart work\n  </active_stage_guidelines>",
+	expect(handlers.has("context")).toBe(false);
+	const activation = messages.find(
+		({ details }) =>
+			typeof details === "object" &&
+			details !== null &&
+			Reflect.get(details, "kind") === "activation",
+	);
+	expect(activation?.content).toContain(
+		'<workflow_stage_activated workflow_id="delivery" stage_id="start"',
+	);
+	expect(activation?.content).toContain(
+		"<stage_guidelines>\nStart work\n  </stage_guidelines>",
 	);
 });
 


### PR DESCRIPTION
## Problem
The PR removed duplicate, repeated prompt data from the model-facing system prompt and moved it into persistent, deduplicated message flow. It addresses issues where MCP and workflow guidance was being re-inserted on every request, stale cached instructions lingered, and workflow activation/restore needed repair, especially around compaction and branch navigation.

## Solution
- Removed `{{tools}}` from bundled system prompt and tool-facing rendering, switching to tool metadata from the provider payload.
- Kept behavioral guidance only as `{{toolGuidelines}}`, with duplicate-normalized and trimmed deduplication.
- Persist MCP instructions as hidden custom messages (`customType: mcp-instructions`, `display: false`) and restore from branch history with replacement/coverage logic.
- Added MCP deferred-toolset activation context to toolset activation payload via shared `activationContext` contract.
- Replaced workflow context projection with an append-only hidden workflow journal (`customType: workflow`, `display: false`, `deliverAs: "steer"`) using records like activation, stage activation, stage updates, completion, checkpoints, and activation options.
- Added workflow compaction and replay repair behavior: context-segment reset deduplication, checkpoint publication, activation-options republishing, and state-version compatibility checks via SHA-256 revision + `WORKFLOW_STATE_JOURNAL_VERSION`.
- Updated lifecycle to publish journal records after successful state persistence and use `deliverAs: "steer"` so records enter the active tool loop immediately.
- Extended unit/integration tests for MCP, system-prompt, workflow journal behavior, provider tool payload ownership, and session restore/compaction paths.

## Testing
- New and updated unit tests cover MCP wrapper lifecycle/state persistence, shared toolset activation context, system prompt formatting, and workflow journal publish/restore logic.
- Integration coverage added/updated for MCP/system-prompt split and workflow loop/message visibility in provider requests.
- Existing validation references in the change set include `bun run test`, `bun run typecheck`, `bun run check`, and `bun run verify` in the technical solution plan.