### PR TITLE
Delegate workflow_create string validation to workflow domain layer

### DIFF
--- a/docs/extensions/workflow.md
+++ b/docs/extensions/workflow.md
@@ -160,7 +160,7 @@ A final-stage agent run remains active until `agent_settled`. The settlement res
 
 A successful call validates the whole graph, stores one `created` snapshot, and immediately activates the initial stage. It replaces an active workflow with a different ID. A replaced dynamic workflow cannot be reactivated. The new ID must not match a catalog ID or the active dynamic ID after NFC normalization and exact case comparison. Reusing the active dynamic ID is rejected without resetting its route.
 
-The `workflow_create` TypeBox schema adds LLM-facing length and collection-size budgets. YAML catalog definitions use the same structural text rules without those tool-specific budgets. `workflow_create` requires a closed `model` object on every stage. Every stage model requires `thinking`. The allowed values are `low`, `medium`, and `high`. Root model settings, `model.id`, and other thinking levels are rejected.
+The `workflow_create` TypeBox schema adds LLM-facing length and collection-size budgets. It leaves exact single-line and identifier rules to domain validation so providers do not need to compile nested regex constraints. YAML catalog definitions use the same domain text rules without the tool-specific budgets. `workflow_create` requires a closed `model` object on every stage. Every stage model requires `thinking`. The allowed values are `low`, `medium`, and `high`. Root model settings, `model.id`, and other thinking levels are rejected.
 
 `workflow_create` remains available with a missing or empty catalog when the agent's `tools` policy permits it. A catalog error blocks creation because ID collisions cannot be checked against an incomplete namespace. Dynamic workflows are never written to YAML.
 

--- a/docs/specs/issues/ollama-workflow-create-grammar/technical-solution.md
+++ b/docs/specs/issues/ollama-workflow-create-grammar/technical-solution.md
@@ -1,0 +1,42 @@
+# Technical Solution: Ollama Workflow Creation Grammar Compatibility
+
+## Problem Statement
+
+- PRB-01: Ollama 0.32.15 converts tool JSON Schema into a constrained-generation grammar before model execution.
+- PRB-02: The `workflow_create` schema combines nested stage and transition arrays with regex `pattern` constraints. Ollama rejects this schema with `Failed to initialize samplers: failed to parse grammar`.
+- PRB-03: `workflow_create` remains active before a workflow starts, so the schema failure blocks requests that do not call the tool.
+
+## Proposed Solution
+
+### SOL-01: Provider-facing schema
+
+- Define the six `workflow_create` string fields with `Type.String` and their existing `minLength`, `maxLength`, and descriptions.
+- Keep required fields, collection limits, enums, and closed object shapes in the provider-facing schema.
+- Keep the shared `technicalIdentifierSchema` and `singleLineTextSchema` contracts for other tools.
+
+### SOL-02: Domain validation
+
+- Pass structurally valid strings from the provider-facing schema to `validateCreatedWorkflowDefinition`.
+- Continue to reject blank, untrimmed, and multiline human text through `isSingleLineText`. Continue to reject whitespace-bearing identifiers through `isTechnicalIdentifier` before workflow state is persisted.
+
+### SOL-03: Validation
+
+- Test that the provider-facing schema accepts structurally valid strings for domain validation.
+- Test that workflow execution rejects invalid root text, stage text and identifiers, and transition endpoints.
+- Run the complete repository verification and a real Pi request with `workflow_create` active against each affected local Ollama model.
+
+## Overengineering and Overspecification Considerations
+
+- The solution changes only the `workflow_create` boundary schema.
+- The solution adds no provider detection, schema rewriting layer, configuration, or dependency.
+- Existing domain validation remains the owner of exact workflow string rules.
+
+## Open Questions
+
+No unresolved questions remain.
+
+## References
+
+- REF-01: `pi-package/extensions/workflow/index.ts` - provider-facing workflow tool schemas.
+- REF-02: `pi-package/extensions/workflow/workflow.ts` - exact workflow domain validation.
+- REF-03: `pi-package/extensions/workflow/index.test.ts` - provider and domain boundary behavior tests.

