### PR TITLE
Support multiple remote image SSH targets and removal

### DIFF
--- a/docs/extensions/remote-image.md
+++ b/docs/extensions/remote-image.md
@@ -45,7 +45,7 @@ For SSH password authentication:
 .\setup-remote-image.ps1 -SshTarget user@server.example -SshPassword 'your-password'
 ```
 
-The setup installs the helper for the current user, saves the connection settings, starts the helper, and configures startup after graphical login. Linux uses `pi-agent-suite-remote-image.service` in the systemd user manager. Reinstallation stops the old helper and waits for shutdown before replacing files. A stop or startup-command error aborts installation. The saved password is stored as plain text in the current user's configuration file. Without a saved password, OpenSSH uses its configured key, agent, and host settings.
+The setup installs the helper for the current user, adds or updates the specified SSH target, starts the helper, and configures startup after graphical login. Run setup once for each remote server. Existing server settings remain in the configuration, and the helper maintains an SSH reverse tunnel to every configured server. Linux uses `pi-agent-suite-remote-image.service` in the systemd user manager. Setup stops the old helper and waits for shutdown before replacing files and restarting all configured tunnels. A stop or startup-command error aborts installation. Each saved password is stored as plain text in the current user's configuration file. Without a saved password, OpenSSH uses its configured key, agent, and host settings.
 
 The first connection can require normal OpenSSH host-key confirmation. Run `ssh user@server.example` once before setup when the host key has not been accepted.
 
@@ -64,7 +64,25 @@ export PI_AGENT_SUITE_IMAGE_PORT=18775
 PI_AGENT_SUITE_IMAGE_PORT=19000 ./setup-remote-image.sh user@server.example
 ```
 
-Restart pi after changing the environment. The extension registers `Ctrl+V` only when `PI_AGENT_SUITE_MODE` is `remote`. Pi can report its normal shortcut-conflict warning because this extension replaces native clipboard image paste in remote mode.
+Configure these variables on every remote server. Different servers can use different `PI_AGENT_SUITE_IMAGE_PORT` values. Restart pi after changing the environment. The extension registers `Ctrl+V` only when `PI_AGENT_SUITE_MODE` is `remote`. Pi can report its normal shortcut-conflict warning because this extension replaces native clipboard image paste in remote mode.
+
+## Remove a remote server
+
+Run the downloaded setup script. The SSH target must exactly match the target used when adding the server.
+
+### macOS or Linux
+
+```bash
+./setup-remote-image.sh remove user@server.example
+```
+
+### Windows PowerShell
+
+```powershell
+.\setup-remote-image.ps1 -Action Remove -SshTarget user@server.example
+```
+
+When other servers remain, removal restarts the helper with their tunnels. Removing the last server stops the helper and deletes its autostart registration, configuration, runtime diagnostics file, and installed executable.
 
 ## Operation
 
@@ -79,13 +97,13 @@ An empty image clipboard produces a warning and inserts no text. A tunnel, HTTP,
 
 | Variable | Location | Default | Meaning |
 | --- | --- | --- | --- |
-| `PI_AGENT_SUITE_SSH_TARGET` | Local setup | None | OpenSSH destination or SSH config alias. Required. |
+| `PI_AGENT_SUITE_SSH_TARGET` | Local setup | None | OpenSSH destination or SSH config alias. Required when adding a server and used as its configuration identity. |
 | `PI_AGENT_SUITE_SSH_PASSWORD` | Local setup | None | Optional SSH account password. |
 | `PI_AGENT_SUITE_IMAGE_PORT` | Local setup and remote pi | `18775` | Loopback image transfer port. |
 | `PI_AGENT_SUITE_MODE` | Remote pi | None | `remote` enables the extension. |
 | `PI_AGENT_SUITE_VERSION` | macOS or Linux setup | `latest` | Helper release version. Accepts `2.9.1` or `v2.9.1`. |
 
-The helper binds `127.0.0.1` only. OpenSSH forwards the same loopback port to the remote server. The feature does not open an externally reachable listener and adds no protocol above SSH.
+The helper binds one local listener to `127.0.0.1` using the first configured server's image port. Each SSH tunnel forwards its remote server's configured image port to that local listener. The feature does not open an externally reachable listener and adds no protocol above SSH.
 
 ## Runtime diagnostics
 

--- a/docs/specs/features/remote-image/remote-image_prd.md
+++ b/docs/specs/features/remote-image/remote-image_prd.md
@@ -14,7 +14,7 @@ Make local images available to remote pi without manual file copying or path cor
 
 ## Scenarios
 
-The user connects to the remote server through SSH, starts pi there, and pastes an image from the local computer.
+The user connects to one or more remote servers through SSH, starts pi on those servers, and pastes an image from the local computer.
 
 ## Scope and non-scope
 
@@ -38,6 +38,12 @@ Prefer the fewest installed components and the least initial configuration. A lo
 - FRQ-04: Support an optional SSH password. Without a configured password, use the user's configured SSH authentication.
   - Goal: Allow automatic connections without requiring SSH keys.
   - Goal achievement: Full for authentication choice. Password authentication and key-based authentication use SSH, not a separate authentication system.
+- FRQ-05: The local helper maintains simultaneous tunnels to every configured SSH target. Adding or updating one SSH target preserves all other target settings.
+  - Goal: Use image paste on multiple remote servers from one local computer.
+  - Goal achievement: Full for concurrent server use. Each remote pi can request the local clipboard image through its tunnel.
+- FRQ-06: Setup provides a command that removes one exact SSH target. When other targets remain, the helper restarts their tunnels. Removing the last target deletes the helper configuration, runtime diagnostics file, installed executable, and autostart registration.
+  - Goal: Remove obsolete servers without damaging active server configurations.
+  - Goal achievement: Full for configuration removal and final uninstall.
 
 ### Non-functional requirements
 
@@ -63,7 +69,7 @@ None that block approval of the requirements. The implementation of clipboard ac
 
 ## Technical supplement
 
-The approved password setting for FRQ-04 is the optional `PI_AGENT_SUITE_SSH_PASSWORD` environment variable. The SSH destination is configured separately through `PI_AGENT_SUITE_SSH_TARGET`, for example `user@server.example`. The password is not embedded in the destination.
+The approved password setting for FRQ-04 is the optional `PI_AGENT_SUITE_SSH_PASSWORD` environment variable. Each SSH destination is configured separately through `PI_AGENT_SUITE_SSH_TARGET`, for example `user@server.example`. The exact SSH target string identifies its saved configuration. The password is not embedded in the destination.
 
 ## References
 

