### PR TITLE
Prevent steering loop after compaction context restoration

### DIFF
--- a/docs/specs/issues/compaction-post-turn-resume/technical-solution.md
+++ b/docs/specs/issues/compaction-post-turn-resume/technical-solution.md
@@ -1,0 +1,47 @@
+# Technical Solution: Passive Post-Compaction Context Restoration
+
+## Problem Statement
+
+- PRB-01: Automatic compaction emits `session_compact` before the active agent run settles.
+- PRB-02: MCP and workflow handlers publish restored hidden context with `deliverAs: "steer"` while the agent run remains active.
+- PRB-03: Pi adds these messages to the steering queue. The non-empty queue causes another model request after a completed assistant response with `stopReason: "stop"`.
+
+## Proposed Solution
+
+### SOL-01: Post-compaction delivery
+
+- Publish MCP instructions, workflow checkpoints, and workflow activation options from `session_compact` with `triggerTurn: false`.
+- Keep `deliverAs: "steer"` so the message contract remains explicit while `triggerTurn: false` prevents steering-queue insertion.
+- Persist each restored message immediately in the post-compaction session history.
+
+### SOL-02: Ordinary workflow delivery
+
+- Keep workflow activation, stage transition, stage update, completion, and active-loop reminder messages on their existing delivery paths.
+- Keep MCP startup instruction publication on its existing delivery path.
+
+### SOL-03: Validation
+
+- Assert that workflow checkpoint and activation-option messages emitted by `session_compact` use `triggerTurn: false`.
+- Assert that MCP instructions emitted by `session_compact` use `triggerTurn: false`.
+- Execute the real `AgentSession` overflow-compaction control flow with `willRetry: true`. Assert that passive context is persisted without steering and that compaction still requests continuation.
+- Retain the ordinary workflow delivery test that requires `deliverAs: "steer"` without passive delivery.
+
+## Overengineering and Overspecification Considerations
+
+- The solution uses the public `pi.sendMessage` option already used by the package.
+- The solution does not change compaction summaries, workflow state, MCP catalogs, message content, dependencies, or Pi core.
+- Passive delivery is limited to the two `session_compact` handlers that restore model-visible context.
+
+## Open Questions
+
+No unresolved questions remain.
+
+## References
+
+- REF-01: `pi-package/extensions/mcp-wrapper/index.ts` - MCP post-compaction instruction publication.
+- REF-02: `pi-package/extensions/mcp-wrapper/index.test.ts` - MCP lifecycle tests.
+- REF-03: `pi-package/extensions/workflow/context.ts` - workflow journal delivery contract.
+- REF-04: `pi-package/extensions/workflow/index.ts` - workflow post-compaction publication.
+- REF-05: `pi-package/extensions/workflow/index.test.ts` - workflow lifecycle tests.
+- REF-06: `test/integration/compaction-overflow-retry.test.ts` - interrupted-work compaction retry test.
+- REF-07: `node_modules/@earendil-works/pi-coding-agent/dist/core/agent-session.js` - custom-message queueing and automatic compaction continuation.

--- a/pi-package/extensions/mcp-wrapper/index.test.ts
+++ b/pi-package/extensions/mcp-wrapper/index.test.ts
@@ -71,6 +71,7 @@ interface ExtensionApiFake extends ExtensionAPI {
 		readonly display: boolean;
 		readonly details: unknown;
 	}>;
+	readonly messageOptions: Parameters<ExtensionAPI["sendMessage"]>[1][];
 	readonly commands: Array<
 		Omit<RegisteredCommand, "name" | "sourceInfo"> & { readonly name: string }
 	>;