--- a/pi-package/extensions/workflow/index.test.ts
+++ b/pi-package/extensions/workflow/index.test.ts
@@ -638,6 +638,52 @@ describe("workflow extension lifecycle", () => {
 	});
 
 	/**
+	 * Proves the provider-facing create schema delegates exact string checks to workflow execution.
+	 * Inputs and expected outputs: structurally valid strings pass TypeBox, then execution rejects invalid workflow text.
+	 * Edge cases: root text, stage text and IDs, and transition endpoints cover every constrained create string.
+	 * Dependencies: the registered workflow_create schema and validateCreatedWorkflowDefinition.
+	 */
+	test("delegates exact create string checks to workflow execution", async () => {
+		await createSuite();
+		const fake = await createFakePi();
+		const create = requireTool(fake, "workflow_create");
+		const schema = create.parameters as Parameters<typeof Check>[0];
+		const cases = [
+			(args: Record<string, unknown>) => {
+				args["id"] = " dynamic-delivery";
+			},
+			(args: Record<string, unknown>) => {
+				args["description"] = "Dynamic\ndelivery";
+			},
+			(args: Record<string, unknown>) => {
+				const stages = args["stages"] as Record<string, unknown>[];
+				stages[0] = { ...stages[0], id: "start stage" };
+			},
+			(args: Record<string, unknown>) => {
+				const stages = args["stages"] as Record<string, unknown>[];
+				stages[0] = { ...stages[0], description: "Start\nwork" };
+			},
+			(args: Record<string, unknown>) => {
+				const transitions = args["transitions"] as Record<string, unknown>[];
+				transitions[0] = { ...transitions[0], from: "start stage" };
+			},
+			(args: Record<string, unknown>) => {
+				const transitions = args["transitions"] as Record<string, unknown>[];
+				transitions[0] = { ...transitions[0], to: "done stage" };
+			},
+		] as const;
+
+		for (const mutate of cases) {
+			const args = createArguments();
+			mutate(args);
+			expect(Check(schema, args)).toBe(true);
+			await expect(create.execute("create", args)).rejects.toThrow(
+				"workflow_create",
+			);
+		}
+	});
+
+	/**
 	 * Proves the dynamic TypeBox boundary requires thinking-only model settings on every stage.
 	 * Inputs and expected outputs: low, medium, and high pass on every stage; other levels and model IDs fail.
 	 * Edge cases: root model settings and stages without model settings are rejected.

--- a/pi-package/extensions/workflow/index.ts
+++ b/pi-package/extensions/workflow/index.ts
@@ -129,12 +129,12 @@ const WORKFLOW_CREATE_MODEL_SCHEMA = Type.Object(
 /** Closed workflow_create stage shape exposed to Pi tool validation. */
 const WORKFLOW_STAGE_SCHEMA = Type.Object(
 	{
-		id: technicalIdentifierSchema({
+		id: Type.String({
 			description: "Unique stage ID referenced by transitions",
 			minLength: 1,
 			maxLength: 32,
 		}),
-		description: singleLineTextSchema({
+		description: Type.String({
 			description: "Short single-line summary of stage outcome",
 			minLength: 1,
 			maxLength: 128,
@@ -225,12 +225,12 @@ const WORKFLOW_EDIT_STAGE_SCHEMA = Type.Object(
 /** Closed workflow_create transition shape exposed to Pi tool validation. */
 const WORKFLOW_TRANSITION_SCHEMA = Type.Object(
 	{
-		from: technicalIdentifierSchema({
+		from: Type.String({
 			description: "Source stage ID",
 			minLength: 1,
 			maxLength: 32,
 		}),
-		to: technicalIdentifierSchema({
+		to: Type.String({
 			description: "Target stage ID",
 			minLength: 1,
 			maxLength: 32,
@@ -246,13 +246,13 @@ const WORKFLOW_TRANSITION_SCHEMA = Type.Object(
 /** Complete workflow_create boundary shape; graph invariants remain domain validation. */
 const WORKFLOW_CREATE_SCHEMA = Type.Object(
 	{
-		id: singleLineTextSchema({
+		id: Type.String({
 			description:
 				"Unique workflow ID. Must not match any other workflow ID after NFC normalization",
 			minLength: 6,
 			maxLength: 32,
 		}),
-		description: singleLineTextSchema({
+		description: Type.String({
 			description: "Single-line summary of workflow's purpose",
 			minLength: 1,
 			maxLength: 256,


### PR DESCRIPTION
## Problem
The Ollama provider can break before tool execution because the `workflow_create` schema includes strict regex-based text rules it can’t parse into grammar. In short, too much validation is happening too early, so some requests fail even before the tool runs.

## Solution
We moved the exact string-validity checks out of the provider-facing schema and into existing domain validation during workflow execution.

- Kept shape, required fields, enums, length limits, and closed object contracts in the tool schema.
- Replaced `technicalIdentifierSchema`/`singleLineTextSchema` usage in `workflow_create` field definitions (`id`, `description`, stage `id`/`description`, transition `from`/`to`) with plain `Type.String` + min/max length.
- Domain validators (`validateCreatedWorkflowDefinition`) now continue to enforce strict rules like single-line text and identifier formatting.
- Added/updated docs for the new boundary behavior and included a technical solution note for the Ollama grammar issue.
- Added a test proving valid structurally-typed args pass TypeBox while invalid identifiers/text/transition endpoints are rejected at execution.

## Testing
- [x] Added/updated unit test in `pi-package/extensions/workflow/index.test.ts` for delegated string validation behavior.