### PR TITLE
Keep workflow tool results visible during context projection

### DIFF
--- a/docs/extensions/context-projection.md
+++ b/docs/extensions/context-projection.md
@@ -66,7 +66,7 @@ Enabled projection requires `custom-compaction` to resolve to a valid configurat
 | `minToolResultTokensL3` | No | Non-negative integer | `1000` | Minimum token count for a tool result to be projected at L3. |
 | `keepRecentTurns` | No | Non-negative integer | `10` | Minimum number of newest tool-use turns kept visible. A tool-use turn is an assistant tool call plus its matching tool results. |
 | `keepRecentTurnsPercent` | No | Number from `0` to `1` | `0.2` | Fraction of newest tool-use turns kept visible in long sessions. The extension uses the larger value from `keepRecentTurns` and this percentage. |
-| `projectionIgnoredTools` | No | Array of unique non-empty strings | `[]` | Tool names whose results stay visible. `consult_advisor` and `convene_council` always stay visible, even when omitted from this list. |
+| `projectionIgnoredTools` | No | Array of unique non-empty strings | `[]` | Tool names whose results stay visible. `consult_advisor`, `convene_council`, and tools whose names start with `workflow_` always stay visible during ordinary projection, even when omitted from this list. |
 | `omittedNotice` | No | Non-empty string | `Result omitted. Run tool again for full result.` | Text that replaces projected tool results when summary mode is disabled or a summary cannot be used. |
 | `summaryNotice` | No | Non-empty string | `Full result omitted. Summary below. Run tool again for full result.` | Text written in `<notice>` when a projected tool result includes a generated summary. |
 | `summary` | No | Object | Summary disabled | Configures optional generated summaries for projected tool results. |

--- a/pi-package/extensions/context-projection/index.test.ts
+++ b/pi-package/extensions/context-projection/index.test.ts
@@ -2354,6 +2354,60 @@ describe("context-projection", () => {
 		});
 	});
 
+	test("keeps every workflow tool result visible during ordinary projection", async () => {
+		// Purpose: workflow records intended for the main model must remain complete outside compaction.
+		// Input and expected output: old large results from every workflow tool remain unchanged and no projection state is recorded.
+		// Edge case: protection is mandatory without projectionIgnoredTools configuration.
+		// Dependencies: the ordinary context hook runs against an isolated branch containing all workflow tool names.
+		await withIsolatedAgentDir(async (agentDir) => {
+			await writeCustomConfig(
+				agentDir,
+				createValidConfig({ keepRecentTurns: 0 }),
+			);
+			const { pi, contextHandler } = installContextProjectionTestHarness();
+			const workflowToolNames = [
+				"workflow_create",
+				"workflow_activate",
+				"workflow_get_stage",
+				"workflow_edit_stage",
+				"workflow_transition",
+			] as const;
+			const branchEntries = [messageEntry("01", userMessage(), null)];
+			let parentId = "01";
+			for (const [index, toolName] of workflowToolNames.entries()) {
+				const assistantEntryId = String(index * 2 + 2).padStart(2, "0");
+				const resultEntryId = String(index * 2 + 3).padStart(2, "0");
+				const toolCallId = `call-${toolName}`;
+				branchEntries.push(
+					messageEntry(
+						assistantEntryId,
+						assistantMessage(toolCallId),
+						parentId,
+					),
+					messageEntry(
+						resultEntryId,
+						toolResultMessage(toolCallId, `${toolName} output `.repeat(5), {
+							toolName,
+						}),
+						assistantEntryId,
+					),
+				);
+				parentId = resultEntryId;
+			}
+			const originalMessages = messagesFromBranch(branchEntries);
+			const context = createContextFake(branchEntries);
+
+			const result = await contextHandler(
+				{ type: "context", messages: originalMessages },
+				context.ctx,
+			);
+
+			expect(result).toBeUndefined();
+			expect(messagesFromBranch(branchEntries)).toEqual(originalMessages);
+			expect(pi.appendEntryCalls).toEqual([]);
+		});
+	});
+
 	test("keeps consult_advisor and configured ignored tool results visible during projection", async () => {
 		// Purpose: projection must preserve advisor output and user-configured tool results while still projecting other eligible results.
 		// Input and expected output: consult_advisor and subagent_start outputs remain unchanged, while bash output is replaced with the omitted notice.

--- a/pi-package/shared/context-projection.ts
+++ b/pi-package/shared/context-projection.ts
@@ -73,6 +73,9 @@ const SUMMARY_CONFIG_KEY = "summary";
 const CONSULT_ADVISOR_TOOL_NAME = "consult_advisor";
 const CONVENE_COUNCIL_TOOL_NAME = "convene_council";
 
+/** Workflow tool results are durable model instructions outside compaction. */
+const WORKFLOW_TOOL_NAME_PREFIX = "workflow_";
+
 /** Built-in tool names whose results are excluded from projection. */
 const BUILT_IN_PROJECTION_IGNORED_TOOLS = [
 	CONSULT_ADVISOR_TOOL_NAME,
@@ -1265,6 +1268,7 @@ function shouldKeepToolResultVisible(
 	ignoredTools: ReadonlySet<string>,
 ): boolean {
 	return (
+		message.toolName.startsWith(WORKFLOW_TOOL_NAME_PREFIX) ||
 		ignoredTools.has(message.toolName) ||
 		isLoadedSkillReadResult(message, readPathsByToolCallId, loadedSkillRoots)
 	);


### PR DESCRIPTION
## Problem
The context tool keeps trimming long tool outputs to make prompts smaller. But workflow tools (like `workflow_create` and `workflow_transition`) can lose important details this way, even though they are used to guide the main model for workflow steps.

## Solution
We made workflow tool results (`workflow_*`) always stay visible during normal context projection, same as other always-kept tools like `consult_advisor`. This is done by updating the visibility check to treat any `workflow_`-prefixed tool name as protected. We also updated the docs for `projectionIgnoredTools` and added a test that verifies workflow tool outputs are kept intact when projection runs.

## Testing
- Added unit test in `pi-package/extensions/context-projection/index.test.ts`: `keeps every workflow tool result visible during ordinary projection`