@@ -110,11 +111,13 @@ function createExtensionApiFake(
 	const tools: ToolDefinition[] = [];
 	const activeToolHistory: string[][] = [];
 	const messages: ExtensionApiFake["messages"] = [];
+	const messageOptions: ExtensionApiFake["messageOptions"] = [];
 	let activeTools: readonly string[] = [];
 
 	return {
 		activeToolHistory,
 		messages,
+		messageOptions,
 		commands,
 		handlers,
 		tools,
@@ -157,13 +160,17 @@ function createExtensionApiFake(
 			return undefined;
 		},
 		setThinkingLevel(): void {},
-		sendMessage(message: Parameters<ExtensionAPI["sendMessage"]>[0]): void {
+		sendMessage(
+			message: Parameters<ExtensionAPI["sendMessage"]>[0],
+			options?: Parameters<ExtensionAPI["sendMessage"]>[1],
+		): void {
 			messages.push({
 				customType: message.customType,
 				content: String(message.content),
 				display: message.display,
 				details: message.details,
 			});
+			messageOptions.push(options);
 		},
 		appendEntry(): void {},
 		getSessionHistory() {
@@ -646,6 +653,10 @@ describe("mcp-wrapper extension", () => {
 		expect(pi.messages).toHaveLength(2);
 		expect(pi.messages[1]?.content).toContain("Use eager files.");
 		expect(pi.messages[1]?.content).toContain("Use deferred search carefully.");
+		expect(pi.messageOptions[1]).toEqual({
+			deliverAs: "steer",
+			triggerTurn: false,
+		});
 	});
 
 	test("restores resumed activation after cacheless live discovery finalizes the catalog", async () => {

--- a/pi-package/extensions/mcp-wrapper/index.ts
+++ b/pi-package/extensions/mcp-wrapper/index.ts
@@ -228,6 +228,7 @@ function registerMcpSessionLifecycleHandlers(options: {
 			options.pi,
 			options.state.serverInstructionRecords,
 			ctx.sessionManager.getBranch(),
+			false,
 		);
 	});
 
@@ -966,6 +967,7 @@ function persistActiveServerInstructions(
 	pi: ExtensionAPI,
 	records: readonly ServerInstructionRecord[],
 	branch: readonly unknown[],
+	triggerTurn?: boolean,
 ): void {
 	const activeToolNames = new Set(pi.getActiveTools());
 	const visible = records.filter((record) =>
@@ -988,7 +990,10 @@ function persistActiveServerInstructions(
 				serverKeys: visible.map(({ serverKey }) => serverKey),
 			},
 		},
-		{ deliverAs: "steer" },
+		{
+			deliverAs: "steer",
+			...(triggerTurn === undefined ? {} : { triggerTurn }),
+		},
 	);
 }
 

--- a/pi-package/extensions/workflow/context.ts
+++ b/pi-package/extensions/workflow/context.ts
@@ -38,6 +38,7 @@ export class WorkflowJournal {
 		private readonly publish: (
 			record: WorkflowJournalRecord,
 			delivery: WorkflowJournalDelivery,
+			triggerTurn?: boolean,
 		) => void,
 	) {}
 
@@ -115,7 +116,7 @@ export class WorkflowJournal {
 		);
 	}
 
-	public checkpoint(state: WorkflowState): void {
+	public checkpoint(state: WorkflowState, triggerTurn?: boolean): void {
 		const stage = requireCurrentStage(state);
 		this.knownStages.clear();
 		if (state.status === "active") {
@@ -126,11 +127,17 @@ export class WorkflowJournal {
 			renderWorkflowCheckpoint(state, stage),
 			"checkpoint",
 			state,
-			{ stageId: stage.id },
+			{
+				stageId: stage.id,
+				...(triggerTurn === undefined ? {} : { triggerTurn }),
+			},
 		);
 	}
 
-	public activationOptions(workflows: readonly WorkflowDefinition[]): void {
+	public activationOptions(
+		workflows: readonly WorkflowDefinition[],
+		triggerTurn?: boolean,
+	): void {
 		const content = renderActivationOptions(workflows);
 		if (content === this.activationOptionsContent) {
 			return;
@@ -144,6 +151,7 @@ export class WorkflowJournal {
 				details: { version: 1, kind: "activation_options" },
 			},
 			"steer",
+			triggerTurn,
 		);
 	}
 
@@ -237,9 +245,10 @@ export class WorkflowJournal {
 		publication: Readonly<Record<string, unknown>> & {
 			readonly stageId: string;
 			readonly delivery?: WorkflowJournalDelivery;
+			readonly triggerTurn?: boolean;
 		},
 	): void {
-		const { delivery = "steer", ...metadata } = publication;
+		const { delivery = "steer", triggerTurn, ...metadata } = publication;
 		this.publish(
 			{
 				customType: "workflow",
@@ -256,6 +265,7 @@ export class WorkflowJournal {
 				},
 			},
 			delivery,
+			triggerTurn,
 		);
 	}
 }

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -2072,6 +2072,10 @@ describe("workflow extension lifecycle", () => {
 
 		expect(fake.messages).toHaveLength(2);
 		expect(fake.messages.at(-1)?.content).toBe(initialOptions);
+		expect(fake.messages.at(-1)?.options).toEqual({
+			deliverAs: "steer",
+			triggerTurn: false,
+		});
 	});
 
 	/** Proves compaction creates one checkpoint and forgets definitions outside that checkpoint. */
@@ -2098,6 +2102,10 @@ describe("workflow extension lifecycle", () => {
 		expect(fake.messages.at(-1)?.content).toBe(
 			"<workflow_activation_options />",
 		);
+		expect(fake.messages.slice(-2).map(({ options }) => options)).toEqual([
+			{ deliverAs: "steer", triggerTurn: false },
+			{ deliverAs: "steer", triggerTurn: false },
+		]);
 
 		await transition.execute("rework", { stageId: "start" });
 		expect(fake.messages.at(-1)?.content).toContain('guidelines="inline"');

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -431,8 +431,11 @@ function createWorkflowRuntimeState(
 		modelRegistry: undefined,
 		lastTurnFailed: false,
 		selfSuppressedNames: new Set<string>(),
-		journal: new WorkflowJournal((record, delivery) => {
-			pi.sendMessage(record, { deliverAs: delivery });
+		journal: new WorkflowJournal((record, delivery, triggerTurn) => {
+			pi.sendMessage(record, {
+				deliverAs: delivery,
+				...(triggerTurn === undefined ? {} : { triggerTurn }),
+			});
 			if (recordCarriesCurrentWorkflowState(record.details)) {
 				reminderScheduler.workflowStatePublished();
 			}
@@ -469,11 +472,12 @@ function publishWorkflowActivationOptions(
 	pi: ExtensionAPI,
 	runtime: WorkflowRuntime,
 	availability: WorkflowAvailability,
+	triggerTurn?: boolean,
 ): void {
 	const options = pi.getActiveTools().includes(WORKFLOW_ACTIVATE_TOOL)
 		? availability.activationOptions
 		: [];
-	runtime.journal.activationOptions(options);
+	runtime.journal.activationOptions(options, triggerTurn);
 }
 
 /** Reports all skipped catalog workflows in one startup notification. */
@@ -768,12 +772,13 @@ function registerWorkflowCompaction(
 	pi.on("session_compact", () => {
 		runtime.journal.startContextSegment();
 		if (runtime.state !== undefined) {
-			runtime.journal.checkpoint(runtime.state);
+			runtime.journal.checkpoint(runtime.state, false);
 		}
 		publishWorkflowActivationOptions(
 			pi,
 			runtime,
 			resolveRuntimeAvailability(runtime, getPolicy()),
+			false,
 		);
 	});
 }

--- a/test/integration/compaction-overflow-retry.test.ts
+++ b/test/integration/compaction-overflow-retry.test.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "bun:test";
+import type {
+	AssistantMessage,
+	Model,
+	UserMessage,
+} from "@earendil-works/pi-ai/compat";
+import { AgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
+
+const MODEL: Model<"openai-completions"> = {
+	api: "openai-completions",
+	provider: "test",
+	id: "test-model",
+	name: "Test model",
+	baseUrl: "http://127.0.0.1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000,
+	maxTokens: 100,
+};
+
+function userMessage(text: string, timestamp: number): UserMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp,
+	};
+}
+
+function assistantMessage(
+	stopReason: AssistantMessage["stopReason"],
+	timestamp: number,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "response" }],
+		api: MODEL.api,
+		provider: MODEL.provider,
+		model: MODEL.id,
+		usage: {
+			input: 100,
+			output: 10,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 110,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp,
+	};
+}
+
+test("overflow compaction retries after passive context restoration", async () => {
+	// Purpose: interrupted work must continue after compaction restores hidden extension context.
+	// Input and expected output: willRetry true returns continuation while one custom context message is persisted without steering.
+	// Edge case: session_compact runs while AgentSession still reports an active run.
+	// Dependencies: real AgentSession auto-compaction and custom-message delivery control flow with an in-memory session.
+	const sessionManager = SessionManager.inMemory(
+		"/tmp/compaction-overflow-retry",
+	);
+	sessionManager.appendMessage(userMessage("old turn", 1));
+	sessionManager.appendMessage(assistantMessage("stop", 2));
+	sessionManager.appendMessage(userMessage("interrupted turn", 3));
+	sessionManager.appendMessage(assistantMessage("error", 4));
+
+	let steerCalls = 0;
+	const agent = {
+		state: { model: MODEL, messages: [] as unknown[] },
+		hasQueuedMessages: () => steerCalls > 0,
+		steer: () => {
+			steerCalls += 1;
+		},
+		followUp: () => {},
+	};
+	const session = Object.create(AgentSession.prototype) as AgentSession;
+	Object.assign(session, {
+		agent,
+		sessionManager,
+		settingsManager: {
+			getCompactionSettings: () => ({
+				enabled: true,
+				reserveTokens: 100,
+				keepRecentTokens: 1,
+			}),
+		},
+		_isAgentRunActive: true,
+		_pendingNextTurnMessages: [],
+		_eventListeners: new Set(),
+		_getSummarizationRequestAuth: async () => ({ model: MODEL }),
+		_extensionRunner: {
+			hasHandlers: (eventName: string) =>
+				eventName === "session_before_compact",
+			emit: async (event: Record<string, unknown>) => {
+				if (event["type"] === "session_before_compact") {
+					const preparation = event["preparation"] as {
+						readonly firstKeptEntryId: string;
+						readonly tokensBefore: number;
+					};
+					return {
+						compaction: {
+							summary: "summary",
+							firstKeptEntryId: preparation.firstKeptEntryId,
+							tokensBefore: preparation.tokensBefore,
+						},
+					};
+				}
+				if (event["type"] === "session_compact") {
+					await session.sendCustomMessage(
+						{
+							customType: "restored-context",
+							content: "context",
+							display: false,
+							details: {},
+						},
+						{ deliverAs: "steer", triggerTurn: false },
+					);
+				}
+				return undefined;
+			},
+		},
+	});
+
+	const continuation = await (
+		session as unknown as {
+			_runAutoCompaction(
+				reason: "overflow",
+				willRetry: boolean,
+			): Promise<boolean>;
+		}
+	)._runAutoCompaction("overflow", true);
+
+	expect(continuation).toBe(true);
+	expect(steerCalls).toBe(0);
+	expect(
+		sessionManager
+			.getEntries()
+			.filter((entry) => entry.type === "custom_message")
+			.map((entry) => entry.customType),
+	).toEqual(["restored-context"]);
+});


### PR DESCRIPTION
## Problem
When a session gets compacted in the middle of an active run, restored hidden context was sometimes sent as steering messages. That made the model take an extra turn even though work should just continue, causing an unwanted steering loop.

## Solution
Treat session-compaction restoration messages as passive context: keep delivering them as `deliverAs: "steer"` so the message type is explicit, but add `triggerTurn: false` so they do not queue a new turn.

Implementation changes:
- MCP wrapper now passes a new optional `triggerTurn` flag when persisting active server instructions and sets it to `false` on `session_compact` restore.
- Workflow journal publish flow now supports optional `triggerTurn` and wiring through checkpoint/activation-options restoration paths.
- Workflow session compaction handler now restores checkpoint and activation options with `triggerTurn: false`.
- Added/updated tests:
  - MCP wrapper lifecycle test checks restored instructions use `{ deliverAs: "steer", triggerTurn: false }`.
  - Workflow lifecycle tests check restored activation options use the same passive delivery mode.
  - New integration test (`test/integration/compaction-overflow-retry.test.ts`) verifies overflow compaction with `willRetry: true` persists restored context without steering while still continuing with compaction flow.