### PR TITLE
Migrate MCP wrapper to SDK v2 with consumer release checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,16 +41,16 @@ pi-update:
 audit:
 	cd $(PACKAGE_DIR) && npm audit --omit=dev --audit-level=low
 
-release-check: audit
+release-check:
 	bun run release:check
 
-release-patch: audit
+release-patch:
 	bun run release:prepare:patch
 
-release-minor: audit
+release-minor:
 	bun run release:prepare:minor
 
-release-major: audit
+release-major:
 	bun run release:prepare:major
 
 release-tag:

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,7 +7,8 @@
 			"tsconfig.json",
 			"pi-package/**/*.ts",
 			"pi-package/**/*.js",
-			"test/**/*.ts"
+			"test/**/*.ts",
+			"scripts/**/*.ts"
 		]
 	},
 	"formatter": {

--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "pi-agent-suite",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/client": "^2.0.0",
         "entities": "^8.0.0",
         "js-tiktoken": "^1.0.21",
         "p-retry": "^7.1.1",
@@ -196,6 +196,10 @@
     "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -68,7 +68,7 @@ make release-minor
 make release-major
 ```
 
-The command updates `pi-package/package.json`, runs validation, temporarily copies `README.md` into `pi-package/`, checks the npm tarball, and removes the temporary copy.
+The command runs validation, repository audit, and both consumer installation checks before changing the version. Only after all checks pass does it run `npm version` in `pi-package/`. A failed check leaves the version unchanged. Package staging and archives stay in system temporary directories; release checks do not write `pi-package/README.md`.
 
 Print the remaining manual steps:
 
@@ -109,9 +109,31 @@ make release-check
 This runs:
 
 - `bun run verify`
-- `npm pack --dry-run` inside `pi-package/`
+- `make audit`, using the package's tracked npm lockfile
+- Both consumer installation checks, each using an actual npm archive and an isolated Pi package-loading check
 
 The publish workflow runs `bun run verify:ci` because the runtime integration test depends on local pi CLI behavior and is covered by `make release-check` before the release commit. Before checking and publishing the npm package, the workflow copies the root `README.md` into `pi-package/`.
+
+## Consumer installation checks
+
+Run registry-dependent checks without the deterministic test suite:
+
+```bash
+bun run release:consumers
+```
+
+Run one scenario with `bun scripts/release-consumers.ts SCN-02` or `bun scripts/release-consumers.ts SCN-03`.
+
+- SCN-02 installs the candidate archive in a clean npm consumer.
+- SCN-03 uses `test/fixtures/mcp-upgrade-consumer/package.json` and its lockfile to install `pi-agent-suite@2.8.0`. It checks that installed and locked `qs` is `6.15.3` and that the baseline audit identifies a reported `qs` advisory. It then installs the candidate without deleting the lockfile or running a repair command.
+
+Both scenarios use `npm install <archive> --prefix <consumer> --legacy-peer-deps`, matching Pi's npm package manager policy. Pi supplies host APIs, so these consumers do not install host peer dependencies. Each scenario runs `npm audit --omit=dev --audit-level=low` at the consumer root and requires exit code 0. The installed dependency tree must exclude SDK v1, Express, body-parser, and qs. The repository-local Pi CLI must load the installed package with `--no-session --no-extensions --offline -p -e <installed-package>` in temporary project and agent directories. No prompt or provider request is used.
+
+The checks report scenario IDs and audit summaries. Temporary state is removed on success and failure. Registry or audit-service errors block release preparation; do not weaken the audit threshold. A dependency's `package-lock.json` does not constrain consumer installs, so a passing repository audit cannot replace these checks.
+
+The upgrade fixture has no override or direct `qs` dependency. Its lockfile retains the historical vulnerable version. When rebuilding this baseline, preserve the published `2.8.0` manifest and verify the installed version and advisory before accepting a replacement fixture.
+
+The development tree can still contain SDK v1 through the optional `@google/genai` peer used by Pi. Root overrides remain applicable to that locked host tree; this is separate from the published package's mandatory production dependencies.
 
 ## Version and tag rule
 

--- a/docs/extensions/mcp-wrapper.md
+++ b/docs/extensions/mcp-wrapper.md
@@ -4,6 +4,14 @@
 
 The MCP wrapper extension registers configured MCP server tools as Pi tools. Pi sends each active generated tool's description and parameter schema through the provider tool payload.
 
+## MCP client dependency
+
+The wrapper uses `@modelcontextprotocol/client@^2.0.0` for stdio and Streamable HTTP. It does not require the monolithic v1 SDK or its Express server dependencies. Node.js 20 or newer is required by the client package.
+
+The adapter passes cancellation and timeout options as the second `callTool` argument. SDK v2 aggregates tool pages when `listTools` has no cursor; an explicit cursor requests one page. The wrapper's discovery loop accepts the aggregate without adding duplicate tools. SDK v2 limits an aggregate to 64 pages and rejects a listing that exceeds that limit.
+
+The protocol tests use the real client with a local stdio fixture and fake HTTP fetch responses. Consumer installation and upgrade audits are separate release checks described in [Publishing](../PUBLISHING.md#consumer-installation-checks).
+
 ## Configuration file
 
 By default, place the configuration at `agent-suite/mcp-wrapper/config.json`. If the file is missing, no MCP tools are registered.

--- a/docs/specs/issues/mcp-client-v2-migration/implementation.md
+++ b/docs/specs/issues/mcp-client-v2-migration/implementation.md
@@ -1,0 +1,35 @@
+# MCP client v2 migration verification
+
+## Implementation
+
+Both manifests declare `@modelcontextprotocol/client@^2.0.0`. All three tracked lockfiles resolve client version `2.0.0`. The adapter imports `Client` and `StreamableHTTPClientTransport` from the package root and `StdioClientTransport` from its `/stdio` export.
+
+The [SDK migration guide](https://ts.sdk.modelcontextprotocol.io/v2/migration/upgrade-to-v2.html) identifies the changed call signature and list aggregation behavior. The adapter passes request options as the second `callTool` argument. Its constructor assignment no longer uses an `unknown` cast. Tests exercise real SDK pagination through `McpClientManager`, including an explicit cursor request, without duplicate tools.
+
+SCN-01 tests cover both transports, request option forwarding, argument and environment configuration, working directory, HTTP headers, result mapping, protocol and tool errors, cancellation, timeout, and closure. Stdio uses a local child fixture. Streamable HTTP uses the real transport with fake fetch responses. No live MCP service or provider is needed.
+
+Release preparation runs validation and SCN-02 and SCN-03 before `npm version`. Consumer checks build npm archives in temporary staging directories and use Pi's `--legacy-peer-deps` installation policy. The upgrade fixture retains the vulnerable transitive version in its lockfile without a direct `qs` dependency or override.
+
+The npm production lockfile and both consumer trees exclude SDK v1 and its Express chain. Bun lockfiles retain SDK v1 through the host's optional `@google/genai` peer. Root overrides still apply to that locked development tree, so this migration does not make those overrides obsolete.
+
+## Verification results
+
+Checks ran on 2026-09-06 with Node.js `25.8.2`, npm `11.11.1`, Bun `1.2.18`, and repository-local Pi `0.85.1`.
+
+| Check | Exit code | Result |
+| --- | --- | --- |
+| Adapter regression before implementation | 1 | Both transport cases failed because call options were undefined. |
+| Release preparation tests before implementation | 1 | Seven assertions failed against the compile-only stub. |
+| `bun run test ./pi-package/extensions/mcp-wrapper ./scripts` | 0 | 105 passed, 0 failed. |
+| `bun run verify` | 0 | 1439 passed, 1 pre-existing skip, 0 failed; type and formatting checks passed. |
+| `make audit` | 0 | 0 vulnerabilities. |
+| `make release-check` | 0 | Full validation, both consumer scenarios, and both isolated Pi loads passed. |
+| SCN-03 baseline audit | 1 | Installed and locked `qs@6.15.3`; 1 moderate vulnerability. |
+| SCN-02 and SCN-03 candidate audits | 0 each | 0 vulnerabilities at the low-severity threshold. |
+| SCN-03 with the published v1-based `2.8.0` archive as candidate | 1 | Consumer audit rejected the retained vulnerability. |
+
+The skipped test is `overflow compaction retries after passive context restoration`. No new tests were skipped.
+
+Both consumer loads used `--no-session --no-extensions --offline -p -e <installed-package>` with temporary project and agent state. No prompt was passed. No consumer fixture directories remained after successful checks and the rejected v1 candidate check.
+
+The package version remains `2.8.0`. No release was published and no commit or tag was created. Registry advisories can change; these results describe the checks on the stated date.

--- a/docs/specs/issues/mcp-client-v2-migration/ticket.md
+++ b/docs/specs/issues/mcp-client-v2-migration/ticket.md
@@ -1,0 +1,148 @@
+# Ticket TKT-01: Migrate the MCP wrapper to TypeScript SDK v2
+
+Replace the monolithic MCP SDK with its dedicated v2 client package. Verify the dependency tree that users receive during installation and upgrade, not only the repository lockfiles.
+
+## Key definitions and abbreviations
+
+- MCP: Model Context Protocol, used by the extension to discover and call server tools.
+- Candidate package: The npm archive built from the project revision under test.
+- Consumer fixture: An isolated temporary npm project that installs the candidate package as a dependency.
+
+## Problem statement
+
+The project declares `@modelcontextprotocol/sdk@^1.30.0`. The wrapper uses its client implementation, but the SDK also installs server dependencies through `express → body-parser → qs`.
+
+After upgrading to `pi-agent-suite@2.8.0`, an existing Pi installation retained `qs@6.15.3` and reported one moderate vulnerability. The Express and body-parser dependency ranges permit that version. Updating the repository lockfiles to `qs@6.16.0` did not prevent this result because npm does not use a dependency's `package-lock.json` to constrain the consumer installation.
+
+The repository audit passed against its updated lockfile. RPC tests, type checks, lint checks, and package dry runs did not exercise the consumer upgrade path.
+
+## Target picture
+
+The wrapper uses the dedicated MCP v2 client without pulling the v1 server dependency chain into the published package's production dependencies. Users install or upgrade the package without a separate dependency repair command for the reported vulnerabilities. Release checks exercise both consumer scenarios and report audit failures before release preparation succeeds.
+
+## Scenarios
+
+### SCN-01: Discover and call tools
+
+- Actor: A Pi user with configured MCP servers.
+- Pre-condition: An isolated server fixture exposes tools over either supported transport.
+- Trigger: Pi starts discovery or the user invokes a generated tool.
+- Required behavior: The wrapper connects, discovers all tool pages, forwards call arguments and request options, and maps results and failures to its public contract.
+- Example input and expected output: A server exposes `echo`; a call with `{"text":"hello"}` produces the server's text result `hello`. Two discovery pages produce both tools exactly once.
+
+### SCN-02: Install the candidate package
+
+- Actor: A user installing the project for the first time.
+- Pre-condition: A consumer fixture has no previous project installation.
+- Trigger: The candidate archive is installed using the npm dependency policy used by Pi.
+- Required behavior: Installation succeeds, the extension loads, and the installed production dependency audit passes without a repair command.
+- Example input and expected output: Installing the candidate archive and auditing at the consumer root produces audit exit code 0 at the project's low-severity threshold.
+
+### SCN-03: Upgrade an installation with the reported vulnerability
+
+- Actor: A user upgrading an existing project installation.
+- Pre-condition: A consumer fixture reproduces `pi-agent-suite@2.8.0` with the installed and locked transitive dependency `qs@6.15.3`.
+- Trigger: The candidate archive replaces the installed project version through the normal installation command.
+- Required behavior: The upgrade succeeds and the resulting production dependency audit passes without clearing state, deleting the consumer lockfile, or running a repair command.
+- Example input and expected output: Before the upgrade, the fixture audit identifies vulnerable `qs`; after the upgrade, the audit exits with code 0 at the low-severity threshold.
+
+## Scope
+
+In scope:
+- Migrate the wrapper's client dependency and SDK adapter to v2.
+- Adapt affected tests and dependency declarations in both project manifests.
+- Synchronize the three tracked lockfiles and remove overrides made obsolete by this migration.
+- Add repeatable release checks for SCN-02 and SCN-03.
+- Update the extension and publishing documentation to describe the resulting dependency and validation contracts.
+
+Out of scope:
+- Implementing an MCP server or adding transports, authentication flows, or protocol features.
+- Redesigning tool rendering, configuration, caching, or on-demand activation.
+- Requiring users to repair their npm installation manually.
+- Introducing a published shrinkwrap, a direct `qs` dependency, or installation scripts that mutate the consumer's dependencies.
+- Unrelated dependency upgrades, publishing a release, or changing global Pi installations.
+
+## Dependencies and preconditions
+
+- npm registry metadata identifies `@modelcontextprotocol/client@2.0.0` as the stable target. Its mandatory dependency tree does not include the Express chain used by SDK v1.
+- The SDK migration guide documents incompatible API and behavior changes. The implementation must evaluate the wrapper's actual calls against that guide.
+- Consumer installation and audit checks need access to the npm registry and audit service. They are release checks, separate from deterministic Bun behavior tests.
+
+## Requirements
+
+### Goals
+
+- Remove the unnecessary server dependency chain responsible for the reported consumer audit failure.
+- Retain the wrapper's tool discovery and invocation behavior with the dedicated v2 client.
+- Detect consumer installation and upgrade failures before release preparation succeeds.
+
+### Functional requirements
+
+- FRQ-01: When Pi uses the wrapper, the wrapper shall use the dedicated v2 MCP client for both stdio and Streamable HTTP connections.
+  - Goal: Remove the unnecessary server dependency chain.
+  - Goal achievement: Full. The wrapper no longer requires the monolithic v1 SDK.
+- FRQ-02: When discovery or a tool call runs, the wrapper shall preserve configured process arguments, environment additions, working directory, HTTP headers, cancellation, timeouts, pagination results, result mapping, error propagation, and connection cleanup.
+  - Goal: Retain tool discovery and invocation behavior.
+  - Goal achievement: Full. Tests exercise successful calls, multiple discovery pages, cancellation, timeout, server errors, and closure for both transports without testing prompt content.
+- FRQ-03: When release installation checks run, they shall install the candidate archive in separate clean and upgrade consumer fixtures and audit the resulting production dependencies at the consumer root.
+  - Goal: Detect consumer dependency failures.
+  - Goal achievement: Full. SCN-02 and SCN-03 must each finish with successful installation and audit exit code 0.
+- FRQ-04: When a consumer installation or audit check fails, release preparation shall fail before changing the package version and shall identify the failing scenario.
+  - Goal: Prevent a repository-only audit from approving a failing consumer installation.
+  - Goal achievement: Full. A failing fixture check produces a nonzero release-check exit status and leaves the version unchanged.
+
+### Non-functional requirements
+
+- NRQ-01: Behavior tests shall use isolated fixtures and fakes rather than user configuration, credentials, live MCP servers, model providers, or real git state. Package installation checks shall use system temporary directories and leave the user's Pi installation unchanged.
+  - Goal: Make verification safe and repeatable.
+  - Goal achievement: Full. The checks require no user state and clean up their temporary state on success and failure.
+- NRQ-02: The candidate shall pass the repository's full validation, repository audit, consumer installation audits, and isolated Pi package-loading check. Audit thresholds shall not be weakened or warnings suppressed.
+  - Goal: Verify runtime compatibility and the reported security failure.
+  - Goal achievement: Full. Completion evidence includes commands, exit codes, audit summaries, and behavior-test results.
+
+## Overengineering and overspecification considerations
+
+This ticket covers one end-to-end dependency migration, including its consumer installation contract. Reuse the SDK transports, wrapper boundaries, and existing test helpers. Do not add a compatibility layer, custom JSON-RPC client, or general dependency-management framework.
+
+## Constraints and risks
+
+- SDK v2 changes call signatures and some list behavior. Updating import paths alone can leave runtime errors hidden behind injected constructor interfaces and fakes.
+- Other packages in a consumer environment can independently install SDK v1 or vulnerable dependencies. The acceptance fixtures contain this project and the host prerequisites needed to reproduce Pi installation, not unrelated user packages.
+- Security advisories change over time. A new audit finding is a release blocker to investigate, not evidence that audits should be disabled or that this migration guarantees permanent vulnerability-free installations.
+
+## Assumptions
+
+- This project needs an MCP client, not the SDK's server implementation. The wrapper currently imports only `Client`, `StdioClientTransport`, and `StreamableHTTPClientTransport`; verify all SDK references before removing v1.
+
+## Open questions
+
+None at ticket creation. Newly discovered API or host dependency conflicts require a scope decision before introducing a workaround.
+
+## Technical supplement
+
+### Migration boundary
+
+- Update `package.json` and `pi-package/package.json` from `@modelcontextprotocol/sdk@^1.30.0` to `@modelcontextprotocol/client@^2.0.0`.
+- Adapt `pi-package/extensions/mcp-wrapper/sdk-client-factory.ts` and its constructor interfaces to the published v2 types. The v1 adapter currently calls `client.callTool(params, undefined, options)`; verify the v2 options position explicitly.
+- Check SDK v2 list aggregation against the wrapper's cursor pagination so tools are neither omitted nor duplicated.
+- Synchronize `bun.lock`, `pi-package/bun.lock`, and `pi-package/package-lock.json`. Do not assume changing those files constrains downstream consumers.
+- Start with the existing adjacent MCP wrapper tests. For behavior changes, demonstrate a failing behavior assertion before the implementation change and a passing assertion afterward. Do not add tests that only inspect dependency strings or prompt text.
+
+### Release verification
+
+- Build an actual npm archive rather than relying on `npm pack --dry-run`.
+- Derive the installation command and peer dependency handling from the supported Pi package manager. Do not use a different npm policy merely to make the fixture audit pass.
+- Reconstruct the upgrade fixture from a controlled manifest and lockfile, not the developer's global installation. Verify the installed baseline contains `qs@6.15.3` before upgrading.
+- Audit with `npm audit --omit=dev --audit-level=low` at each consumer root. The baseline must reproduce the reported finding; the candidate installations must pass.
+- Run `bun run verify` and `make audit`. Run an isolated real Pi package-loading check with no user state or provider request. Do not pass a prompt in offline mode.
+- Verify the published package's own mandatory dependency tree no longer brings in SDK v1's Express chain. Distinguish it from host peer dependencies in the report.
+
+## References
+
+- [SDK v2 migration guide](https://ts.sdk.modelcontextprotocol.io/v2/migration/upgrade-to-v2.html): API, packaging, and behavior changes.
+- [MCP client package](https://www.npmjs.com/package/@modelcontextprotocol/client): Published client package and versions.
+- [npm package-lock documentation](https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json): Lockfile behavior outside the root project.
+- [qs array-limit advisory](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx): One reported vulnerability affecting the retained dependency.
+- [qs isBuffer advisory](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g): Reported denial-of-service vulnerability fixed in `qs@6.16.0`.
+- `docs/extensions/mcp-wrapper.md`: Wrapper configuration and behavior contract.
+- `docs/PUBLISHING.md` and `Makefile`: Publication workflow and release checks.

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
 	"scripts": {
 		"test": "bun test",
 		"typecheck": "tsc --noEmit",
-		"check": "biome check package.json pi-package/package.json tsconfig.json pi-package test",
-		"verify": "bun test && tsc --noEmit && biome check package.json pi-package/package.json tsconfig.json pi-package test",
-		"verify:ci": "bun test ./pi-package ./test/extensions ./test/shared && tsc --noEmit && biome check package.json pi-package/package.json tsconfig.json pi-package test",
-		"release:check": "sh -c 'trap \"rm -f pi-package/README.md\" EXIT; cp README.md pi-package/README.md; bun run verify && (cd pi-package && npm pack --dry-run)'",
-		"release:prepare:patch": "cd pi-package && npm version patch --no-git-tag-version && cd .. && bun run release:check",
-		"release:prepare:minor": "cd pi-package && npm version minor --no-git-tag-version && cd .. && bun run release:check",
-		"release:prepare:major": "cd pi-package && npm version major --no-git-tag-version && cd .. && bun run release:check"
+		"check": "biome check package.json pi-package/package.json tsconfig.json pi-package test scripts",
+		"verify": "bun test && tsc --noEmit && biome check package.json pi-package/package.json tsconfig.json pi-package test scripts",
+		"verify:ci": "bun test ./pi-package ./test/extensions ./test/shared ./scripts && tsc --noEmit && biome check package.json pi-package/package.json tsconfig.json pi-package test scripts",
+		"release:consumers": "bun scripts/release-consumers.ts",
+		"release:check": "bun scripts/release.ts",
+		"release:prepare:patch": "bun scripts/release.ts patch",
+		"release:prepare:minor": "bun scripts/release.ts minor",
+		"release:prepare:major": "bun scripts/release.ts major"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.0",
@@ -25,7 +26,7 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.30.0",
+		"@modelcontextprotocol/client": "^2.0.0",
 		"entities": "^8.0.0",
 		"js-tiktoken": "^1.0.21",
 		"p-retry": "^7.1.1",

--- a/pi-package/bun.lock
+++ b/pi-package/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "pi-agent-suite",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/client": "^2.0.0",
         "entities": "^8.0.0",
         "js-tiktoken": "^1.0.21",
         "p-retry": "^7.1.1",
@@ -162,6 +162,10 @@
     "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, ""],
 

--- a/pi-package/extensions/mcp-wrapper/sdk-client-factory.test.ts
+++ b/pi-package/extensions/mcp-wrapper/sdk-client-factory.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { McpRequestOptions } from "./client-manager.ts";
 import type { McpServerConfig } from "./config.ts";
 import { createSdkMcpClient } from "./sdk-client-factory.ts";
 
@@ -9,22 +10,42 @@ class FakeSdkClient {
 	readonly clientInfo: unknown;
 	readonly options: unknown;
 	readonly connectedTransports: unknown[] = [];
+	connectOptions: McpRequestOptions | undefined;
+	listRequest:
+		| { params: unknown; options: McpRequestOptions | undefined }
+		| undefined;
 	closeCalls = 0;
+	readonly calls: {
+		params: unknown;
+		options: McpRequestOptions | undefined;
+	}[] = [];
 
 	constructor(clientInfo: unknown, options?: unknown) {
 		this.clientInfo = clientInfo;
 		this.options = options;
 	}
 
-	async connect(transport: unknown): Promise<void> {
+	async connect(
+		transport: unknown,
+		options?: McpRequestOptions,
+	): Promise<void> {
 		this.connectedTransports.push(transport);
+		this.connectOptions = options;
 	}
 
-	async listTools(): Promise<{ readonly tools: [] }> {
+	async listTools(
+		params?: { readonly cursor?: string },
+		options?: McpRequestOptions,
+	): Promise<{ readonly tools: [] }> {
+		this.listRequest = { params, options };
 		return { tools: [] };
 	}
 
-	async callTool(): Promise<unknown> {
+	async callTool(
+		params: unknown,
+		options?: McpRequestOptions,
+	): Promise<unknown> {
+		this.calls.push({ params, options });
 		return { content: [] };
 	}
 
@@ -45,6 +66,9 @@ class FakeStdioTransport {
 		this.params = params;
 	}
 
+	async start(): Promise<void> {}
+	async send(): Promise<void> {}
+
 	async close(): Promise<void> {
 		this.closeCalls += 1;
 	}
@@ -60,12 +84,52 @@ class FakeHttpTransport {
 		this.options = options;
 	}
 
+	async start(): Promise<void> {}
+	async send(): Promise<void> {}
+
 	async close(): Promise<void> {
 		this.closeCalls += 1;
 	}
 }
 
 describe("mcp-wrapper SDK client factory", () => {
+	// Purpose: preserve request parameters at the SDK boundary for both transports.
+	// Inputs: cursor, tool arguments, signal, timeout, and total timeout; expect exact forwarding.
+	// Edge: v2 receives call options in the second argument. Dependencies: constructor fakes only.
+	test.each<McpServerConfig>([
+		{ type: "stdio", command: "fixture", args: [], env: {} },
+		{ type: "streamableHttp", url: "https://example.com/mcp", headers: {} },
+	])("forwards call arguments and request options with $type", async (config) => {
+		const client = createSdkMcpClient("echo", config, {
+			client: FakeSdkClient,
+			stdioClientTransport: FakeStdioTransport,
+			streamableHttpClientTransport: FakeHttpTransport,
+		});
+		const params = { name: "echo", arguments: { text: "hello" } };
+		const options = {
+			signal: new AbortController().signal,
+			timeout: 1234,
+			maxTotalTimeout: 5678,
+		};
+		await client.connect(options);
+		try {
+			const sdkClient = client.sdkClient as FakeSdkClient;
+			expect(sdkClient.connectOptions).toBe(options);
+			expect(await client.listTools({ cursor: "next" }, options)).toEqual({
+				tools: [],
+			});
+			expect(sdkClient.listRequest).toEqual({
+				params: { cursor: "next" },
+				options,
+			});
+			expect(await client.callTool(params, options)).toEqual({ content: [] });
+			expect((client.sdkClient as FakeSdkClient).calls).toEqual([
+				{ params, options },
+			]);
+		} finally {
+			await client.close();
+		}
+	});
 	test("creates stdio transport without command rewriting and with merged literal env", async () => {
 		const previousEnv = process.env["MCP_WRAPPER_TEST_TOKEN"];
 		process.env["MCP_WRAPPER_TEST_TOKEN"] = "inherited";

--- a/pi-package/extensions/mcp-wrapper/sdk-client-factory.ts
+++ b/pi-package/extensions/mcp-wrapper/sdk-client-factory.ts
@@ -1,14 +1,17 @@
 import { env } from "node:process";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+	Client,
+	StreamableHTTPClientTransport,
+	type Transport,
+} from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import type { McpClientLike, McpRequestOptions } from "./client-manager.ts";
 import type { McpServerConfig } from "./config.ts";
 
 const CLIENT_VERSION = "1.0.0";
 
 interface SdkClientInstance {
-	connect(transport: unknown, options?: McpRequestOptions): Promise<void>;
+	connect(transport: Transport, options?: McpRequestOptions): Promise<void>;
 	listTools(
 		params?: { readonly cursor?: string },
 		options?: McpRequestOptions,
@@ -25,7 +28,6 @@ interface SdkClientInstance {
 			readonly name: string;
 			readonly arguments: Record<string, unknown>;
 		},
-		resultSchema?: unknown,
 		options?: McpRequestOptions,
 	): Promise<unknown>;
 	getInstructions(): string | undefined;
@@ -34,7 +36,7 @@ interface SdkClientInstance {
 
 type SdkClientConstructor = new (
 	clientInfo: { readonly name: string; readonly version: string },
-	options?: unknown,
+	options?: ConstructorParameters<typeof Client>[1],
 ) => SdkClientInstance;
 
 type StdioTransportConstructor = new (params: {
@@ -43,7 +45,7 @@ type StdioTransportConstructor = new (params: {
 	readonly env?: Readonly<Record<string, string>>;
 	readonly cwd?: string;
 	readonly stderr?: "ignore";
-}) => { close(): Promise<void> };
+}) => Transport;
 
 type HttpTransportConstructor = new (
 	url: URL,
@@ -52,7 +54,7 @@ type HttpTransportConstructor = new (
 			readonly headers?: Readonly<Record<string, string>>;
 		};
 	},
-) => { close(): Promise<void> };
+) => Transport;
 
 export interface SdkMcpClientConstructors {
 	readonly client?: SdkClientConstructor;
@@ -70,8 +72,7 @@ export function createSdkMcpClient(
 	config: McpServerConfig,
 	constructors: SdkMcpClientConstructors = {},
 ): SdkMcpClient {
-	const ClientCtor =
-		constructors.client ?? (Client as unknown as SdkClientConstructor);
+	const ClientCtor = constructors.client ?? Client;
 	const client = new ClientCtor({
 		name: `pi-mcp-wrapper-${serverKey}`,
 		version: CLIENT_VERSION,
@@ -85,7 +86,7 @@ class SdkMcpClientAdapter implements SdkMcpClient {
 	private readonly client: SdkClientInstance;
 	private readonly config: McpServerConfig;
 	private readonly constructors: SdkMcpClientConstructors;
-	private transport: { close(): Promise<void> } | undefined;
+	private transport: Transport | undefined;
 
 	constructor(
 		client: SdkClientInstance,
@@ -117,7 +118,7 @@ class SdkMcpClientAdapter implements SdkMcpClient {
 		},
 		options?: McpRequestOptions,
 	): Promise<unknown> {
-		return this.client.callTool(params, undefined, options);
+		return this.client.callTool(params, options);
 	}
 
 	getInstructions(): string | undefined {
@@ -129,7 +130,7 @@ class SdkMcpClientAdapter implements SdkMcpClient {
 		await this.transport?.close().catch(() => {});
 	}
 
-	private createTransport(): { close(): Promise<void> } {
+	private createTransport(): Transport {
 		if (this.config.type === "stdio") {
 			const TransportCtor =
 				this.constructors.stdioClientTransport ?? StdioClientTransport;

--- a/pi-package/extensions/mcp-wrapper/sdk-client-protocol.test.ts
+++ b/pi-package/extensions/mcp-wrapper/sdk-client-protocol.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import {
+	Client,
+	StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import {
+	type FixtureRequest,
+	fixtureResponse,
+} from "../../../test/support/mcp-server.ts";
+import { createTempDir } from "../../../test/support/temp-dir.ts";
+import { McpClientManager } from "./client-manager.ts";
+import { mapMcpToolResult } from "./result-mapper.ts";
+import { createSdkMcpClient } from "./sdk-client-factory.ts";
+
+const TIMEOUT_ERROR = /timed out/i;
+
+// Purpose: exercise published SDK signatures and transport behavior, not fake client methods.
+// Inputs: two list pages, echo, tool error, protocol error, and a pending call.
+// Expected: each tool once, mapped text/errors, cancellation/timeout rejection, closed transport.
+// Edges: both transports; HTTP uses fake fetch, stdio uses an isolated local child fixture.
+// Dependencies: real SDK, client manager, result mapper, and fixture helpers; no other tests or network.
+describe.each([
+	"stdio",
+	"streamableHttp",
+] as const)("SDK v2 over %s", (type) => {
+	test("discovers all pages, maps calls, propagates failures, and closes", async () => {
+		const fixture = createFixture(type);
+		const manager = new McpClientManager({
+			createClient: () => fixture.client,
+			timeouts: {
+				startupSeconds: 5,
+				listToolsSeconds: 5,
+				callSeconds: 5,
+				maxTotalSeconds: 5,
+			},
+		});
+		try {
+			const discovery = await manager.discoverServers({
+				fixture: fixture.config,
+			});
+			expect(discovery.failures).toEqual([]);
+			expect(
+				discovery.serverToolLists[0]?.tools.map((tool) => tool.name),
+			).toEqual(["echo", "second"]);
+			const singlePage = await fixture.client.listTools({ cursor: "second" });
+			expect(singlePage.tools.map((tool) => tool.name)).toEqual(["second"]);
+			for (const name of ["echo", "tool-error"]) {
+				const raw = await fixture.client.callTool({
+					name,
+					arguments: { text: "hello" },
+				});
+				const mapped = await mapMcpToolResult(
+					raw as Parameters<typeof mapMcpToolResult>[0],
+				);
+				expect(mapped.content).toEqual([{ type: "text", text: "hello" }]);
+				expect(mapped.details.isError).toBe(name === "tool-error");
+			}
+			await expect(
+				fixture.client.callTool({ name: "protocol-error", arguments: {} }),
+			).rejects.toThrow("Fixture server failure");
+		} finally {
+			await manager.closeAll();
+			fixture.remove();
+		}
+		expect(fixture.closed()).toBe(true);
+	});
+
+	test.each([
+		"cancel",
+		"timeout",
+	] as const)("rejects a pending call on %s", async (mode) => {
+		const fixture = createFixture(type);
+		try {
+			await fixture.client.connect({ timeout: 5000 });
+			const controller = new AbortController();
+			const pending = fixture.client.callTool(
+				{ name: "wait", arguments: {} },
+				{
+					signal: controller.signal,
+					timeout: mode === "timeout" ? 20 : 5000,
+				},
+			);
+			if (mode === "cancel") {
+				controller.abort(new Error("Fixture cancellation"));
+			}
+			await expect(pending).rejects.toThrow(
+				mode === "cancel" ? "Fixture cancellation" : TIMEOUT_ERROR,
+			);
+		} finally {
+			await fixture.client.close();
+			fixture.remove();
+		}
+		expect(fixture.closed()).toBe(true);
+	});
+});
+
+function createFixture(type: "stdio" | "streamableHttp") {
+	const temp = createTempDir("pi-mcp-sdk-");
+	let closed = false;
+	class ObservedClient extends Client {
+		constructor(...args: ConstructorParameters<typeof Client>) {
+			super(...args);
+			this.onclose = () => {
+				closed = true;
+			};
+		}
+	}
+	class FixtureHttpTransport extends StreamableHTTPClientTransport {
+		constructor(
+			url: URL,
+			options?: ConstructorParameters<typeof StreamableHTTPClientTransport>[1],
+		) {
+			super(url, {
+				...options,
+				fetch: async (_input, init) => {
+					if (init?.method !== "POST") {
+						return new Response(null, { status: 405 });
+					}
+					const request = JSON.parse(String(init.body)) as FixtureRequest;
+					const response = fixtureResponse(request);
+					return response === undefined
+						? new Response(null, { status: 202 })
+						: Response.json(response);
+				},
+			});
+		}
+	}
+	const config =
+		type === "stdio"
+			? {
+					type,
+					command: process.execPath,
+					args: [
+						resolve(import.meta.dir, "../../../test/fixtures/mcp-stdio.ts"),
+					],
+					env: {},
+					cwd: temp.path,
+				}
+			: {
+					type,
+					url: "https://fixture.invalid/mcp",
+					headers: { "X-Fixture": "isolated" },
+				};
+	const client = createSdkMcpClient("fixture", config, {
+		client: ObservedClient,
+		stdioClientTransport: StdioClientTransport,
+		streamableHttpClientTransport: FixtureHttpTransport,
+	});
+	return { client, config, closed: () => closed, remove: temp.remove };
+}

--- a/pi-package/extensions/system-prompt/prompts/system.md
+++ b/pi-package/extensions/system-prompt/prompts/system.md
@@ -17,6 +17,13 @@ Current working directory: {{cwd}}
     4. If requirement conflicts with goal, MUST STOP IMMEDIATELY and report
 </goal_guard>
 
+<task_relevance>
+    1. Follow established engineering practices
+    2. MUST NOT turn general recommendations into additional task requirements or restrictions without a concrete need supported by task context
+    3. Generic claims about safety, robustness, or performance are NOT SUFFICIENT JUSTIFICATION
+    4. Without that need, preserve requested behavior and scope
+</task_relevance>
+
 <no_limits>
     1. You have no limits on:
         1) Tokens

--- a/pi-package/package-lock.json
+++ b/pi-package/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "pi-agent-suite",
 			"version": "2.8.0",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.30.0",
+				"@modelcontextprotocol/client": "^2.0.0",
 				"entities": "^8.0.0",
 				"js-tiktoken": "^1.0.21",
 				"p-retry": "^7.1.1",
@@ -23,92 +23,34 @@
 				"typebox": "*"
 			}
 		},
-		"node_modules/@hono/node-server": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			},
-			"peerDependencies": {
-				"hono": "^4"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.30.0",
+		"node_modules/@modelcontextprotocol/client": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+			"integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
 			"license": "MIT",
 			"dependencies": {
-				"@hono/node-server": "^1.19.9 || ^2.0.5",
-				"ajv": "^8.17.1",
-				"ajv-formats": "^3.0.1",
-				"content-type": "^1.0.5",
-				"cors": "^2.8.5",
+				"@modelcontextprotocol/core": "2.0.0",
 				"cross-spawn": "^7.0.5",
 				"eventsource": "^3.0.2",
 				"eventsource-parser": "^3.0.0",
-				"express": "^5.2.1",
-				"express-rate-limit": "^8.2.1",
-				"hono": "^4.11.4",
 				"jose": "^6.1.3",
-				"json-schema-typed": "^8.0.2",
 				"pkce-challenge": "^5.0.0",
-				"raw-body": "^3.0.0",
-				"zod": "^3.25 || ^4.0",
-				"zod-to-json-schema": "^3.25.1"
+				"zod": "^4.2.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"@cfworker/json-schema": "^4.1.1",
-				"zod": "^3.25 || ^4.0"
-			},
-			"peerDependenciesMeta": {
-				"@cfworker/json-schema": {
-					"optional": true
-				},
-				"zod": {
-					"optional": false
-				}
+				"node": ">=20"
 			}
 		},
-		"node_modules/accepts": {
+		"node_modules/@modelcontextprotocol/core": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+			"integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
 			"license": "MIT",
 			"dependencies": {
-				"mime-types": "^3.0.0",
-				"negotiator": "^1.0.0"
+				"zod": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/ajv": {
-			"version": "8.20.0",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
+				"node": ">=20"
 			}
 		},
 		"node_modules/base64-js": {
@@ -129,118 +71,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/body-parser": {
-			"version": "2.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "^3.1.2",
-				"content-type": "^2.0.0",
-				"debug": "^4.4.3",
-				"http-errors": "^2.0.1",
-				"iconv-lite": "^0.7.2",
-				"on-finished": "^2.4.1",
-				"qs": "^6.15.2",
-				"raw-body": "^3.0.2",
-				"type-is": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/body-parser/node_modules/content-type": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/bytes": {
-			"version": "3.1.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/call-bound": {
-			"version": "1.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"get-intrinsic": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/content-disposition": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/content-type": {
-			"version": "1.0.5",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie": {
-			"version": "0.7.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/cookie-signature": {
-			"version": "1.2.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.6.0"
-			}
-		},
-		"node_modules/cors": {
-			"version": "2.8.6",
-			"license": "MIT",
-			"dependencies": {
-				"object-assign": "^4",
-				"vary": "^1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"license": "MIT",
@@ -253,51 +83,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/debug": {
-			"version": "4.4.3",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"license": "MIT"
-		},
-		"node_modules/encodeurl": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/entities": {
 			"version": "8.0.0",
 			"license": "BSD-2-Clause",
@@ -306,41 +91,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.2",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"license": "MIT"
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/eventsource": {
@@ -360,242 +110,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/express": {
-			"version": "5.2.1",
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "^2.0.0",
-				"body-parser": "^2.2.1",
-				"content-disposition": "^1.0.0",
-				"content-type": "^1.0.5",
-				"cookie": "^0.7.1",
-				"cookie-signature": "^1.2.1",
-				"debug": "^4.4.0",
-				"depd": "^2.0.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"finalhandler": "^2.1.0",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.0",
-				"merge-descriptors": "^2.0.0",
-				"mime-types": "^3.0.0",
-				"on-finished": "^2.4.1",
-				"once": "^1.4.0",
-				"parseurl": "^1.3.3",
-				"proxy-addr": "^2.0.7",
-				"qs": "^6.14.0",
-				"range-parser": "^1.2.1",
-				"router": "^2.2.0",
-				"send": "^1.1.0",
-				"serve-static": "^2.2.0",
-				"statuses": "^2.0.1",
-				"type-is": "^2.0.1",
-				"vary": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express-rate-limit": {
-			"version": "8.6.2",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.3",
-				"ip-address": "^10.2.0"
-			},
-			"engines": {
-				"node": ">= 16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/express-rate-limit"
-			},
-			"peerDependencies": {
-				"express": ">= 4.11"
-			}
-		},
-		"node_modules/fast-deep-equal": {
-			"version": "3.1.3",
-			"license": "MIT"
-		},
-		"node_modules/fast-uri": {
-			"version": "3.1.6",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/finalhandler": {
-			"version": "2.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"on-finished": "^2.4.1",
-				"parseurl": "^1.3.3",
-				"statuses": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.4",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/hono": {
-			"version": "4.13.5",
-			"license": "MIT",
-			"engines": {
-				"node": ">=16.9.0"
-			}
-		},
-		"node_modules/http-errors": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "~2.0.0",
-				"inherits": "~2.0.4",
-				"setprototypeof": "~1.2.0",
-				"statuses": "~2.0.2",
-				"toidentifier": "~1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/iconv-lite": {
-			"version": "0.7.3",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"license": "ISC"
-		},
-		"node_modules/ip-address": {
-			"version": "10.5.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
-		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
 		"node_modules/is-network-error": {
 			"version": "1.3.2",
 			"license": "MIT",
@@ -605,10 +119,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/is-promise": {
-			"version": "4.0.0",
-			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -628,126 +138,6 @@
 				"base64-js": "^1.5.1"
 			}
 		},
-		"node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"license": "MIT"
-		},
-		"node_modules/json-schema-typed": {
-			"version": "8.0.2",
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/media-typer": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.54.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "3.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/ms": {
-			"version": "2.1.3",
-			"license": "MIT"
-		},
-		"node_modules/negotiator": {
-			"version": "1.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/negotiator/node_modules/content-type": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/object-assign": {
-			"version": "4.1.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object-inspect": {
-			"version": "1.13.4",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/p-retry": {
 			"version": "7.1.1",
 			"license": "MIT",
@@ -761,26 +151,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/path-to-regexp": {
-			"version": "8.4.2",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/pkce-challenge": {
@@ -789,127 +164,6 @@
 			"engines": {
 				"node": ">=16.20.0"
 			}
-		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"license": "MIT",
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/qs": {
-			"version": "6.16.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
-			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"es-define-property": "^1.0.1",
-				"side-channel": "^1.1.1"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/range-parser": {
-			"version": "1.3.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "3.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "~3.1.2",
-				"http-errors": "~2.0.1",
-				"iconv-lite": "~0.7.0",
-				"unpipe": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/require-from-string": {
-			"version": "2.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/router": {
-			"version": "2.2.0",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.0",
-				"depd": "^2.0.0",
-				"is-promise": "^4.0.0",
-				"parseurl": "^1.3.3",
-				"path-to-regexp": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			}
-		},
-		"node_modules/safer-buffer": {
-			"version": "2.1.2",
-			"license": "MIT"
-		},
-		"node_modules/send": {
-			"version": "1.2.1",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.4.3",
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"etag": "^1.8.1",
-				"fresh": "^2.0.0",
-				"http-errors": "^2.0.1",
-				"mime-types": "^3.0.2",
-				"ms": "^2.1.3",
-				"on-finished": "^2.4.1",
-				"range-parser": "^1.2.1",
-				"statuses": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/serve-static": {
-			"version": "2.2.1",
-			"license": "MIT",
-			"dependencies": {
-				"encodeurl": "^2.0.0",
-				"escape-html": "^1.0.3",
-				"parseurl": "^1.3.3",
-				"send": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -926,77 +180,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/side-channel": {
-			"version": "1.1.1",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.4",
-				"side-channel-list": "^1.0.1",
-				"side-channel-map": "^1.0.1",
-				"side-channel-weakmap": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-list": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-map": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/side-channel-weakmap": {
-			"version": "1.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.5",
-				"object-inspect": "^1.13.3",
-				"side-channel-map": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/statuses": {
-			"version": "2.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/stream-chain": {
@@ -1023,54 +206,6 @@
 				"url": "https://github.com/sponsors/uhop"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/type-is": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^2.0.0",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/type-is/node_modules/content-type": {
-			"version": "2.1.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/vary": {
-			"version": "1.1.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"license": "ISC",
@@ -1083,10 +218,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"license": "ISC"
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",
@@ -1106,13 +237,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.25.2",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/pi-package/package.json
+++ b/pi-package/package.json
@@ -59,7 +59,7 @@
 		"typebox": "*"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.30.0",
+		"@modelcontextprotocol/client": "^2.0.0",
 		"entities": "^8.0.0",
 		"js-tiktoken": "^1.0.21",
 		"p-retry": "^7.1.1",

--- a/scripts/release-consumers.ts
+++ b/scripts/release-consumers.ts
@@ -1,0 +1,219 @@
+import { spawnSync } from "node:child_process";
+import {
+	cpSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { env as processEnv } from "node:process";
+import { createTempDir } from "../test/support/temp-dir.ts";
+
+type Scenario = "SCN-02" | "SCN-03";
+const root = resolve(import.meta.dir, "..");
+const auditArgs = ["audit", "--omit=dev", "--audit-level=low", "--json"];
+const PI_EXTENSION_ERROR =
+	/Failed to load extension|Extension error|Error loading extension/i;
+const MAX_COMMAND_OUTPUT = 10_485_760;
+
+function report(message: string): void {
+	process.stdout.write(`${message}\n`);
+}
+
+function command(
+	executable: string,
+	args: readonly string[],
+	cwd: string,
+	options: { allowFailure?: boolean; env?: NodeJS.ProcessEnv } = {},
+): { status: number; stdout: string; stderr: string } {
+	const result = spawnSync(executable, args, {
+		cwd,
+		env: options.env,
+		encoding: "utf8",
+		timeout: 180_000,
+		maxBuffer: MAX_COMMAND_OUTPUT,
+	});
+	if (
+		result.error ||
+		result.status === null ||
+		(!options.allowFailure && result.status !== 0)
+	) {
+		throw new Error(
+			`${executable} ${args.join(" ")} failed\n${result.stdout}\n${result.stderr}`,
+			{
+				cause: result.error,
+			},
+		);
+	}
+	return {
+		status: result.status,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}
+
+function readJson(path: string) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function buildCandidate(scratch: string): string {
+	const staging = join(scratch, "package");
+	mkdirSync(staging);
+	const packageDir = join(root, "pi-package");
+	const manifest = readJson(join(packageDir, "package.json"));
+	for (const entry of manifest.files as string[]) {
+		cpSync(
+			join(entry === "README.md" ? root : packageDir, entry),
+			join(staging, entry),
+			{ recursive: true },
+		);
+	}
+	command("npm", ["pack", "--pack-destination", scratch], staging);
+	const archive = readdirSync(scratch).find((name) => name.endsWith(".tgz"));
+	if (!archive) {
+		throw new Error("npm pack produced no archive");
+	}
+	return join(scratch, archive);
+}
+
+function prepareBaseline(consumer: string): void {
+	for (const file of ["package.json", "package-lock.json"]) {
+		cpSync(
+			join(root, "test/fixtures/mcp-upgrade-consumer", file),
+			join(consumer, file),
+		);
+	}
+	command("npm", ["ci", "--legacy-peer-deps"], consumer);
+	const installed = readJson(join(consumer, "node_modules/qs/package.json"));
+	const lock = readJson(join(consumer, "package-lock.json"));
+	if (
+		installed.version !== "6.15.3" ||
+		lock.packages["node_modules/qs"].version !== "6.15.3"
+	) {
+		throw new Error("Upgrade baseline must install and lock qs@6.15.3");
+	}
+	const result = command("npm", auditArgs, consumer, { allowFailure: true });
+	const audit = JSON.parse(result.stdout);
+	if (
+		result.status !== 1 ||
+		!audit.vulnerabilities?.qs?.via?.some(
+			(via: { url?: string } | string) =>
+				typeof via !== "string" &&
+				(via.url?.endsWith("GHSA-x5fp-wj9c-mxmx") ||
+					via.url?.endsWith("GHSA-4mjr-xmp4-gh2g")),
+		)
+	) {
+		throw new Error(
+			`Baseline did not reproduce the reported qs advisory\n${result.stdout}`,
+		);
+	}
+	report(
+		`SCN-03 baseline: qs@6.15.3 installed and locked; audit exit ${result.status}`,
+	);
+	report(JSON.stringify(audit.metadata.vulnerabilities));
+}
+
+function loadPackage(consumer: string, scratch: string): void {
+	const agentDir = join(scratch, "agent");
+	const project = join(scratch, "project");
+	mkdirSync(agentDir);
+	mkdirSync(project);
+	writeFileSync(join(agentDir, "settings.json"), "{}");
+	const env = { ...processEnv };
+	for (const name of Object.keys(env)) {
+		if (name.startsWith("PI_")) {
+			delete env[name];
+		}
+	}
+	env["PI_CODING_AGENT_DIR"] = agentDir;
+	env["PI_AGENT_SUITE_DIR"] = join(agentDir, "agent-suite");
+	const result = command(
+		"node",
+		[
+			join(root, "node_modules/@earendil-works/pi-coding-agent/dist/cli.js"),
+			"--no-session",
+			"--no-extensions",
+			"--offline",
+			"-p",
+			"-e",
+			join(consumer, "node_modules/pi-agent-suite"),
+		],
+		project,
+		{ env },
+	);
+	if (PI_EXTENSION_ERROR.test(`${result.stdout}\n${result.stderr}`)) {
+		throw new Error(
+			`Pi package loading failed\n${result.stdout}\n${result.stderr}`,
+		);
+	}
+}
+
+export function checkConsumer(scenario: Scenario, candidate?: string): void {
+	const scratch = createTempDir("pi-release-consumer-");
+	try {
+		const archive = candidate ?? buildCandidate(scratch.path);
+		const consumer = join(scratch.path, "consumer");
+		mkdirSync(consumer);
+		if (scenario === "SCN-03") {
+			prepareBaseline(consumer);
+		} else {
+			writeFileSync(
+				join(consumer, "package.json"),
+				JSON.stringify({
+					name: "mcp-clean-consumer",
+					version: "1.0.0",
+					private: true,
+				}),
+			);
+		}
+		// Same npm peer policy as Pi's getNpmInstallArgs. No repair between these steps.
+		command(
+			"npm",
+			["install", archive, "--prefix", consumer, "--legacy-peer-deps"],
+			consumer,
+		);
+		const audit = command("npm", auditArgs, consumer);
+		report(
+			`${scenario}: installation passed; production audit exit ${audit.status}`,
+		);
+		report(JSON.stringify(JSON.parse(audit.stdout).metadata.vulnerabilities));
+		const lock = readJson(join(consumer, "package-lock.json"));
+		for (const name of [
+			"@modelcontextprotocol/sdk",
+			"express",
+			"body-parser",
+			"qs",
+		]) {
+			if (
+				Object.keys(lock.packages).some((path) =>
+					path.endsWith(`node_modules/${name}`),
+				)
+			) {
+				throw new Error(
+					`Candidate mandatory dependency tree still contains ${name}`,
+				);
+			}
+		}
+		loadPackage(consumer, scratch.path);
+		report(
+			`${scenario}: Pi offline package loading passed; v1 server dependency chain absent`,
+		);
+	} catch (error) {
+		throw new Error(`${scenario} consumer check failed`, { cause: error });
+	} finally {
+		scratch.remove();
+	}
+}
+
+if (import.meta.main) {
+	const scenario = process.argv[2];
+	if (scenario === undefined) {
+		checkConsumer("SCN-02");
+		checkConsumer("SCN-03");
+	} else if (scenario === "SCN-02" || scenario === "SCN-03") {
+		checkConsumer(scenario);
+	} else {
+		throw new Error(`Unknown consumer scenario: ${scenario}`);
+	}
+}

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { checkRelease } from "./release.ts";
+
+// Purpose: release failures must stop preparation before npm changes the version.
+// Inputs: a fake command runner fails validation, audit, or either consumer scenario.
+// Expected: the error propagates and no version command runs; success bumps last.
+// Edges: all release kinds use the same checks. No real npm, git, or registry.
+// Dependencies: checkRelease only; no dependency on other tests.
+describe("release preparation", () => {
+	for (const failure of ["verify", "audit", "SCN-02", "SCN-03"]) {
+		test(`stops before changing the version on ${failure} failure`, () => {
+			const commands: string[][] = [];
+			expect(() =>
+				checkRelease(
+					"/fixture",
+					(command) => {
+						commands.push([...command]);
+						if (command.includes(failure)) {
+							throw new Error(`${failure} failed`);
+						}
+					},
+					"patch",
+				),
+			).toThrow(`${failure} failed`);
+			expect(commands.some((command) => command.includes("version"))).toBe(
+				false,
+			);
+		});
+	}
+
+	test.each([
+		"patch",
+		"minor",
+		"major",
+	] as const)("bumps %s only after checks pass", (kind) => {
+		const calls: { command: readonly string[]; cwd: string }[] = [];
+		checkRelease(
+			"/fixture",
+			(command, cwd) => calls.push({ command, cwd }),
+			kind,
+		);
+		expect(calls).toEqual([
+			{ command: ["bun", "run", "verify"], cwd: "/fixture" },
+			{ command: ["make", "audit"], cwd: "/fixture" },
+			{
+				command: ["bun", "scripts/release-consumers.ts", "SCN-02"],
+				cwd: "/fixture",
+			},
+			{
+				command: ["bun", "scripts/release-consumers.ts", "SCN-03"],
+				cwd: "/fixture",
+			},
+			{
+				command: ["npm", "version", kind, "--no-git-tag-version"],
+				cwd: "/fixture/pi-package",
+			},
+		]);
+	});
+});

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+
+export type ReleaseKind = "patch" | "minor" | "major";
+export type ReleaseCommand = (command: readonly string[], cwd: string) => void;
+
+export function checkRelease(
+	root: string,
+	run: ReleaseCommand,
+	kind?: ReleaseKind,
+): void {
+	run(["bun", "run", "verify"], root);
+	run(["make", "audit"], root);
+	for (const scenario of ["SCN-02", "SCN-03"]) {
+		run(["bun", "scripts/release-consumers.ts", scenario], root);
+	}
+	if (kind !== undefined) {
+		run(
+			["npm", "version", kind, "--no-git-tag-version"],
+			join(root, "pi-package"),
+		);
+	}
+}
+
+if (import.meta.main) {
+	const kind = process.argv[2];
+	if (
+		kind !== undefined &&
+		kind !== "patch" &&
+		kind !== "minor" &&
+		kind !== "major"
+	) {
+		throw new Error("Expected patch, minor, major, or no release kind");
+	}
+	checkRelease(
+		resolve(import.meta.dir, ".."),
+		(command, cwd) => {
+			const [executable, ...args] = command;
+			if (!executable) {
+				throw new Error("Empty release command");
+			}
+			const result = spawnSync(executable, args, {
+				cwd,
+				stdio: "inherit",
+				timeout: 900_000,
+			});
+			if (result.error || result.status !== 0) {
+				throw new Error(`Release check failed: ${command.join(" ")}`, {
+					cause: result.error,
+				});
+			}
+		},
+		kind,
+	);
+}

--- a/test/fixtures/mcp-stdio.ts
+++ b/test/fixtures/mcp-stdio.ts
@@ -1,0 +1,10 @@
+import { createInterface } from "node:readline";
+import { fixtureResponse } from "../support/mcp-server.ts";
+
+const lines = createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+	const response = fixtureResponse(JSON.parse(line));
+	if (response !== undefined) {
+		process.stdout.write(`${JSON.stringify(response)}\n`);
+	}
+});

--- a/test/fixtures/mcp-upgrade-consumer/package-lock.json
+++ b/test/fixtures/mcp-upgrade-consumer/package-lock.json
@@ -1,0 +1,1325 @@
+{
+  "name": "mcp-upgrade-consumer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-upgrade-consumer",
+      "version": "1.0.0",
+      "dependencies": {
+        "pi-agent-suite": "2.8.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pi-agent-suite": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/pi-agent-suite/-/pi-agent-suite-2.8.0.tgz",
+      "integrity": "sha512-3J+k+iC5JlWZiVD+QjYmmjYupeN7n3rUEN+EYEgTKgSqfk2gPGMXb5e5HMNF1MJh47aCpH1NesEiP5BmsE+m9w==",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "entities": "^8.0.0",
+        "js-tiktoken": "^1.0.21",
+        "p-retry": "^7.1.1",
+        "stream-json": "^3.6.0",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-agent-core": "*",
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "typebox": "*"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-4.2.5.tgz",
+      "integrity": "sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/stream-json": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-3.6.0.tgz",
+      "integrity": "sha512-NiJdqxKyau579z/E8vfqcjWfSDWxW/AT99javFXdPXF147Z5za85LRXSHEmSX9TKOakB7gaIccfD0fOIctb7KQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^4.2.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/test/fixtures/mcp-upgrade-consumer/package.json
+++ b/test/fixtures/mcp-upgrade-consumer/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "mcp-upgrade-consumer",
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"pi-agent-suite": "2.8.0"
+	}
+}

--- a/test/support/mcp-server.ts
+++ b/test/support/mcp-server.ts
@@ -1,0 +1,55 @@
+export interface FixtureRequest {
+	jsonrpc: "2.0";
+	id?: number | string;
+	method: string;
+	params?: {
+		cursor?: string;
+		name?: string;
+		arguments?: Record<string, unknown>;
+	};
+}
+
+export function fixtureResponse(request: FixtureRequest): unknown {
+	if (request.id === undefined || request.params?.name === "wait") {
+		return undefined;
+	}
+	const reply = { jsonrpc: "2.0", id: request.id };
+	if (request.method === "initialize") {
+		return {
+			...reply,
+			result: {
+				protocolVersion: "2025-11-25",
+				capabilities: { tools: {} },
+				serverInfo: { name: "isolated-fixture", version: "1.0.0" },
+			},
+		};
+	}
+	if (request.method === "tools/list") {
+		const name = request.params?.cursor === "second" ? "second" : "echo";
+		return {
+			...reply,
+			result: {
+				tools: [{ name, inputSchema: { type: "object" } }],
+				...(name === "echo" ? { nextCursor: "second" } : {}),
+			},
+		};
+	}
+	if (request.params?.name === "protocol-error") {
+		return {
+			...reply,
+			error: { code: -32603, message: "Fixture server failure" },
+		};
+	}
+	return {
+		...reply,
+		result: {
+			content: [
+				{
+					type: "text",
+					text: String(request.params?.arguments?.["text"] ?? "hello"),
+				},
+			],
+			...(request.params?.name === "tool-error" ? { isError: true } : {}),
+		},
+	};
+}

--- a/test/support/temp-dir.ts
+++ b/test/support/temp-dir.ts
@@ -1,0 +1,11 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export function createTempDir(prefix: string): {
+	path: string;
+	remove: () => void;
+} {
+	const path = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+	return { path, remove: () => rmSync(path, { recursive: true, force: true }) };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
 		"types": ["bun-types"],
 		"verbatimModuleSyntax": true
 	},
-	"include": ["pi-package/**/*.ts", "test/**/*.ts"]
+	"include": ["pi-package/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Problem
The MCP v1 SDK adds unnecessary server dependencies and can leave users with vulnerable consumer installations. Repository audits alone do not catch upgrade dependency issues.

## Solution
Migrate the wrapper to `@modelcontextprotocol/client` v2 and add isolated consumer installation and upgrade checks to release preparation. Preserve stdio and Streamable HTTP behavior, pagination, request options, and cleanup. See TKT-01: Migrate the MCP wrapper to TypeScript SDK v2.

## Testing
- `bun run verify` passed: 1439 passed, 1 pre-existing skip
- `make audit` passed with 0 vulnerabilities
- `make release-check` passed, including SCN-02 and SCN-03 consumer checks
- MCP protocol and release tests passed
- No release was published; package version remains `2.8.0`