--- a/docs/specs/features/remote-image/remote-image_solution.md
+++ b/docs/specs/features/remote-image/remote-image_solution.md
@@ -11,22 +11,23 @@ See the [problem statement](remote-image_problem.md), [domain glossary](domain-g
 - Add a standalone Go local helper in this repository. Use `golang.design/x/clipboard` v0.9.0 for image acquisition and the system OpenSSH client for the tunnel. Go is a build dependency, not a workstation prerequisite.
 - Configure automatic helper startup in the user's graphical session. A machine-level service cannot be assumed to have access to that user's clipboard.
 - Add a TypeScript remote image extension to the pi package. The remote server runs pi; the local computer does not.
-- Distribute prebuilt helper binaries and setup scripts for macOS, Linux, and Windows. The user runs the setup script once with connection settings. Ordinary SSH terminal connections remain independent of the helper.
+- Distribute prebuilt helper binaries and setup scripts for macOS, Linux, and Windows. The user runs the setup script for each SSH target. Ordinary SSH terminal connections remain independent of the helper.
 
 ### Persistent setup and startup
 
-- The setup script saves connection settings, including the optional SSH password, in a local configuration file. There is no separate encrypted credential store.
+- The setup script stores a list of SSH target settings, including each optional SSH password, in one local configuration file. Adding an SSH target appends it to the list. Adding an exact existing target replaces that target's settings and preserves other targets. The old single-target configuration format is migrated when setup next writes the file. There is no separate encrypted credential store.
 - Use a user LaunchAgent on macOS, a systemd user service bound to `graphical-session.target` on Linux, and an interactive-user logon task on Windows. The helper runs in the graphical session that owns the clipboard, not Windows Session 0.
 - Reinstallation stops the old helper before replacing its executable or configuration. On macOS, wait for LaunchAgent removal after `bootout`. On Linux, synchronous `systemctl --user stop` stops the service control group, including SSH. On Windows, disable the old task, terminate the helper process tree, and wait for the task and tracked processes to exit. A stop failure aborts replacement.
 - Runtime and SSH diagnostics go to the systemd user journal on Linux and a file next to the configuration on macOS and Windows. Setup prints the diagnostic location. Successful service registration does not confirm SSH connectivity.
 - Initial SSH host-key confirmation remains part of normal setup. The helper uses OpenSSH authentication and host-key handling rather than adding a separate trust or authentication mechanism.
-- The remote image extension is enabled through `PI_AGENT_SUITE_MODE=remote`. The local helper and remote image extension use the same image transfer port.
+- The setup removal command matches the exact SSH target string. When targets remain, setup restarts the helper with those targets. Removing the final target stops the helper and deletes its configuration, runtime diagnostics file, executable, and platform autostart registration.
+- The remote image extension is enabled through `PI_AGENT_SUITE_MODE=remote`. Each SSH target setting and its remote image extension use the same image transfer port.
 
 ### Configuration
 
 | Setting | Location | Meaning |
 | --- | --- | --- |
-| `PI_AGENT_SUITE_SSH_TARGET` | Local setup | Required SSH target. |
+| `PI_AGENT_SUITE_SSH_TARGET` | Local setup | Required SSH target and identity for one saved target setting. |
 | `PI_AGENT_SUITE_SSH_PASSWORD` | Local setup | Optional SSH password. Without it, use the user's configured SSH authentication. |
 | `PI_AGENT_SUITE_IMAGE_PORT` | Local setup and remote pi | Image transfer port. Default `18775`. |
 | `PI_AGENT_SUITE_MODE` | Remote pi | Set to `remote` to enable the remote image extension. |
@@ -35,10 +36,10 @@ The SSH server port comes from OpenSSH configuration and defaults. The helper ha
 
 ### SSH and password handling
 
-- The local helper starts the system OpenSSH client with a loopback-to-loopback reverse TCP forward. The helper maintains this connection independently of interactive terminal connections and reconnects after network loss.
-- The local HTTP listener binds to `127.0.0.1` at the image transfer port. The reverse forward requests the same loopback address and port on the remote server.
+- The local helper starts one system OpenSSH client per configured SSH target with a loopback-to-loopback reverse TCP forward. The helper maintains these connections independently of interactive terminal connections and reconnects each tunnel after network loss.
+- The local helper binds one HTTP listener to `127.0.0.1` using the first configured target's image transfer port. Each reverse forward binds its target's configured loopback port on the remote server and forwards requests to the one local listener.
 - The server must permit loopback-only reverse forwarding. The setup scripts do not change `sshd` configuration automatically. This topology adds no ports for external connections.
-- With a configured password, OpenSSH uses `SSH_ASKPASS` to invoke the same helper executable in a password-response mode. This mode returns the configured password rather than starting another listener or tunnel. No separate askpass application is installed. Select SSH password-capable authentication methods in this mode so the saved account password does not answer a private-key passphrase prompt.
+- With a configured password, OpenSSH uses `SSH_ASKPASS` to invoke the same helper executable in a password-response mode. The SSH tunnel identifies its exact target, and this mode returns only that target's configured password rather than starting another listener or tunnel. No separate askpass application is installed. Select SSH password-capable authentication methods in this mode so the saved account password does not answer a private-key passphrase prompt.
 - Without a configured password, OpenSSH uses the user's configured authentication. The helper does not implement a second SSH client or a custom authentication protocol.
 
 ### Image request and editor behavior
@@ -69,7 +70,7 @@ Ctrl+V in remote pi
 
 ## Overengineering and overspecification considerations
 
-The runtime consists of one local helper, system OpenSSH, and one pi extension. Setup scripts provide persistent configuration without requiring a replacement SSH command or local pi process. Clipboard and SSH implementations come from existing libraries and tools, not new protocol implementations.
+The runtime consists of one local helper, one system OpenSSH process per SSH target, and one pi extension on each remote server. Setup scripts provide persistent configuration without requiring a replacement SSH command or local pi process. Clipboard and SSH implementations come from existing libraries and tools, not new protocol implementations.
 
 There is no added security layer, token service, encrypted credential store, continuous clipboard synchronization, or custom terminal UI. The image transfer uses one request through SSH. Reverse image transfer is outside scope.
 

--- a/remote-image-helper/config.go
+++ b/remote-image-helper/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -23,59 +22,107 @@ type config struct {
 }
 
 type storedConfig struct {
-	SSHTarget   string `json:"sshTarget"`
-	SSHPassword string `json:"sshPassword,omitempty"`
-	ImagePort   *int   `json:"imagePort"`
+	Targets     []config `json:"targets,omitempty"`
+	SSHTarget   string   `json:"sshTarget,omitempty"`
+	SSHPassword string   `json:"sshPassword,omitempty"`
+	ImagePort   *int     `json:"imagePort,omitempty"`
 }
 
-func loadConfig(path string, getenv func(string) string) (config, error) {
+func loadConfigs(path string, getenv func(string) string) ([]config, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
-		return config{}, fmt.Errorf("read config: %w", err)
+		return nil, fmt.Errorf("read config: %w", err)
 	}
 	var stored storedConfig
 	if err := json.Unmarshal(contents, &stored); err != nil {
-		return config{}, fmt.Errorf("parse config: %w", err)
+		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
-	configuration := config{
-		SSHTarget:   stored.SSHTarget,
-		SSHPassword: stored.SSHPassword,
-		ImagePort:   defaultImagePort,
-	}
-	if stored.ImagePort != nil {
-		configuration.ImagePort = *stored.ImagePort
-	}
-	if value := getenv("PI_AGENT_SUITE_SSH_TARGET"); value != "" {
-		configuration.SSHTarget = value
-	}
-	if value := getenv("PI_AGENT_SUITE_SSH_PASSWORD"); value != "" {
-		configuration.SSHPassword = value
-	}
-	if value := getenv("PI_AGENT_SUITE_IMAGE_PORT"); value != "" {
-		port, parseErr := strconv.Atoi(value)
-		if parseErr != nil {
-			return config{}, errors.New("PI_AGENT_SUITE_IMAGE_PORT must be an integer from 1 to 65535")
+	legacyFormat := len(stored.Targets) == 0
+	configurations := stored.Targets
+	if legacyFormat && stored.SSHTarget != "" {
+		port := defaultImagePort
+		if stored.ImagePort != nil {
+			port = *stored.ImagePort
 		}
-		configuration.ImagePort = port
+		configurations = []config{{SSHTarget: stored.SSHTarget, SSHPassword: stored.SSHPassword, ImagePort: port}}
 	}
+	if legacyFormat && getenv("PI_AGENT_SUITE_SSH_TARGET") != "" {
+		configuration, configErr := configFromEnvironment(getenv)
+		if configErr != nil {
+			return nil, configErr
+		}
+		configurations = []config{configuration}
+	}
+	if len(configurations) == 0 {
+		return nil, errors.New("remote image configuration has no SSH targets")
+	}
+	for index := range configurations {
+		if configurations[index].ImagePort == 0 {
+			configurations[index].ImagePort = defaultImagePort
+		}
+		if err := validateConfig(configurations[index]); err != nil {
+			return nil, err
+		}
+	}
+	return configurations, nil
+}
+
+func mergeConfig(configurations []config, added config) []config {
+	merged := append([]config(nil), configurations...)
+	for index := range merged {
+		if merged[index].SSHTarget == added.SSHTarget {
+			merged[index] = added
+			return merged
+		}
+	}
+	return append(merged, added)
+}
+
+func removeConfig(configurations []config, target string) ([]config, bool) {
+	remaining := make([]config, 0, len(configurations))
+	removed := false
+	for _, configuration := range configurations {
+		if configuration.SSHTarget == target {
+			removed = true
+			continue
+		}
+		remaining = append(remaining, configuration)
+	}
+	if !removed {
+		return configurations, false
+	}
+	return remaining, true
+}
+
+func validateConfig(configuration config) error {
 	if strings.TrimSpace(configuration.SSHTarget) == "" {
-		return config{}, errors.New("PI_AGENT_SUITE_SSH_TARGET is required")
+		return errors.New("PI_AGENT_SUITE_SSH_TARGET is required")
 	}
 	if configuration.ImagePort < minimumPort || configuration.ImagePort > maximumPort {
-		return config{}, errors.New("PI_AGENT_SUITE_IMAGE_PORT must be an integer from 1 to 65535")
+		return errors.New("PI_AGENT_SUITE_IMAGE_PORT must be an integer from 1 to 65535")
 	}
-	return configuration, nil
+	return nil
 }
 
 func runAskpass(configPath string, output io.Writer) error {
-	configuration, err := loadConfig(configPath, os.Getenv)
+	configurations, err := loadConfigs(configPath, func(string) string { return "" })
 	if err != nil {
 		return err
 	}
-	if configuration.SSHPassword == "" {
-		return errors.New("PI_AGENT_SUITE_SSH_PASSWORD is not configured")
+	target := os.Getenv("PI_AGENT_SUITE_ASKPASS_TARGET")
+	if target == "" && len(configurations) == 1 {
+		target = configurations[0].SSHTarget
 	}
-	_, err = fmt.Fprintln(output, configuration.SSHPassword)
-	return err
+	for _, configuration := range configurations {
+		if configuration.SSHTarget != target {
+			continue
+		}
+		if configuration.SSHPassword == "" {
+			return errors.New("PI_AGENT_SUITE_SSH_PASSWORD is not configured")
+		}
+		_, err = fmt.Fprintln(output, configuration.SSHPassword)
+		return err
+	}
+	return fmt.Errorf("SSH target %q is not configured", target)
 }

--- a/remote-image-helper/config_test.go
+++ b/remote-image-helper/config_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
-func TestLoadConfigAppliesEnvironmentOverrides(t *testing.T) {
+func TestLoadConfigsAppliesEnvironmentOverrides(t *testing.T) {
 	// Purpose: documented environment settings must override persisted setup values.
 	// Input and expected output: target, password, and port environment values replace JSON values.
 	// Edge case: the password can be omitted from the saved file.
@@ -20,17 +21,89 @@ func TestLoadConfigAppliesEnvironmentOverrides(t *testing.T) {
 		"PI_AGENT_SUITE_SSH_PASSWORD": "secret",
 		"PI_AGENT_SUITE_IMAGE_PORT":   "19000",
 	}
-	got, err := loadConfig(path, func(key string) string { return environment[key] })
+	got, err := loadConfigs(path, func(key string) string { return environment[key] })
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := config{SSHTarget: "override", SSHPassword: "secret", ImagePort: 19000}
-	if got != want {
-		t.Fatalf("config = %#v, want %#v", got, want)
+	want := []config{{SSHTarget: "override", SSHPassword: "secret", ImagePort: 19000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configs = %#v, want %#v", got, want)
 	}
 }
 
-func TestLoadConfigRejectsInvalidSettings(t *testing.T) {
+func TestLoadConfigsReadsMultipleServersAndLegacyConfig(t *testing.T) {
+	// Purpose: one helper configuration must preserve every configured remote server and migrate the old format.
+	// Input and expected output: a two-target file returns both targets, and a legacy file returns one target.
+	// Edge case: the multi-target format ignores the legacy runtime target override; the legacy file has no password.
+	// Dependencies: configuration files are isolated test fixtures.
+	dir := t.TempDir()
+	multiPath := filepath.Join(dir, "multi.json")
+	if err := os.WriteFile(multiPath, []byte(`{"targets":[{"sshTarget":"first","imagePort":18775},{"sshTarget":"second","sshPassword":"secret","imagePort":19000}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadConfigs(multiPath, func(key string) string {
+		if key == "PI_AGENT_SUITE_SSH_TARGET" {
+			return "legacy-runtime-override"
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", SSHPassword: "secret", ImagePort: 19000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configs = %#v, want %#v", got, want)
+	}
+
+	legacyPath := filepath.Join(dir, "legacy.json")
+	if err := os.WriteFile(legacyPath, []byte(`{"sshTarget":"legacy","imagePort":18775}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = loadConfigs(legacyPath, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []config{{SSHTarget: "legacy", ImagePort: 18775}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy configs = %#v, want %#v", got, want)
+	}
+}
+
+func TestMergeConfigPreservesServersAndUpdatesExactTarget(t *testing.T) {
+	// Purpose: adding a server must not break existing servers, while reinstalling one server must update that entry.
+	// Input and expected output: a new target is appended and an exact duplicate replaces its saved settings in place.
+	// Edge case: the SSH target string is the stable server identity.
+	// Dependencies: none.
+	existing := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}}
+	got := mergeConfig(existing, config{SSHTarget: "third", ImagePort: 20000})
+	want := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}, {SSHTarget: "third", ImagePort: 20000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("added configs = %#v, want %#v", got, want)
+	}
+	got = mergeConfig(existing, config{SSHTarget: "second", SSHPassword: "new-secret", ImagePort: 21000})
+	want = []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", SSHPassword: "new-secret", ImagePort: 21000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("updated configs = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoveConfigRemovesOnlyExactTarget(t *testing.T) {
+	// Purpose: removal must leave all unrelated remote servers configured.
+	// Input and expected output: removing one exact SSH target returns the other target and reports success.
+	// Edge case: an unknown target leaves the list unchanged and reports failure.
+	// Dependencies: none.
+	existing := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}}
+	got, removed := removeConfig(existing, "first")
+	if !removed || !reflect.DeepEqual(got, []config{{SSHTarget: "second", ImagePort: 19000}}) {
+		t.Fatalf("remove = %#v, %t", got, removed)
+	}
+	got, removed = removeConfig(existing, "missing")
+	if removed || !reflect.DeepEqual(got, existing) {
+		t.Fatalf("missing remove = %#v, %t", got, removed)
+	}
+}
+
+func TestLoadConfigsRejectsInvalidSettings(t *testing.T) {
 	// Purpose: helper startup must fail before starting an unusable listener or tunnel.
 	// Input and expected output: missing target and out-of-range port each return an error.
 	// Edge case: port 0 is invalid after defaulting only absent values.
@@ -44,8 +117,8 @@ func TestLoadConfigRejectsInvalidSettings(t *testing.T) {
 		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := loadConfig(path, func(string) string { return "" }); err == nil {
-			t.Fatalf("loadConfig(%s) succeeded, want error", contents)
+		if _, err := loadConfigs(path, func(string) string { return "" }); err == nil {
+			t.Fatalf("loadConfigs(%s) succeeded, want error", contents)
 		}
 	}
 }
@@ -62,7 +135,7 @@ func TestWriteConfigRestrictsExistingFilePermissions(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeConfig(path, config{SSHTarget: "server", SSHPassword: "secret", ImagePort: 18775}); err != nil {
+	if err := writeConfigs(path, []config{{SSHTarget: "server", SSHPassword: "secret", ImagePort: 18775}}); err != nil {
 		t.Fatal(err)
 	}
 	info, err := os.Stat(path)
@@ -71,6 +144,26 @@ func TestWriteConfigRestrictsExistingFilePermissions(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("mode = %o, want 600", got)
+	}
+}
+
+func TestAskpassSelectsPasswordForTunnelTarget(t *testing.T) {
+	// Purpose: concurrent SSH tunnels must receive only the password saved for their own target.
+	// Input and expected output: selecting the second target prints the second target password.
+	// Edge case: both targets use password authentication at the same time.
+	// Dependencies: the configuration file is an isolated fixture and the selector is a test environment value.
+	path := filepath.Join(t.TempDir(), "config.json")
+	configurations := []config{{SSHTarget: "first", SSHPassword: "first-secret", ImagePort: 18775}, {SSHTarget: "second", SSHPassword: "second-secret", ImagePort: 19000}}
+	if err := writeConfigs(path, configurations); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_AGENT_SUITE_ASKPASS_TARGET", "second")
+	var output stringWriter
+	if err := runAskpass(path, &output); err != nil {
+		t.Fatal(err)
+	}
+	if output.value != "second-secret\n" {
+		t.Fatalf("askpass output = %q", output.value)
 	}
 }
 

--- a/remote-image-helper/install.go
+++ b/remote-image-helper/install.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"html"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -19,15 +20,80 @@ type installationPlan struct {
 	LogPath        string
 }
 
-// install applies one plan only after the old platform-managed process has stopped.
-func (plan installationPlan) install(source string, configuration config, goos string, commands setupCommands) error {
+func (plan installationPlan) installTarget(source string, added config, goos string, commands setupCommands) error {
+	configurations := []config{}
+	if _, err := os.Stat(plan.ConfigPath); err == nil {
+		loaded, loadErr := loadConfigs(plan.ConfigPath, func(string) string { return "" })
+		if loadErr != nil {
+			return loadErr
+		}
+		configurations = loaded
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect config: %w", err)
+	}
+	return plan.installConfigs(source, mergeConfig(configurations, added), goos, commands)
+}
+
+func (plan installationPlan) removeTarget(source, target, goos string, commands setupCommands) (int, error) {
+	configurations, err := loadConfigs(plan.ConfigPath, func(string) string { return "" })
+	if err != nil {
+		return 0, err
+	}
+	remaining, removed := removeConfig(configurations, target)
+	if !removed {
+		return len(configurations), fmt.Errorf("SSH target %q is not configured", target)
+	}
+	if len(remaining) == 0 {
+		if err := plan.uninstall(goos, commands); err != nil {
+			return 0, err
+		}
+		return 0, nil
+	}
+	if err := plan.installConfigs(source, remaining, goos, commands); err != nil {
+		return len(configurations), err
+	}
+	return len(remaining), nil
+}
+
+func (plan installationPlan) uninstall(goos string, commands setupCommands) error {
+	if err := stopStartup(goos, plan, commands); err != nil {
+		return err
+	}
+	switch goos {
+	case "linux":
+		if err := commands.run(commandSpec{Name: "systemctl", Args: []string{"--user", "disable", linuxServiceName}}); err != nil {
+			return fmt.Errorf("disable systemd user service: %w", err)
+		}
+	case "windows":
+		if err := commands.run(commandSpec{Name: "schtasks", Args: []string{"/Delete", "/F", "/TN", windowsTaskName}}); err != nil {
+			return fmt.Errorf("delete Windows logon task: %w", err)
+		}
+	}
+	for _, file := range []string{plan.StartupPath, plan.ConfigPath, plan.LogPath, plan.BinaryPath} {
+		if file == "" {
+			continue
+		}
+		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", file, err)
+		}
+	}
+	if goos == "linux" {
+		if err := commands.run(commandSpec{Name: "systemctl", Args: []string{"--user", "daemon-reload"}}); err != nil {
+			return fmt.Errorf("reload systemd user units: %w", err)
+		}
+	}
+	return nil
+}
+
+// installConfigs applies one plan only after the old platform-managed process has stopped.
+func (plan installationPlan) installConfigs(source string, configurations []config, goos string, commands setupCommands) error {
 	if err := checkExecutableSource(source, plan.BinaryPath); err != nil {
 		return err
 	}
 	return (installationSteps{
 		stop:   func() error { return stopStartup(goos, plan, commands) },
 		binary: func() error { return copyExecutable(source, plan.BinaryPath) },
-		config: func() error { return writeConfig(plan.ConfigPath, configuration) },
+		config: func() error { return writeConfigs(plan.ConfigPath, configurations) },
 		startup: func() error {
 			if plan.StartupPath == "" {
 				return nil

--- a/remote-image-helper/install_sequence_test.go
+++ b/remote-image-helper/install_sequence_test.go
@@ -4,8 +4,176 @@ import (
 	"encoding/json/v2"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
+
+func TestInstallTargetPreservesExistingServers(t *testing.T) {
+	// Purpose: installing another remote server must preserve all existing server connections.
+	// Input and expected output: a legacy one-server config plus a new target is saved as a two-target config.
+	// Edge case: the old single-server JSON format is migrated during installation.
+	// Dependencies: files and service-manager commands are isolated fixtures and fakes.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "download")
+	plan := installationPlan{BinaryPath: filepath.Join(dir, "helper"), ConfigPath: filepath.Join(dir, "config.json")}
+	if err := os.WriteFile(source, []byte("new binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plan.ConfigPath, []byte(`{"sshTarget":"old","imagePort":18775}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	commands := setupCommands{
+		run:     func(commandSpec) error { return nil },
+		capture: func(commandSpec) ([]byte, error) { return nil, nil },
+	}
+	if err := plan.installTarget(source, config{SSHTarget: "new", ImagePort: 19000}, "linux", commands); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadConfigs(plan.ConfigPath, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []config{{SSHTarget: "old", ImagePort: 18775}, {SSHTarget: "new", ImagePort: 19000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configs = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoveTargetPreservesAndRestartsRemainingServers(t *testing.T) {
+	// Purpose: removing one server must preserve and restart every remaining server connection.
+	// Input and expected output: a two-server config becomes a one-server config and reports one remaining target.
+	// Edge case: the downloaded helper replaces the installed version during the restart.
+	// Dependencies: files and service-manager commands are isolated fixtures and fakes.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "download")
+	plan := installationPlan{BinaryPath: filepath.Join(dir, "helper"), ConfigPath: filepath.Join(dir, "config.json")}
+	if err := os.WriteFile(source, []byte("new binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plan.BinaryPath, []byte("old binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeConfigs(plan.ConfigPath, []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}}); err != nil {
+		t.Fatal(err)
+	}
+	commands := setupCommands{
+		run:     func(commandSpec) error { return nil },
+		capture: func(commandSpec) ([]byte, error) { return nil, nil },
+	}
+	remaining, err := plan.removeTarget(source, "first", "linux", commands)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 1 {
+		t.Fatalf("remaining = %d, want 1", remaining)
+	}
+	got, err := loadConfigs(plan.ConfigPath, func(string) string { return "" })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []config{{SSHTarget: "second", ImagePort: 19000}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configs = %#v, want %#v", got, want)
+	}
+}
+
+func TestUninstallRemovesHelperConfigurationAndStartup(t *testing.T) {
+	// Purpose: removing the last server must completely remove the local helper installation.
+	// Input and expected output: installed binary, config, and startup files are deleted after service shutdown.
+	// Edge case: Linux startup is disabled before its unit file is deleted.
+	// Dependencies: files and service-manager commands are isolated fixtures and fakes.
+	dir := t.TempDir()
+	plan := installationPlan{
+		BinaryPath:  filepath.Join(dir, "helper"),
+		ConfigPath:  filepath.Join(dir, "config.json"),
+		StartupPath: filepath.Join(dir, linuxServiceName),
+		LogPath:     filepath.Join(dir, "remote-image.log"),
+	}
+	files := []string{plan.BinaryPath, plan.ConfigPath, plan.StartupPath, plan.LogPath}
+	for _, file := range files {
+		if err := os.WriteFile(file, []byte("fixture"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var calls []commandSpec
+	commands := setupCommands{
+		run: func(command commandSpec) error {
+			calls = append(calls, command)
+			return nil
+		},
+		capture: func(commandSpec) ([]byte, error) {
+			return []byte(linuxServiceName + " loaded active running Helper\n"), nil
+		},
+	}
+	if err := plan.uninstall("linux", commands); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			t.Fatalf("file %q still exists or stat failed: %v", file, err)
+		}
+	}
+	if !hasCommand(calls, "systemctl", "--user", "disable", linuxServiceName) {
+		t.Fatalf("commands = %#v, want systemctl disable", calls)
+	}
+}
+
+func TestUninstallUsesPlatformRegistrationManager(t *testing.T) {
+	// Purpose: final removal must unregister autostart on macOS and Windows as well as Linux.
+	// Input and expected output: each platform removes all installation files, and Windows deletes its scheduled task.
+	// Edge case: the platform manager reports no running helper before removal.
+	// Dependencies: files and service-manager commands are isolated fixtures and fakes.
+	for _, goos := range []string{"darwin", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			dir := t.TempDir()
+			plan := installationPlan{
+				BinaryPath:  filepath.Join(dir, "helper"),
+				ConfigPath:  filepath.Join(dir, "config.json"),
+				StartupPath: filepath.Join(dir, "startup"),
+				LogPath:     filepath.Join(dir, "runtime.log"),
+			}
+			files := []string{plan.BinaryPath, plan.ConfigPath, plan.StartupPath, plan.LogPath}
+			for _, file := range files {
+				if err := os.WriteFile(file, []byte("fixture"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var calls []commandSpec
+			commands := setupCommands{
+				run: func(command commandSpec) error {
+					calls = append(calls, command)
+					return nil
+				},
+				capture: func(commandSpec) ([]byte, error) {
+					if goos == "windows" {
+						return json.Marshal(windowsServiceState{})
+					}
+					return nil, nil
+				},
+			}
+			if err := plan.uninstall(goos, commands); err != nil {
+				t.Fatal(err)
+			}
+			for _, file := range files {
+				if _, err := os.Stat(file); !os.IsNotExist(err) {
+					t.Fatalf("file %q still exists or stat failed: %v", file, err)
+				}
+			}
+			if goos == "windows" && !hasCommand(calls, "schtasks", "/Delete", "/F", "/TN", windowsTaskName) {
+				t.Fatalf("commands = %#v, want schtasks delete", calls)
+			}
+		})
+	}
+}
+
+func hasCommand(commands []commandSpec, name string, arguments ...string) bool {
+	for _, command := range commands {
+		if command.Name == name && reflect.DeepEqual(command.Args, arguments) {
+			return true
+		}
+	}
+	return false
+}
 
 func TestPlatformReinstallReplacesFilesAfterShutdown(t *testing.T) {
 	// Purpose: prove production wiring, not only the abstract order of injected steps.
@@ -58,11 +226,11 @@ func TestPlatformReinstallReplacesFilesAfterShutdown(t *testing.T) {
 						if err != nil {
 							t.Fatal(err)
 						}
-						var saved config
+						var saved storedConfig
 						if err := json.Unmarshal(data, &saved); err != nil {
 							t.Fatal(err)
 						}
-						if saved.SSHTarget != "new-target" {
+						if len(saved.Targets) != 1 || saved.Targets[0].SSHTarget != "new-target" {
 							t.Fatalf("config = %#v", saved)
 						}
 					}
@@ -91,7 +259,7 @@ func TestPlatformReinstallReplacesFilesAfterShutdown(t *testing.T) {
 					}
 				},
 			}
-			if err := plan.install(source, config{SSHTarget: "new-target", ImagePort: 18775}, goos, commands); err != nil {
+			if err := plan.installConfigs(source, []config{{SSHTarget: "new-target", ImagePort: 18775}}, goos, commands); err != nil {
 				t.Fatal(err)
 			}
 			checkBinary("new binary")

--- a/remote-image-helper/main.go
+++ b/remote-image-helper/main.go
@@ -31,27 +31,46 @@ func execute() error {
 			return err
 		}
 	}
-	if flag.NArg() > 0 && flag.Arg(0) == "install" {
-		configuration, err := configFromEnvironment(os.Getenv)
-		if err != nil {
-			return err
-		}
+	if flag.NArg() > 0 {
 		executablePath, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("find helper executable: %w", err)
 		}
-		plan, err := installHelper(executablePath, configuration)
-		if err != nil {
-			return err
+		switch flag.Arg(0) {
+		case "install":
+			configuration, configErr := configFromEnvironment(os.Getenv)
+			if configErr != nil {
+				return configErr
+			}
+			plan, installErr := installHelper(executablePath, configuration)
+			if installErr != nil {
+				return installErr
+			}
+			fmt.Printf("Installed remote image helper for %s. Configure remote pi with PI_AGENT_SUITE_MODE=remote and PI_AGENT_SUITE_IMAGE_PORT=%d.\n", configuration.SSHTarget, configuration.ImagePort)
+			fmt.Printf("Saved local configuration to %s.\n", plan.ConfigPath)
+			if plan.LogPath != "" {
+				fmt.Printf("Runtime and SSH diagnostics: %s\n", plan.LogPath)
+			} else {
+				fmt.Printf("Runtime and SSH diagnostics: journalctl --user -u %s\n", linuxServiceName)
+			}
+			return nil
+		case "remove":
+			if flag.NArg() != 2 || flag.Arg(1) == "" {
+				return fmt.Errorf("usage: remote-image remove <ssh-target>")
+			}
+			plan, remaining, removeErr := removeHelper(executablePath, flag.Arg(1))
+			if removeErr != nil {
+				return removeErr
+			}
+			if remaining == 0 {
+				fmt.Printf("Removed %s and uninstalled remote image helper.\n", flag.Arg(1))
+			} else {
+				fmt.Printf("Removed %s. %d remote server configurations remain in %s.\n", flag.Arg(1), remaining, plan.ConfigPath)
+			}
+			return nil
+		default:
+			return fmt.Errorf("unknown command %q", flag.Arg(0))
 		}
-		fmt.Printf("Installed remote image helper. Configure remote pi with PI_AGENT_SUITE_MODE=remote and PI_AGENT_SUITE_IMAGE_PORT=%d.\n", configuration.ImagePort)
-		fmt.Printf("Saved local configuration to %s.\n", plan.ConfigPath)
-		if plan.LogPath != "" {
-			fmt.Printf("Runtime and SSH diagnostics: %s\n", plan.LogPath)
-		} else {
-			fmt.Printf("Runtime and SSH diagnostics: journalctl --user -u %s\n", linuxServiceName)
-		}
-		return nil
 	}
 
 	resolvedConfigPath := *configPath

--- a/remote-image-helper/runtime.go
+++ b/remote-image-helper/runtime.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.design/x/clipboard"
@@ -22,6 +23,10 @@ type nativeClipboard struct{}
 func (nativeClipboard) ReadImage(ctx context.Context) ([]byte, error) {
 	image, err := clipboard.Read(ctx, clipboard.FmtImage)
 	return normalizeClipboardImage(image, err)
+}
+
+func localImagePort(configurations []config) int {
+	return configurations[0].ImagePort
 }
 
 func normalizeClipboardImage(image []byte, err error) ([]byte, error) {
@@ -62,7 +67,7 @@ func (systemCommandRunner) Run(ctx context.Context, specification commandSpec) e
 }
 
 func run(ctx context.Context, configPath, executablePath string) error {
-	configuration, err := loadConfig(configPath, os.Getenv)
+	configurations, err := loadConfigs(configPath, os.Getenv)
 	if err != nil {
 		return err
 	}
@@ -71,7 +76,7 @@ func run(ctx context.Context, configPath, executablePath string) error {
 	}
 
 	server := &http.Server{
-		Addr:              "127.0.0.1:" + strconv.Itoa(configuration.ImagePort),
+		Addr:              "127.0.0.1:" + strconv.Itoa(localImagePort(configurations)),
 		Handler:           newImageHandler(nativeClipboard{}),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -91,7 +96,14 @@ func run(ctx context.Context, configPath, executablePath string) error {
 		}
 		return nil
 	}, func(ctx context.Context) {
-		runTunnel(ctx, systemCommandRunner{}, buildSSHCommand(configuration, executablePath, configPath), waitForReconnect)
+		commands := buildSSHCommands(configurations, executablePath, configPath)
+		var tunnels sync.WaitGroup
+		for _, command := range commands {
+			tunnels.Go(func() {
+				runTunnel(ctx, systemCommandRunner{}, command, waitForReconnect)
+			})
+		}
+		tunnels.Wait()
 	})
 }
 

--- a/remote-image-helper/runtime_lifecycle_test.go
+++ b/remote-image-helper/runtime_lifecycle_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+func TestLocalImagePortUsesOneSharedListener(t *testing.T) {
+	// Purpose: adding a server with a different remote port must not require another local listener that can break existing servers.
+	// Input and expected output: the first configured target selects the helper's one local listener port.
+	// Edge case: later targets use different remote ports.
+	// Dependencies: none.
+	configurations := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}}
+	if got := localImagePort(configurations); got != 18775 {
+		t.Fatalf("local port = %d, want 18775", got)
+	}
+}
+
 func TestRuntimeWaitsForTunnelShutdown(t *testing.T) {
 	// Purpose: helper exit must not leave SSH running during reinstallation.
 	// Input and expected output: cancellation shuts down HTTP and waits until the tunnel acknowledges exit.

--- a/remote-image-helper/setup.go
+++ b/remote-image-helper/setup.go
@@ -23,10 +23,27 @@ func installHelper(sourceExecutable string, configuration config) (installationP
 		return installationPlan{}, err
 	}
 	commands := setupCommands{run: runSetupCommand, capture: captureSetupCommand}
-	if err := plan.install(sourceExecutable, configuration, runtime.GOOS, commands); err != nil {
+	if err := plan.installTarget(sourceExecutable, configuration, runtime.GOOS, commands); err != nil {
 		return installationPlan{}, err
 	}
 	return plan, nil
+}
+
+func removeHelper(sourceExecutable, target string) (installationPlan, int, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return installationPlan{}, 0, fmt.Errorf("find user home: %w", err)
+	}
+	plan, err := buildInstallationPlan(runtime.GOOS, home, os.Getenv("LOCALAPPDATA"))
+	if err != nil {
+		return installationPlan{}, 0, err
+	}
+	commands := setupCommands{run: runSetupCommand, capture: captureSetupCommand}
+	remaining, err := plan.removeTarget(sourceExecutable, target, runtime.GOOS, commands)
+	if err != nil {
+		return installationPlan{}, 0, err
+	}
+	return plan, remaining, nil
 }
 
 func configFromEnvironment(getenv func(string) string) (config, error) {
@@ -98,8 +115,8 @@ func checkExecutableSource(source, destination string) error {
 	return nil
 }
 
-func writeConfig(path string, configuration config) error {
-	contents, err := json.Marshal(&configuration, jsontext.WithIndent("  "))
+func writeConfigs(path string, configurations []config) error {
+	contents, err := json.Marshal(&storedConfig{Targets: configurations}, jsontext.WithIndent("  "))
 	if err != nil {
 		return fmt.Errorf("encode config: %w", err)
 	}

--- a/remote-image-helper/setup.ps1
+++ b/remote-image-helper/setup.ps1
@@ -1,4 +1,6 @@
 param(
+    [ValidateSet("Add", "Remove")]
+    [string]$Action = "Add",
     [string]$SshTarget = $env:PI_AGENT_SUITE_SSH_TARGET,
     [string]$SshPassword = $env:PI_AGENT_SUITE_SSH_PASSWORD,
     [int]$ImagePort = 18775,
@@ -31,10 +33,14 @@ New-Item -ItemType Directory -Path $temporaryDirectory | Out-Null
 try {
     $helper = Join-Path $temporaryDirectory $asset
     Invoke-WebRequest -Uri $url -OutFile $helper
-    $env:PI_AGENT_SUITE_SSH_TARGET = $SshTarget
-    $env:PI_AGENT_SUITE_SSH_PASSWORD = $SshPassword
-    $env:PI_AGENT_SUITE_IMAGE_PORT = $ImagePort.ToString()
-    & $helper install
+    if ($Action -eq "Remove") {
+        & $helper remove $SshTarget
+    } else {
+        $env:PI_AGENT_SUITE_SSH_TARGET = $SshTarget
+        $env:PI_AGENT_SUITE_SSH_PASSWORD = $SshPassword
+        $env:PI_AGENT_SUITE_IMAGE_PORT = $ImagePort.ToString()
+        & $helper install
+    }
     if ($LASTEXITCODE -ne 0) {
         throw "Remote image helper setup failed with exit code $LASTEXITCODE"
     }

--- a/remote-image-helper/setup.sh
+++ b/remote-image-helper/setup.sh
@@ -3,11 +3,28 @@ set -eu
 
 repository="n-r-w/pi-agent-suite"
 version="${PI_AGENT_SUITE_VERSION:-latest}"
-target="${1:-${PI_AGENT_SUITE_SSH_TARGET:-}}"
+action="install"
+target="${PI_AGENT_SUITE_SSH_TARGET:-}"
 port="${PI_AGENT_SUITE_IMAGE_PORT:-18775}"
+
+if [ "${1:-}" = "remove" ]; then
+	action="remove"
+	target="${2:-}"
+	if [ "$#" -ne 2 ]; then
+		echo "Usage: $0 remove <ssh-target>" >&2
+		exit 1
+	fi
+else
+	target="${1:-$target}"
+	if [ "$#" -gt 1 ]; then
+		echo "Usage: PI_AGENT_SUITE_SSH_PASSWORD=optional $0 <ssh-target>" >&2
+		exit 1
+	fi
+fi
 
 if [ -z "$target" ]; then
 	echo "Usage: PI_AGENT_SUITE_SSH_PASSWORD=optional $0 <ssh-target>" >&2
+	echo "       $0 remove <ssh-target>" >&2
 	exit 1
 fi
 
@@ -37,7 +54,11 @@ helper="$temporary_directory/$asset"
 curl -fL "$url" -o "$helper"
 chmod 700 "$helper"
 
-PI_AGENT_SUITE_SSH_TARGET="$target" \
-PI_AGENT_SUITE_SSH_PASSWORD="${PI_AGENT_SUITE_SSH_PASSWORD:-}" \
-PI_AGENT_SUITE_IMAGE_PORT="$port" \
-	"$helper" install
+if [ "$action" = "remove" ]; then
+	"$helper" remove "$target"
+else
+	PI_AGENT_SUITE_SSH_TARGET="$target" \
+	PI_AGENT_SUITE_SSH_PASSWORD="${PI_AGENT_SUITE_SSH_PASSWORD:-}" \
+	PI_AGENT_SUITE_IMAGE_PORT="$port" \
+		"$helper" install
+fi

--- a/remote-image-helper/tunnel.go
+++ b/remote-image-helper/tunnel.go
@@ -17,14 +17,27 @@ type commandRunner interface {
 	Run(context.Context, commandSpec) error
 }
 
+func buildSSHCommands(configurations []config, executablePath, configPath string) []commandSpec {
+	commands := make([]commandSpec, 0, len(configurations))
+	localPort := localImagePort(configurations)
+	for _, configuration := range configurations {
+		commands = append(commands, buildSSHCommandToPort(configuration, localPort, executablePath, configPath))
+	}
+	return commands
+}
+
 func buildSSHCommand(configuration config, executablePath, configPath string) commandSpec {
-	port := strconv.Itoa(configuration.ImagePort)
+	return buildSSHCommandToPort(configuration, configuration.ImagePort, executablePath, configPath)
+}
+
+func buildSSHCommandToPort(configuration config, localPort int, executablePath, configPath string) commandSpec {
+	remotePort := strconv.Itoa(configuration.ImagePort)
 	arguments := []string{
 		"-N", "-T",
 		"-o", "ExitOnForwardFailure=yes",
 		"-o", "ServerAliveInterval=30",
 		"-o", "ServerAliveCountMax=3",
-		"-R", fmt.Sprintf("127.0.0.1:%s:127.0.0.1:%s", port, port),
+		"-R", fmt.Sprintf("127.0.0.1:%s:127.0.0.1:%d", remotePort, localPort),
 	}
 	environment := []string{}
 	if configuration.SSHPassword != "" {
@@ -36,6 +49,7 @@ func buildSSHCommand(configuration config, executablePath, configPath string) co
 			"SSH_ASKPASS="+executablePath,
 			"SSH_ASKPASS_REQUIRE=force",
 			"PI_AGENT_SUITE_ASKPASS=1",
+			"PI_AGENT_SUITE_ASKPASS_TARGET="+configuration.SSHTarget,
 			"PI_AGENT_SUITE_IMAGE_CONFIG="+configPath,
 		)
 	}

--- a/remote-image-helper/tunnel_test.go
+++ b/remote-image-helper/tunnel_test.go
@@ -33,6 +33,24 @@ func TestBuildSSHCommandUsesLoopbackReverseForward(t *testing.T) {
 	}
 }
 
+func TestBuildSSHCommandsCreatesTunnelForEveryServer(t *testing.T) {
+	// Purpose: one helper process must connect every configured remote server to the local clipboard endpoint.
+	// Input and expected output: two server settings produce two SSH commands with their own targets and remote ports.
+	// Edge case: both tunnels forward to the first target's shared local listener port.
+	// Dependencies: command construction does not start SSH.
+	configurations := []config{{SSHTarget: "first", ImagePort: 18775}, {SSHTarget: "second", ImagePort: 19000}}
+	commands := buildSSHCommands(configurations, "/opt/helper", "/tmp/config.json")
+	if len(commands) != 2 {
+		t.Fatalf("commands = %#v", commands)
+	}
+	if commands[0].Args[len(commands[0].Args)-1] != "first" || commands[1].Args[len(commands[1].Args)-1] != "second" {
+		t.Fatalf("commands = %#v", commands)
+	}
+	if !containsSequence(commands[1].Args, []string{"-R", "127.0.0.1:19000:127.0.0.1:18775"}) {
+		t.Fatalf("second args = %v", commands[1].Args)
+	}
+}
+
 func TestBuildSSHCommandConfiguresPasswordAskpass(t *testing.T) {
 	// Purpose: saved SSH passwords must be supplied only to password-capable authentication.
 	// Input and expected output: a configured password adds askpass environment and disables public-key prompts.
@@ -44,6 +62,7 @@ func TestBuildSSHCommandConfiguresPasswordAskpass(t *testing.T) {
 		"SSH_ASKPASS=/opt/helper",
 		"SSH_ASKPASS_REQUIRE=force",
 		"PI_AGENT_SUITE_ASKPASS=1",
+		"PI_AGENT_SUITE_ASKPASS_TARGET=server",
 		"PI_AGENT_SUITE_IMAGE_CONFIG=/tmp/config.json",
 	}
 	if !reflect.DeepEqual(got.Environment, wantEnvironment) {


### PR DESCRIPTION
## Problem
The remote image helper only supported one SSH server, making it difficult to use multiple remote pi sessions or remove an obsolete server.

## Solution
Store multiple SSH targets, run a tunnel for each target, and add commands to remove one target or fully uninstall the helper when none remain.

### Details
- Preserve and update existing target configurations, including legacy configuration migration
- Route each remote port through one shared local clipboard listener
- Select the correct saved password for each SSH tunnel
- Add macOS, Linux, and Windows removal support
- Update documentation and add configuration, installation, runtime, and tunnel tests